### PR TITLE
Change applicative instances to implement apEval and remove lazyAp

### DIFF
--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
@@ -58,8 +58,8 @@ interface FluxKApplicative : Applicative<ForFluxK> {
   override fun <A, B> FluxKOf<A>.map(f: (A) -> B): FluxK<B> =
     fix().map(f)
 
-  override fun <A, B> Kind<ForFluxK, A>.lazyAp(ff: () -> Kind<ForFluxK, (A) -> B>): Kind<ForFluxK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForFluxK, A>.apEval(ff: Eval<Kind<ForFluxK, (A) -> B>>): Eval<Kind<ForFluxK, B>> =
+    Eval.now(fix().ap(FluxK.defer { ff.value() }))
 }
 
 @extension

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
@@ -76,8 +76,8 @@ interface FluxKMonad : Monad<ForFluxK>, FluxKApplicative {
   override fun <A, B> tailRecM(a: A, f: kotlin.Function1<A, FluxKOf<arrow.core.Either<A, B>>>): FluxK<B> =
     FluxK.tailRecM(a, f)
 
-  override fun <A, B> Kind<ForFluxK, A>.lazyAp(ff: () -> Kind<ForFluxK, (A) -> B>): Kind<ForFluxK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForFluxK, A>.apEval(ff: Eval<Kind<ForFluxK, (A) -> B>>): Eval<Kind<ForFluxK, B>> =
+    Eval.now(fix().ap(FluxK.defer { ff.value() }))
 }
 
 @extension

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok.kt
@@ -2,6 +2,7 @@ package arrow.fx.reactor.extensions
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.Eval
 import arrow.extension
 import arrow.fx.Timer
 import arrow.fx.reactor.ForMonoK
@@ -47,8 +48,8 @@ interface MonoKApplicative : Applicative<ForMonoK>, MonoKFunctor {
   override fun <A> just(a: A): MonoK<A> =
     MonoK.just(a)
 
-  override fun <A, B> Kind<ForMonoK, A>.lazyAp(ff: () -> Kind<ForMonoK, (A) -> B>): Kind<ForMonoK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForMonoK, A>.apEval(ff: Eval<Kind<ForMonoK, (A) -> B>>): Eval<Kind<ForMonoK, B>> =
+    Eval.now(fix().ap(MonoK.defer { ff.value() }))
 }
 
 @extension
@@ -65,8 +66,8 @@ interface MonoKMonad : Monad<ForMonoK>, MonoKApplicative {
   override fun <A, B> tailRecM(a: A, f: kotlin.Function1<A, MonoKOf<Either<A, B>>>): MonoK<B> =
     MonoK.tailRecM(a, f)
 
-  override fun <A, B> Kind<ForMonoK, A>.lazyAp(ff: () -> Kind<ForMonoK, (A) -> B>): Kind<ForMonoK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForMonoK, A>.apEval(ff: Eval<Kind<ForMonoK, (A) -> B>>): Eval<Kind<ForMonoK, B>> =
+    Eval.now(fix().ap(MonoK.defer { ff.value() }))
 }
 
 @extension

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
@@ -75,8 +75,8 @@ interface FlowableKApplicative : Applicative<ForFlowableK> {
   override fun <A> just(a: A): FlowableK<A> =
     FlowableK.just(a)
 
-  override fun <A, B> Kind<ForFlowableK, A>.lazyAp(ff: () -> Kind<ForFlowableK, (A) -> B>): Kind<ForFlowableK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForFlowableK, A>.apEval(ff: Eval<Kind<ForFlowableK, (A) -> B>>): Eval<Kind<ForFlowableK, B>> =
+    Eval.now(fix().ap(FlowableK.defer { ff.value() }))
 }
 
 @extension
@@ -93,8 +93,8 @@ interface FlowableKMonad : Monad<ForFlowableK>, FlowableKApplicative {
   override fun <A, B> tailRecM(a: A, f: (A) -> FlowableKOf<Either<A, B>>): FlowableK<B> =
     FlowableK.tailRecM(a, f)
 
-  override fun <A, B> Kind<ForFlowableK, A>.lazyAp(ff: () -> Kind<ForFlowableK, (A) -> B>): Kind<ForFlowableK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForFlowableK, A>.apEval(ff: Eval<Kind<ForFlowableK, (A) -> B>>): Eval<Kind<ForFlowableK, B>> =
+    Eval.now(fix().ap(FlowableK.defer { ff.value() }))
 }
 
 @extension

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
@@ -70,8 +70,8 @@ interface MaybeKApplicative : Applicative<ForMaybeK> {
   override fun <A> just(a: A): MaybeK<A> =
     MaybeK.just(a)
 
-  override fun <A, B> Kind<ForMaybeK, A>.lazyAp(ff: () -> Kind<ForMaybeK, (A) -> B>): Kind<ForMaybeK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForMaybeK, A>.apEval(ff: Eval<Kind<ForMaybeK, (A) -> B>>): Eval<Kind<ForMaybeK, B>> =
+    Eval.now(fix().ap(MaybeK.defer { ff.value() }))
 }
 
 @extension
