### PR TITLE
Fix the code which is stumbled on an old type inference problem of the Kotlin compiler

### DIFF
--- a/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
@@ -811,7 +811,7 @@ sealed class IO<out A> : IOOf<A> {
           ThrowCancellationException ->
             cb andThen { it.fix().unsafeRunAsync { } }
           Silent ->
-            { either -> either.fold({ if (!conn.isCanceled() || it != CancellationException) cb(either) }, { cb(either) }) }
+            { either -> either.fold({ if (!conn.isCanceled() || it != CancellationException) cb(either) }, { cb(either); Unit }) }
         }
       ccb(conn.toDisposable().right())
       IORunLoop.startCancelable(this, conn, onCancelCb)


### PR DESCRIPTION
Fix the code which is stumbled on an old type inference problem of the Kotlin compiler

Background.
The old type inference has some problems with common super type calculation on Unit-returning lambdas. Namely, in one of the following cases, the old type inference runs "coercion to Unit":
1) If in the place where common super type calculation is required (e.g. "if", "when", "select" function), the first candidate was a lambda which returns Unit (explicitly or implicitly);
2) If in any of the branches there was an explicit specifying of the returned functional type, namely, Unit in the return position.

This is the wrong behavior: type inference in such cases should still run common super type calculation. The new type inference behave correctly in such cases.

Problem with the changing code.
The problem appears when someone relies on the inferred type (for example, `() -> Unit`), although in the new inference, due to run of the common super type calculation, the type could be more common (for example, `() -> Any`). This is exactly what happened in the changing code: `cb(either)` returns `IOOf<Unit>` (and the branch returns `(Either<Throwable, A>) -> IOOf<Unit>`), but all the remaining branches return `(Either<Throwable, A>) -> Unit`, so we have `CST((Either<Throwable, A>) -> Unit, (Either<Throwable, A>) -> IOOf<Unit>) = (Either<Throwable, A>) -> Any`. In `IORunLoop.startCancelable` signature, we expect `(Either<Throwable, A>) -> Unit`, because now we have an error in the new type inference.

The new type inference turning on.
We are going to turn on the new type inference in Kotlin 1.4 by default. Therefore, now we are trying to test the compilation of large projects on Kotlin with the new inference. Nevertheless, sometimes errors are detected not in the new inference, but in the old one, which means that if someone uses a code that was erroneously compiled, such code will stop compiling. We try to warn of such cases (like this one).