### PR TITLE
Fix package for eq

### DIFF
--- a/arrow-fx-kotlinx-coroutines/src/test/kotlin/arrow/integrations/kotlinx/CoroutinesIntegrationTest.kt
+++ b/arrow-fx-kotlinx-coroutines/src/test/kotlin/arrow/integrations/kotlinx/CoroutinesIntegrationTest.kt
@@ -23,7 +23,7 @@ import arrow.fx.typeclasses.ExitCase2
 import arrow.fx.typeclasses.milliseconds
 import arrow.fx.typeclasses.seconds
 import arrow.fx.unsafeRunAsync
-import arrow.test.eq
+import arrow.fx.test.eq
 import arrow.fx.test.laws.shouldBeEq
 import arrow.typeclasses.Eq
 import io.kotlintest.fail

--- a/arrow-fx-test/src/main/kotlin/arrow/fx/test/eq.kt
+++ b/arrow-fx-test/src/main/kotlin/arrow/fx/test/eq.kt
@@ -1,4 +1,4 @@
-package arrow.test
+package arrow.fx.test
 
 import arrow.fx.IOResult
 import arrow.typeclasses.Eq

--- a/arrow-fx-test/src/main/kotlin/arrow/fx/test/eq/EqK.kt
+++ b/arrow-fx-test/src/main/kotlin/arrow/fx/test/eq/EqK.kt
@@ -17,7 +17,7 @@ import arrow.fx.typeclasses.FiberPartialOf
 import arrow.fx.typeclasses.fix
 import arrow.fx.typeclasses.seconds
 import arrow.fx.unsafeRunSync
-import arrow.test.eq
+import arrow.fx.test.eq
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 

--- a/arrow-fx-test/src/main/kotlin/arrow/fx/test/laws/Law.kt
+++ b/arrow-fx-test/src/main/kotlin/arrow/fx/test/laws/Law.kt
@@ -14,7 +14,7 @@ import arrow.core.test.generators.tuple4
 import arrow.core.test.generators.tuple5
 import arrow.fx.IOResult
 import arrow.fx.unsafeRunSync
-import arrow.test.eq
+import arrow.fx.test.eq
 import arrow.typeclasses.Eq
 import io.kotlintest.Matcher
 import io.kotlintest.Result


### PR DESCRIPTION
PR on `release/0.11.0` branch.

cc @nomisRev , we left `eq.kt` outside `arrow.fx.test` package.