@@ -88,8 +88,8 @@ interface MaybeKMonad : Monad<ForMaybeK>, MaybeKApplicative {
   override fun <A, B> tailRecM(a: A, f: (A) -> MaybeKOf<Either<A, B>>): MaybeK<B> =
     MaybeK.tailRecM(a, f)
 
-  override fun <A, B> Kind<ForMaybeK, A>.lazyAp(ff: () -> Kind<ForMaybeK, (A) -> B>): Kind<ForMaybeK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForMaybeK, A>.apEval(ff: Eval<Kind<ForMaybeK, (A) -> B>>): Eval<Kind<ForMaybeK, B>> =
+    Eval.now(fix().ap(MaybeK.defer { ff.value() }))
 }
 
 @extension

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
@@ -68,8 +68,8 @@ interface ObservableKApplicative : Applicative<ForObservableK> {
   override fun <A> just(a: A): ObservableK<A> =
     ObservableK.just(a)
 
-  override fun <A, B> Kind<ForObservableK, A>.lazyAp(ff: () -> Kind<ForObservableK, (A) -> B>): Kind<ForObservableK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForObservableK, A>.apEval(ff: Eval<Kind<ForObservableK, (A) -> B>>): Eval<Kind<ForObservableK, B>> =
+    Eval.now(fix().ap(ObservableK.defer { ff.value() }))
 }
 
 @extension
@@ -86,8 +86,8 @@ interface ObservableKMonad : Monad<ForObservableK>, ObservableKApplicative {
   override fun <A, B> tailRecM(a: A, f: (A) -> ObservableKOf<Either<A, B>>): ObservableK<B> =
     ObservableK.tailRecM(a, f)
 
-  override fun <A, B> Kind<ForObservableK, A>.lazyAp(ff: () -> Kind<ForObservableK, (A) -> B>): Kind<ForObservableK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForObservableK, A>.apEval(ff: Eval<Kind<ForObservableK, (A) -> B>>): Eval<Kind<ForObservableK, B>> =
+    Eval.now(fix().ap(ObservableK.defer { ff.value() }))
 }
 
 @extension

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
@@ -2,6 +2,7 @@ package arrow.fx.rx2.extensions
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.Eval
 import arrow.core.Tuple2
 
 import arrow.fx.RacePair
@@ -68,8 +69,8 @@ interface SingleKApplicative : Applicative<ForSingleK> {
   override fun <A> just(a: A): SingleK<A> =
     SingleK.just(a)
 
-  override fun <A, B> Kind<ForSingleK, A>.lazyAp(ff: () -> Kind<ForSingleK, (A) -> B>): Kind<ForSingleK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForSingleK, A>.apEval(ff: Eval<Kind<ForSingleK, (A) -> B>>): Eval<Kind<ForSingleK, B>> =
+    Eval.now(fix().ap(SingleK.defer { ff.value() }))
 }
 
 @extension
@@ -86,8 +87,8 @@ interface SingleKMonad : Monad<ForSingleK>, SingleKApplicative {
   override fun <A, B> tailRecM(a: A, f: (A) -> SingleKOf<Either<A, B>>): SingleK<B> =
     SingleK.tailRecM(a, f)
 
-  override fun <A, B> Kind<ForSingleK, A>.lazyAp(ff: () -> Kind<ForSingleK, (A) -> B>): Kind<ForSingleK, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForSingleK, A>.apEval(ff: Eval<Kind<ForSingleK, (A) -> B>>): Eval<Kind<ForSingleK, B>> =
+    Eval.now(fix().ap(SingleK.defer { ff.value() }))
 }
 
 @extension

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
@@ -2,6 +2,7 @@ package arrow.fx.extensions
 
 import arrow.Kind
 import arrow.core.Either
+import arrow.core.Eval
 import arrow.core.identity
 import arrow.extension
 import arrow.fx.ForIO
