### PR TITLE
Fix #139: Wrong scope for dependencies

### DIFF
--- a/arrow-fx-kotlinx-coroutines/build.gradle
+++ b/arrow-fx-kotlinx-coroutines/build.gradle
@@ -16,11 +16,10 @@ apply from: "$PUBLISH_CONF"
 dependencies {
     compile project(':arrow-fx')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
-    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$KOTLINX_COROUTINES_VERSION"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$KOTLINX_COROUTINES_VERSION"
 
     testCompile project(":arrow-fx-test")
     testImplementation project(":arrow-fx-test")
     testImplementation project(':arrow-fx')
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$KOTLINX_COROUTINES_VERSION"
 }
-

--- a/arrow-fx-kotlinx-coroutines/build.gradle
+++ b/arrow-fx-kotlinx-coroutines/build.gradle
@@ -14,7 +14,7 @@ apply from: "$DOC_CONF"
 apply from: "$PUBLISH_CONF"
 
 dependencies {
-    compile project(':arrow-fx')
+    api project(':arrow-fx')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$KOTLINX_COROUTINES_VERSION"
 

--- a/arrow-fx-kotlinx-coroutines/build.gradle
+++ b/arrow-fx-kotlinx-coroutines/build.gradle
@@ -15,7 +15,7 @@ apply from: "$PUBLISH_CONF"
 
 dependencies {
     api project(':arrow-fx')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$KOTLINX_COROUTINES_VERSION"
 
     testCompile project(":arrow-fx-test")

--- a/arrow-fx-kotlinx-coroutines/build.gradle
+++ b/arrow-fx-kotlinx-coroutines/build.gradle
@@ -14,9 +14,9 @@ apply from: "$DOC_CONF"
 apply from: "$PUBLISH_CONF"
 
 dependencies {
-    implementation project(':arrow-fx')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$KOTLINX_COROUTINES_VERSION"
+    compile project(':arrow-fx')
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
+    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$KOTLINX_COROUTINES_VERSION"
 
     testCompile project(":arrow-fx-test")
     testImplementation project(":arrow-fx-test")


### PR DESCRIPTION
Fix #139 issue about the wrong scope for arrow-fx-kotlinx-coroutines dependencies.