### PR TITLE
New BIO APIs for unhappy paths

### DIFF
--- a/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
@@ -137,7 +137,7 @@ sealed class IO<out E, out A> : IOOf<E, A> {
      * ```
      */
     fun <A> just(a: A): IO<Nothing, A> = Pure(a)
-    
+
     /**
      * Yeets an exception in a pure way without actually throwing.
      *
@@ -155,7 +155,7 @@ sealed class IO<out E, out A> : IOOf<E, A> {
     fun <A> yeet(e: Throwable): IO<Nothing, A> = RaiseException(e)
 
     /**
-     * Raise an error in a pure way
+     * Kobes an error in a pure way
      *
      * ```kotlin:ank:playground
      * import arrow.fx.IO

--- a/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
@@ -139,7 +139,7 @@ sealed class IO<out E, out A> : IOOf<E, A> {
     fun <A> just(a: A): IO<Nothing, A> = Pure(a)
 
     /**
-     * Yeets an exception in a pure way without actually throwing.
+     * Yeets an exception as far away as possible
      *
      * ```kotlin:ank:playground
      * import arrow.fx.IO
@@ -155,7 +155,7 @@ sealed class IO<out E, out A> : IOOf<E, A> {
     fun <A> yeet(e: Throwable): IO<Nothing, A> = RaiseException(e)
 
     /**
-     * Kobes an error in a pure way
+     * Kobes an error with perfect accuracy *swish swish*
      *
      * ```kotlin:ank:playground
      * import arrow.fx.IO

--- a/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/IO.kt
@@ -137,22 +137,22 @@ sealed class IO<out E, out A> : IOOf<E, A> {
      * ```
      */
     fun <A> just(a: A): IO<Nothing, A> = Pure(a)
-
+    
     /**
-     * Raise an exception in a pure way without actually throwing.
+     * Yeets an exception in a pure way without actually throwing.
      *
      * ```kotlin:ank:playground
      * import arrow.fx.IO
      *
      * fun main(args: Array<String>) {
      *   //sampleStart
-     *   val result: IO<Nothing, Int> = IO.raiseException<Int>(RuntimeException("Boom"))
+     *   val result: IO<Nothing, Int> = IO.yeet<Int>(RuntimeException("Boom"))
      *   //sampleEnd
      *   println(result.unsafeRunSync())
      * }
      * ```
      */
-    fun <A> raiseException(e: Throwable): IO<Nothing, A> = RaiseException(e)
+    fun <A> yeet(e: Throwable): IO<Nothing, A> = RaiseException(e)
 
     /**
      * Raise an error in a pure way
@@ -164,13 +164,13 @@ sealed class IO<out E, out A> : IOOf<E, A> {
      *
      * fun main(args: Array<String>) {
      *   //sampleStart
-     *   val result: IO<Nothing, NetworkError, Int> = IO.raiseError(NetworkError)
+     *   val result: IO<Nothing, NetworkError, Int> = IO.kobe(NetworkError)
      *   //sampleEnd
      *   println(result.unsafeRunSync())
      * }
      * ```
      */
-    fun <E, A> raiseError(e: E): IO<E, A> = RaiseError(e)
+    fun <E, A> kobe(e: E): IO<E, A> = RaiseError(e)
 
     /**
      *  Sleeps for a given [duration] without blocking a thread.


### PR DESCRIPTION
After consulting with the community about less scary and more familiar API names, we have landed in two terms acquired from the young people's lingo.

Instead of throwing we will `yeet` to signify that the `Exceptions` will be reaching far up in the callstack.

We believe `kobe` perfectly represents accurate and elegant error signaling aming directly to your domain.

I hope adopting these terms will drive us away from the more academic lexicon the rest of the library uses.  