@@ -63,8 +64,8 @@ interface IOApply : Apply<ForIO> {
   override fun <A, B> IOOf<A>.ap(ff: IOOf<(A) -> B>): IO<B> =
     fix().ap(ff)
 
-  override fun <A, B> Kind<ForIO, A>.lazyAp(ff: () -> Kind<ForIO, (A) -> B>): Kind<ForIO, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForIO, A>.apEval(ff: Eval<Kind<ForIO, (A) -> B>>): Eval<Kind<ForIO, B>> =
+    Eval.now(fix().ap(IO.defer { ff.value() }))
 }
 
 @extension
@@ -78,8 +79,8 @@ interface IOApplicative : Applicative<ForIO> {
   override fun <A, B> IOOf<A>.ap(ff: IOOf<(A) -> B>): IO<B> =
     fix().ap(ff)
 
-  override fun <A, B> Kind<ForIO, A>.lazyAp(ff: () -> Kind<ForIO, (A) -> B>): Kind<ForIO, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForIO, A>.apEval(ff: Eval<Kind<ForIO, (A) -> B>>): Eval<Kind<ForIO, B>> =
+    Eval.now(fix().ap(IO.defer { ff.value() }))
 }
 
 @extension
@@ -96,8 +97,8 @@ interface IOMonad : Monad<ForIO> {
   override fun <A> just(a: A): IO<A> =
     IO.just(a)
 
-  override fun <A, B> Kind<ForIO, A>.lazyAp(ff: () -> Kind<ForIO, (A) -> B>): Kind<ForIO, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForIO, A>.apEval(ff: Eval<Kind<ForIO, (A) -> B>>): Eval<Kind<ForIO, B>> =
+    Eval.now(fix().ap(IO.defer { ff.value() }))
 }
 
 @extension
@@ -141,8 +142,8 @@ interface IOMonadError : MonadError<ForIO, Throwable>, IOApplicativeError, IOMon
   override fun <A> raiseError(e: Throwable): IO<A> =
     IO.raiseError(e)
 
-  override fun <A, B> Kind<ForIO, A>.lazyAp(ff: () -> Kind<ForIO, (A) -> B>): Kind<ForIO, B> =
-    fix().flatMap { a -> ff().map { f -> f(a) } }
+  override fun <A, B> Kind<ForIO, A>.apEval(ff: Eval<Kind<ForIO, (A) -> B>>): Eval<Kind<ForIO, B>> =
+    Eval.now(fix().ap(IO.defer { ff.value() }))
 }
 
 @extension

--- a/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/ParApplicative.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/ParApplicative.kt
@@ -3,6 +3,9 @@ package arrow.fx.typeclasses
 import arrow.Kind
 import arrow.core.Eval
 import arrow.core.Tuple2
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.fix
 import arrow.typeclasses.Applicative
 import kotlin.coroutines.CoroutineContext
 
@@ -20,7 +23,8 @@ internal fun <F> Concurrent<F>.ParApplicative(ctx: CoroutineContext? = null): Ap
   override fun <A, B> Kind<F, A>.ap(ff: Kind<F, (A) -> B>): Kind<F, B> =
     _ctx.parMapN(ff, this@ap) { f, a -> f(a) }
 
-  override fun <A, B> Kind<F, A>.lazyAp(ff: () -> Kind<F, (A) -> B>): Kind<F, B> = ap(ff())
+  override fun <A, B> Kind<F, A>.apEval(ff: Eval<Kind<F, (A) -> B>>): Eval<Kind<F, B>> =
+    Eval.now(_ctx.parMapN(defer { ff.value() }, this@apEval) { f, a -> f(a) })
 
   override fun <A, B> Kind<F, A>.product(fb: Kind<F, B>): Kind<F, Tuple2<A, B>> =
     _ctx.parMapN(this@product, fb, ::Tuple2)

--- a/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/ParApplicative.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/ParApplicative.kt
@@ -3,9 +3,6 @@ package arrow.fx.typeclasses
 import arrow.Kind
 import arrow.core.Eval
 import arrow.core.Tuple2
-import arrow.fx.ForIO
-import arrow.fx.IO
-import arrow.fx.fix
 import arrow.typeclasses.Applicative
 import kotlin.coroutines.CoroutineContext
 


### PR DESCRIPTION
Changes from https://github.com/arrow-kt/arrow-core/pull/23 broke every arrow build with an applicative instance, here is the fix.

This non-deterministically failed MVar tests locally. Is this linked to #46 ?