### PR TITLE
Removed (almost) all Try examples in documentation/comment blocks

### DIFF
--- a/arrow-docs/docs/fx/polymorphism/README.md
+++ b/arrow-docs/docs/fx/polymorphism/README.md
@@ -94,7 +94,7 @@ import arrow.core.extensions.fx
 val result =
   Either.fx<Throwable, Int> {
     val (one) = Either.right(1)
-    val (two) = Either.right(one+one)
+    val (two) = Either.right(one + one)
     two
   }
 //sampleEnd

--- a/arrow-docs/docs/fx/polymorphism/README.md
+++ b/arrow-docs/docs/fx/polymorphism/README.md
@@ -85,16 +85,16 @@ fun main() {
 }
 ```
 
-*Fx over `Try`*
+*Fx over `Either`*
 ```kotlin:ank:playground
-import arrow.core.Try
+import arrow.core.Either
 import arrow.core.extensions.fx
 
 //sampleStart
 val result =
-  Try.fx {
-    val (one) = Try { 1 }
-    val (two) = Try { one + one }
+  Either.fx<Throwable, Int> {
+    val (one) = Either.right(1)
+    val (two) = Either.right(one+one)
     two
   }
 //sampleEnd

--- a/arrow-docs/docs/integrations/reactor/README.md
+++ b/arrow-docs/docs/integrations/reactor/README.md
@@ -154,14 +154,14 @@ fun main() {
 ```
 
 ```kotlin:ank:fail
-import arrow.core.Try
+import arrow.fx.IO
 
 // This will result in a stack overflow
-Try {
+IO {
   MonoK.monad().fx.monad {
     (1..50000).fold(just(0)) { acc: Kind<ForMonoK, Int>, x: Int ->
       just(acc.bind() + 1)
     }.bind()
   }.fix().mono.block()
-}
+}.attempt().unsafeRunSync()
 ```

--- a/arrow-docs/docs/integrations/rx2/README.md
+++ b/arrow-docs/docs/integrations/rx2/README.md
@@ -230,5 +230,5 @@ IO {
       just(acc.bind() + 1)
     }.bind()
   }.fix().flowable.blockingFirst()
-}.attempt()
+}.attempt().unsafeRunSync()
 ```

--- a/arrow-docs/docs/integrations/rx2/README.md
+++ b/arrow-docs/docs/integrations/rx2/README.md
@@ -217,14 +217,18 @@ fun main() {
 ```
 
 ```kotlin:ank:fail
-import arrow.core.Try
+import arrow.Kind
+import arrow.fx.IO
+import arrow.fx.rx2.*
+import arrow.fx.rx2.extensions.flowablek.monad.monad
+
 // This will result in a stack overflow
 
-Try {
+IO {
   FlowableK.monad().fx.monad {
     (1..50000).fold(just(0)) { acc: Kind<ForFlowableK, Int>, x: Int ->
       just(acc.bind() + 1)
     }.bind()
   }.fix().flowable.blockingFirst()
-}
+}.attempt()
 ```


### PR DESCRIPTION
Original PR can be seen [here](https://github.com/arrow-kt/arrow-core/issues/26).

What version are you currently using? 0.10

What would you like to see?
The documentation includes Try examples. Since Try is deprecated, these examples should be removed (or transitioned to Either examples) to prevent confusion.