### PR TITLE
IO<E, A>: remove `E` from cancel tokens

### DIFF
--- a/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Cancellable.kt
+++ b/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/Cancellable.kt
@@ -27,7 +27,7 @@ open class Cancellable {
   var size: Int = 0
 
   fun evalCancellable(n: Int): IO<Nothing, Int> =
-    IO.concurrent<Nothing>().cancellable<Int> { cb ->
+    IO.concurrent().cancellable<Int> { cb ->
       cb(Right(n))
       IO.unit
     }.fix()

--- a/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/ParMap.kt
+++ b/arrow-benchmarks-fx/src/jmh/kotlin/arrow/benchmarks/ParMap.kt
@@ -2,9 +2,6 @@ package arrow.benchmarks
 
 import arrow.core.extensions.list.foldable.foldLeft
 import arrow.fx.IO
-import arrow.fx.IODispatchers
-
-import arrow.fx.extensions.io.concurrent.parMapN
 import arrow.fx.unsafeRunSync
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.CompilerControl
@@ -28,7 +25,7 @@ open class ParMap {
 
   private fun ioHelper(): IO<Nothing, Int> =
     (0 until size).toList().foldLeft(IO { 0 }) { acc, i ->
-      IO.parMapN(IODispatchers.CommonPool, acc, IO { i }) { (a, b) -> a + b }
+      IO.parMapN(acc, IO { i }) { (a, b) -> a + b }
     }
 
   @Benchmark

--- a/arrow-docs/docs/effects/async/README.md
+++ b/arrow-docs/docs/effects/async/README.md
@@ -21,14 +21,14 @@ import arrow.core.*
 import arrow.fx.*
 import arrow.fx.extensions.io.async.*
 
-IO.async<Nothing>()
+IO.async()
   .async { callback: (Either<Throwable, Int>) -> Unit ->
     callback(1.right())
   }.fix().attempt().unsafeRunSync()
 ```
 
 ```kotlin:ank
-IO.async<Nothing>()
+IO.async()
   .async { callback: (Either<Throwable, Int>) -> Unit ->
     callback(RuntimeException().left())
   }.fix().attempt().unsafeRunSync()

--- a/arrow-docs/docs/fx/typeclasses/bracket/README.md
+++ b/arrow-docs/docs/fx/typeclasses/bracket/README.md
@@ -164,7 +164,7 @@ class Program<F>(BF: Bracket<F, Throwable>) : Bracket<F, Throwable> by BF {
 
 fun main(args: Array<String>) {
 //sampleStart
-val ioProgram = Program(IO.bracket<Nothing>())
+val ioProgram = Program(IO.bracket())
 
 val safeComputation = with (ioProgram) {
   openFile("data.json").bracket(

--- a/arrow-docs/docs/ref/README.md
+++ b/arrow-docs/docs/ref/README.md
@@ -21,7 +21,7 @@ Since the allocation of mutable state is not referentially transparent, this sid
 import arrow.fx.*
 import arrow.fx.extensions.io.monadDefer.monadDefer
 
-val ioRef: IO<Nothing, Ref<IOPartialOf<Nothing>, Int>> = Ref(IO.monadDefer<Nothing>(), 1).fix()
+val ioRef: IO<Nothing, Ref<IOPartialOf<Nothing>, Int>> = Ref(IO.monadDefer(), 1).fix()
 ```
 
 In case you want the side-effect to execute immediately and return the `Ref` instance, you can use the `unsafe` function.

--- a/arrow-fx-kotlinx-coroutines/src/test/kotlin/arrow/integrations/kotlinx/CoroutinesIntegrationTest.kt
+++ b/arrow-fx-kotlinx-coroutines/src/test/kotlin/arrow/integrations/kotlinx/CoroutinesIntegrationTest.kt
@@ -13,17 +13,13 @@ import arrow.fx.onCancel
 import arrow.fx.bracketCase
 import arrow.fx.extensions.exitcase2.eq.eq
 import arrow.fx.extensions.fx
-import arrow.fx.extensions.io.async.effectMap
 import arrow.fx.extensions.io.monad.followedBy
 import arrow.fx.handleErrorWith
 import arrow.fx.flatMap
-import arrow.fx.onCancel
-import arrow.fx.handleErrorWith
 import arrow.fx.typeclasses.ExitCase2
 import arrow.fx.typeclasses.milliseconds
 import arrow.fx.typeclasses.seconds
 import arrow.fx.unsafeRunAsync
-import arrow.fx.test.eq
 import arrow.fx.test.laws.shouldBeEq
 import arrow.typeclasses.Eq
 import io.kotlintest.fail

--- a/arrow-fx-test/src/main/kotlin/arrow/fx/test/eq/EqK.kt
+++ b/arrow-fx-test/src/main/kotlin/arrow/fx/test/eq/EqK.kt
@@ -8,7 +8,6 @@ import arrow.fx.IOPartialOf
 import arrow.fx.IOResult
 import arrow.fx.Schedule
 import arrow.fx.extensions.io.applicative.applicative
-import arrow.fx.extensions.io.concurrent.waitFor
 import arrow.fx.fix
 import arrow.fx.typeclasses.Duration
 import arrow.fx.typeclasses.Fiber
@@ -18,6 +17,7 @@ import arrow.fx.typeclasses.fix
 import arrow.fx.typeclasses.seconds
 import arrow.fx.unsafeRunSync
 import arrow.fx.test.eq
+import arrow.fx.waitFor
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
 

--- a/arrow-fx-test/src/main/kotlin/arrow/fx/test/laws/Law.kt
+++ b/arrow-fx-test/src/main/kotlin/arrow/fx/test/laws/Law.kt
@@ -4,8 +4,8 @@ import arrow.core.extensions.either.eq.eq
 import arrow.fx.IO
 import arrow.fx.IOOf
 import arrow.fx.fix
+import arrow.fx.waitFor
 import arrow.fx.extensions.io.applicative.applicative
-import arrow.fx.extensions.io.concurrent.waitFor
 import arrow.fx.typeclasses.Duration
 import arrow.fx.typeclasses.seconds
 import arrow.core.test.generators.tuple2

--- a/arrow-fx/src/main/kotlin/arrow/fx/IORace.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/IORace.kt
@@ -64,7 +64,7 @@ interface IORace {
    *     return result
    *   }
    *
-   *   IO.concurrent<Nothing>().example().fix().unsafeRunSync().let(::println)
+   *   IO.concurrent().example().fix().unsafeRunSync().let(::println)
    * }
    * ```
    *
@@ -276,7 +276,9 @@ interface IORace {
         other.cancel().fix().unsafeRunAsync { r2 ->
           main.pop()
           cb(IOResult.Error(r2.fold({
-            it.printStackTrace() // TODO send to undelivered cancellation error to async handler
+            // TODO create issue: send to `Enviroment#handleAsyncError` or return cancelation exception here instead
+            // The cancelation exceptions can be exposed and could include and additional `IOErrorException(a: Any)`
+            it.printStackTrace()
             err
           }, { err })))
         }
@@ -342,7 +344,9 @@ interface IORace {
         other2.cancel().fix().unsafeRunAsync { r2 ->
           other3.cancel().fix().unsafeRunAsync { r3 ->
             main.pop()
-            r2.fold({ it.printStackTrace() }, {}) // TODO send to undelivered cancellation error to async handler
+            // TODO create issue: send to `Enviroment#handleAsyncError` or return cancelation exception here instead
+            // The cancelation exceptions can be exposed and could include and additional `IOErrorException(a: Any)`
+            r2.fold({ it.printStackTrace() }, {})
             r3.fold({ it.printStackTrace() }, {})
             cb(IOResult.Error(err))
           }

--- a/arrow-fx/src/main/kotlin/arrow/fx/MVar.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/MVar.kt
@@ -213,7 +213,7 @@ interface MVar<F, A> {
      *
      * fun main(args: Array<String>) {
      *   //sampleStart
-     *   val mvar: IOOf<Nothing, MVar<IOPartialOf<Nothing>, Int>> = MVar.empty(IO.concurrent<Nothing>())
+     *   val mvar: IOOf<Nothing, MVar<IOPartialOf<Nothing>, Int>> = MVar.empty(IO.concurrent())
      *   //sampleEnd
      * }
      * ```
@@ -230,7 +230,7 @@ interface MVar<F, A> {
      *
      * fun main(args: Array<String>) {
      *   //sampleStart
-     *   val mvar: IOOf<Nothing, MVar<IOPartialOf<Nothing>, Int>> = MVar.cancellable(5, IO.concurrent<Nothing>())
+     *   val mvar: IOOf<Nothing, MVar<IOPartialOf<Nothing>, Int>> = MVar.cancellable(5, IO.concurrent())
      *   //sampleEnd
      * }
      * ```
@@ -251,7 +251,7 @@ interface MVar<F, A> {
      *
      * fun main(args: Array<String>) {
      *   //sampleStart
-     *   val mvar: IOOf<Nothing, MVar<IOPartialOf<Nothing>, Int>> = MVar.cancellable(5, IO.concurrent<Nothing>())
+     *   val mvar: IOOf<Nothing, MVar<IOPartialOf<Nothing>, Int>> = MVar.cancellable(5, IO.concurrent())
      *   //sampleEnd
      * }
      * ```
@@ -348,7 +348,7 @@ interface MVar<F, A> {
  *
  * fun main(args: Array<String>) {
  *   //sampleStart
- *   val mvarFactory: MVarFactory<IOPartialOf<Nothing>> = MVar.factoryCancellable(IO.concurrent<Nothing>())
+ *   val mvarFactory: MVarFactory<IOPartialOf<Nothing>> = MVar.factoryCancellable(IO.concurrent())
  *   val intVar: IOOf<Nothing, MVar<IOPartialOf<Nothing>, Int>> = mvarFactory.just(5)
  *   val stringVar: IOOf<Nothing, MVar<IOPartialOf<Nothing>, String>> = mvarFactory.empty<String>()
  *   //sampleEnd

--- a/arrow-fx/src/main/kotlin/arrow/fx/Promise.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Promise.kt
@@ -210,7 +210,7 @@ interface Promise<F, A> {
      *
      * fun main(args: Array<String>) {
      *   //sampleStart
-     *   val promise: IOOf<Nothing, Promise<IOPartialOf<Nothing>, Int>> = Promise(IO.concurrent<Nothing>())
+     *   val promise: IOOf<Nothing, Promise<IOPartialOf<Nothing>, Int>> = Promise(IO.concurrent())
      *   //sampleEnd
      * }
      * ```
@@ -228,7 +228,7 @@ interface Promise<F, A> {
      *
      * fun main(args: Array<String>) {
      *   //sampleStart
-     *   val unsafePromise: Promise<IOPartialOf<Nothing>, Int> = Promise.unsafeCancellable(IO.concurrent<Nothing>())
+     *   val unsafePromise: Promise<IOPartialOf<Nothing>, Int> = Promise.unsafeCancellable(IO.concurrent())
      *   //sampleEnd
      * }
      * ```

--- a/arrow-fx/src/main/kotlin/arrow/fx/Queue.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Queue.kt
@@ -341,7 +341,7 @@ interface Queue<F, A> : QueueOf<F, A>, Dequeue<F, A>, Enqueue<F, A> {
      *
      * suspend fun main(args: Array<String>): Unit = IO.fx<Nothing, Unit> {
      *  val capacity = 2
-     *  val q = !Queue.sliding<IOPartialOf<Nothing>, Int>(capacity, IO.concurrent<Nothing>())
+     *  val q = !Queue.sliding<IOPartialOf<Nothing>, Int>(capacity, IO.concurrent())
      *  !q.offer(42)
      *  !q.offer(43)
      *  !q.offer(44) // <-- This `offer` exceeds the capacity, causing the oldest value to be removed
@@ -371,7 +371,7 @@ interface Queue<F, A> : QueueOf<F, A>, Dequeue<F, A>, Enqueue<F, A> {
      *
      * suspend fun main(args: Array<String>): Unit = IO.fx<Nothing, Unit> {
      *   val capacity = 2
-     *   val q = !Queue.dropping<IOPartialOf<Nothing>, Int>(capacity, IO.concurrent<Nothing>())
+     *   val q = !Queue.dropping<IOPartialOf<Nothing>, Int>(capacity, IO.concurrent())
      *   !q.offer(42)
      *   !q.offer(43)
      *   !q.offer(44) // <-- This `offer` exceeds the capacity and will be dropped immediately
@@ -400,7 +400,7 @@ interface Queue<F, A> : QueueOf<F, A>, Dequeue<F, A>, Enqueue<F, A> {
      * import arrow.fx.extensions.io.concurrent.concurrent
      *
      * suspend fun main(args: Array<String>): Unit = IO.fx<Nothing, Unit> {
-     *   val q = !Queue.unbounded<IOPartialOf<Nothing>, Int>(IO.concurrent<Nothing>())
+     *   val q = !Queue.unbounded<IOPartialOf<Nothing>, Int>(IO.concurrent())
      *   !q.offer(42)
      *   // ...
      *   !q.offer(42000000)
@@ -436,7 +436,7 @@ interface Queue<F, A> : QueueOf<F, A>, Dequeue<F, A>, Enqueue<F, A> {
  *
  * //sampleStart
  * suspend fun main(): Unit = IO.fx<Nothing, Unit> {
- *   val factory: QueueFactory<IOPartialOf<Nothing>> = Queue.factory(IO.concurrent<Nothing>())
+ *   val factory: QueueFactory<IOPartialOf<Nothing>> = Queue.factory(IO.concurrent())
  *   val unbounded = !factory.unbounded<Int>()
  *   val bounded = !factory.bounded<String>(10)
  *   val sliding = !factory.sliding<Double>(4)

--- a/arrow-fx/src/main/kotlin/arrow/fx/Resource.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Resource.kt
@@ -133,7 +133,7 @@ inline fun <F, E, A> ResourceOf<F, E, A>.fix(): Resource<F, E, A> =
  * fun shutDownFancyService(service: Service): IO<Nothing, Unit> = IO { println("Closed service") }
  *
  * //sampleStart
- * val managedTProgram = Resource.monad(IO.bracket<Nothing>()).fx.monad {
+ * val managedTProgram = Resource.monad(IO.bracket()).fx.monad {
  *   val consumer = Resource(::createConsumer, ::closeConsumer, IO.bracket()).bind()
  *   val handle = Resource(::createDBHandle, ::closeDBHandle, IO.bracket()).bind()
  *   Resource({ createFancyService(consumer, handle) }, ::shutDownFancyService, IO.bracket()).bind()
@@ -170,7 +170,7 @@ sealed class Resource<F, E, A> : ResourceOf<F, E, A> {
    *
    * fun main() {
    *   //sampleStart
-   *   val program = Resource(::acquireResource, ::releaseResource, IO.bracket<Nothing>()).use {
+   *   val program = Resource(::acquireResource, ::releaseResource, IO.bracket()).use {
    *     IO { println("Expensive resource under use! $it") }
    *   }
    *   //sampleEnd
@@ -291,7 +291,7 @@ sealed class Resource<F, E, A> : ResourceOf<F, E, A> {
      *
      * fun main() {
      *   //sampleStart
-     *   val resource = Resource(::acquireResource, ::releaseResource, IO.bracket<Nothing>())
+     *   val resource = Resource(::acquireResource, ::releaseResource, IO.bracket())
      *   //sampleEnd
      *   resource.use {
      *     IO { println("Expensive resource under use! $it") }

--- a/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
@@ -126,7 +126,7 @@ inline fun <A, B> DecisionOf<A, B>.fix(): Schedule.Decision<A, B> =
  *   var counter = 0
  *   val io = IO { println("Run: ${counter++}") }
  *   //sampleStart
- *   val res = io.repeat(IO.concurrent<Nothing>(), Schedule.recurs(IO.monad(), 3))
+ *   val res = io.repeat(IO.concurrent(), Schedule.recurs(IO.monad(), 3))
  *   //sampleEnd
  *   println(res.fix().unsafeRunSync())
  * }
@@ -150,10 +150,10 @@ inline fun <A, B> DecisionOf<A, B>.fix(): Schedule.Decision<A, B> =
  *   var counter = 0
  *   val io = IO { println("Run: ${counter++}") }
  *   //sampleStart
- *   val res = io.repeat(IO.concurrent<Nothing>(), Schedule.unit<IOPartialOf<Nothing>, Unit>(IO.monad()).zipLeft(Schedule.recurs(IO.monad(), 3)))
+ *   val res = io.repeat(IO.concurrent(), Schedule.unit<IOPartialOf<Nothing>, Unit>(IO.monad()).zipLeft(Schedule.recurs(IO.monad(), 3)))
  *
  *   // equal to
- *   val res2 = io.repeat(IO.concurrent<Nothing>(), Schedule.recurs<IOPartialOf<Nothing>, Unit>(IO.monad(), 3).zipRight(Schedule.unit(IO.monad())))
+ *   val res2 = io.repeat(IO.concurrent(), Schedule.recurs<IOPartialOf<Nothing>, Unit>(IO.monad(), 3).zipRight(Schedule.unit(IO.monad())))
  *
  *   //sampleEnd
  *   println(res.fix().unsafeRunSync())
@@ -177,10 +177,10 @@ inline fun <A, B> DecisionOf<A, B>.fix(): Schedule.Decision<A, B> =
  *   var counter = 0
  *   val io = IO { println("Run: ${counter++}"); counter }
  *   //sampleStart
- *   val res = io.repeat(IO.concurrent<Nothing>(), Schedule.identity<IOPartialOf<Nothing>, Int>(IO.monad()).zipLeft(Schedule.recurs(IO.monad(), 3)))
+ *   val res = io.repeat(IO.concurrent(), Schedule.identity<IOPartialOf<Nothing>, Int>(IO.monad()).zipLeft(Schedule.recurs(IO.monad(), 3)))
  *
  *   // equal to
- *   val res2 = io.repeat(IO.concurrent<Nothing>(), Schedule.recurs<IOPartialOf<Nothing>, Int>(IO.monad(), 3).zipRight(Schedule.identity<IOPartialOf<Nothing>, Int>(IO.monad())))
+ *   val res2 = io.repeat(IO.concurrent(), Schedule.recurs<IOPartialOf<Nothing>, Int>(IO.monad(), 3).zipRight(Schedule.identity<IOPartialOf<Nothing>, Int>(IO.monad())))
  *
  *   //sampleEnd
  *   println(res.fix().unsafeRunSync())
@@ -204,10 +204,10 @@ inline fun <A, B> DecisionOf<A, B>.fix(): Schedule.Decision<A, B> =
  *   var counter = 0
  *   val io = IO { println("Run: ${counter++}"); counter }
  *   //sampleStart
- *   val res = io.repeat(IO.concurrent<Nothing>(), Schedule.collect<IOPartialOf<Nothing>, Int>(IO.monad()).zipLeft(Schedule.recurs(IO.monad(), 3)))
+ *   val res = io.repeat(IO.concurrent(), Schedule.collect<IOPartialOf<Nothing>, Int>(IO.monad()).zipLeft(Schedule.recurs(IO.monad(), 3)))
  *
  *   // equal to
- *   val res2 = io.repeat(IO.concurrent<Nothing>(), Schedule.recurs<IOPartialOf<Nothing>, Int>(IO.monad(), 3).zipRight(Schedule.collect<IOPartialOf<Nothing>, Int>(IO.monad())))
+ *   val res2 = io.repeat(IO.concurrent(), Schedule.recurs<IOPartialOf<Nothing>, Int>(IO.monad(), 3).zipRight(Schedule.collect<IOPartialOf<Nothing>, Int>(IO.monad())))
  *
  *   //sampleEnd
  *   println(res.fix().unsafeRunSync())
@@ -233,7 +233,7 @@ inline fun <A, B> DecisionOf<A, B>.fix(): Schedule.Decision<A, B> =
  *   var counter = 0
  *   val io = IO { println("Run: ${counter++}"); counter }
  *   //sampleStart
- *   val res = io.repeat(IO.concurrent<Nothing>(), Schedule.doWhile<IOPartialOf<Nothing>, Int>(IO.monad()) { it <= 3 })
+ *   val res = io.repeat(IO.concurrent(), Schedule.doWhile<IOPartialOf<Nothing>, Int>(IO.monad()) { it <= 3 })
  *   //sampleEnd
  *   println(res.fix().unsafeRunSync())
  * }

--- a/arrow-fx/src/main/kotlin/arrow/fx/Semaphore.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Semaphore.kt
@@ -198,7 +198,7 @@ interface Semaphore<F> {
      *
      * fun main(args: Array<String>) {
      *   //sampleStart
-     *   val semaphore = Semaphore<IOPartialOf<Nothing>>(5, IO.concurrent<Nothing>())
+     *   val semaphore = Semaphore<IOPartialOf<Nothing>>(5, IO.concurrent())
      *   //sampleEnd
      * }
      */

--- a/arrow-fx/src/main/kotlin/arrow/fx/Timer.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Timer.kt
@@ -28,7 +28,7 @@ interface Timer<F> {
    *       effect { println("Hello World!") }
    *     }
    *   //sampleEnd
-   *   IO.concurrent<Nothing>().delayHelloWorld()
+   *   IO.concurrent().delayHelloWorld()
    *     .fix().unsafeRunSync()
    * }
    * ```

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/async/async.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/async/async.kt
@@ -1,0 +1,11 @@
+package arrow.fx.extensions.io.async
+
+import arrow.fx.IO
+import arrow.fx.IOPartialOf
+import arrow.fx.extensions.IOAsync
+import arrow.fx.typeclasses.Async
+
+private val defaultAsync = object : IOAsync {}
+
+fun IO.Companion.async(): Async<IOPartialOf<Nothing>> =
+  defaultAsync

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/bracket/bracket.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/bracket/bracket.kt
@@ -1,0 +1,11 @@
+package arrow.fx.extensions.io.bracket
+
+import arrow.fx.IO
+import arrow.fx.IOPartialOf
+import arrow.fx.extensions.IOBracket
+import arrow.fx.typeclasses.Bracket
+
+private val defaultBracket = object : IOBracket {}
+
+fun IO.Companion.bracket(): Bracket<IOPartialOf<Nothing>, Throwable> =
+  defaultBracket

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/concurrent/concurrent.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/concurrent/concurrent.kt
@@ -1,0 +1,88 @@
+package arrow.fx.extensions.io.concurrent
+
+import arrow.Kind
+import arrow.core.ListK
+import arrow.core.extensions.listk.traverse.traverse
+import arrow.core.fix
+import arrow.core.identity
+import arrow.core.k
+import arrow.fx.IO
+import arrow.fx.IOOf
+import arrow.fx.IOPartialOf
+import arrow.fx.MVar
+import arrow.fx.Promise
+import arrow.fx.Queue
+import arrow.fx.Ref
+import arrow.fx.Semaphore
+import arrow.fx.extensions.IODefaultConcurrent
+import arrow.fx.extensions.io.dispatchers.dispatchers
+import arrow.fx.fix
+import arrow.fx.typeclasses.Concurrent
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Traverse
+import kotlin.coroutines.CoroutineContext
+
+private val defaultConcurrent = object : IODefaultConcurrent {}
+
+fun IO.Companion.concurrent(): Concurrent<IOPartialOf<Nothing>> =
+  defaultConcurrent
+
+fun <E> par(ctx: CoroutineContext) =
+  object : Applicative<IOPartialOf<E>> {
+    override fun <A> just(a: A): Kind<IOPartialOf<E>, A> = IO.just(a)
+
+    override fun <A, B> Kind<IOPartialOf<E>, A>.ap(ff: Kind<IOPartialOf<E>, (A) -> B>): Kind<IOPartialOf<E>, B> =
+      IO.parMapN(ctx, ff, this) { (f, a) -> f(a) }
+  }
+
+fun <G, E, A, B> Kind<G, A>.parTraverse(ctx: CoroutineContext, TG: Traverse<G>, f: (A) -> IOOf<E, B>): IO<E, Kind<G, B>> =
+  TG.run { traverse(par(ctx), f) }.fix()
+
+fun <E, A, B> Iterable<A>.parTraverse(ctx: CoroutineContext, f: (A) -> IOOf<E, B>): IO<E, List<B>> =
+  toList().k().parTraverse(ctx, ListK.traverse(), f).map { it.fix() }
+
+fun <E, A> Iterable<IOOf<E, A>>.parSequence(ctx: CoroutineContext): IO<E, List<A>> =
+  parTraverse(ctx, ::identity)
+
+fun <E, A> Iterable<IOOf<E, A>>.parSequence(): IO<E, List<A>> =
+  parSequence(IO.dispatchers().default())
+
+fun <E, A, B> Iterable<A>.parTraverse(f: (A) -> IOOf<E, B>): IO<E, List<B>> =
+  parTraverse(IO.dispatchers().default(), f)
+
+fun <A> Ref(a: A): IO<Nothing, Ref<IOPartialOf<Nothing>, A>> =
+  Ref.invoke(IO.concurrent(), a).fix()
+
+fun <A> Promise(): IO<Nothing, Promise<IOPartialOf<Nothing>, A>> =
+  Promise<IOPartialOf<Nothing>, A>(IO.concurrent()).fix()
+
+fun Semaphore(n: Long): IO<Nothing, Semaphore<IOPartialOf<Nothing>>> =
+  Semaphore(n, IO.concurrent()).fix()
+
+fun <A> MVar(a: A): IO<Nothing, MVar<IOPartialOf<Nothing>, A>> =
+  MVar(a, IO.concurrent()).fix()
+
+/**
+ * Create an empty [MVar] or mutable variable structure to be used for thread-safe sharing.
+ *
+ * @see MVar
+ * @see [MVar] for more usage details.
+ */
+fun <A> MVar(): IO<Nothing, MVar<IOPartialOf<Nothing>, A>> =
+  MVar.empty<IOPartialOf<Nothing>, A>(IO.concurrent()).fix()
+
+/** @see [Queue.Companion.bounded] **/
+fun <A> Queue.Companion.bounded(capacity: Int): IO<Nothing, Queue<IOPartialOf<Nothing>, A>> =
+  Queue.bounded<IOPartialOf<Nothing>, A>(capacity, IO.concurrent()).fix()
+
+/** @see [Queue.Companion.sliding] **/
+fun <A> Queue.Companion.sliding(capacity: Int): IO<Nothing, Queue<IOPartialOf<Nothing>, A>> =
+  Queue.sliding<IOPartialOf<Nothing>, A>(capacity, IO.concurrent()).fix()
+
+/** @see [Queue.Companion.dropping] **/
+fun <A> Queue.Companion.dropping(capacity: Int): IO<Nothing, Queue<IOPartialOf<Nothing>, A>> =
+  Queue.dropping<IOPartialOf<Nothing>, A>(capacity, IO.concurrent()).fix()
+
+/** @see [Queue.Companion.unbounded] **/
+fun <A> Queue.Companion.unbounded(): IO<Nothing, Queue<IOPartialOf<Nothing>, A>> =
+  Queue.unbounded<IOPartialOf<Nothing>, A>(IO.concurrent()).fix()

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/dispatchers/dispatchers.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/dispatchers/dispatchers.kt
@@ -1,0 +1,11 @@
+package arrow.fx.extensions.io.dispatchers
+
+import arrow.fx.IO
+import arrow.fx.IOPartialOf
+import arrow.fx.extensions.IODispatchers
+import arrow.fx.typeclasses.Dispatchers
+
+private val defaultDispatchers = object : IODispatchers {}
+
+fun IO.Companion.dispatchers(): Dispatchers<IOPartialOf<Nothing>> =
+  defaultDispatchers

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/enviroment/enviroment.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/enviroment/enviroment.kt
@@ -1,0 +1,11 @@
+package arrow.fx.extensions.io.enviroment
+
+import arrow.fx.IO
+import arrow.fx.IOPartialOf
+import arrow.fx.extensions.IOEnvironment
+import arrow.fx.typeclasses.Environment
+
+private val defaultEnviroment = object : IOEnvironment {}
+
+fun IO.Companion.enviroment(): Environment<IOPartialOf<Nothing>> =
+  defaultEnviroment

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadDefer/monadDefer.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadDefer/monadDefer.kt
@@ -1,0 +1,11 @@
+package arrow.fx.extensions.io.monadDefer
+
+import arrow.fx.IO
+import arrow.fx.IOPartialOf
+import arrow.fx.extensions.IOMonadDefer
+import arrow.fx.typeclasses.MonadDefer
+
+private val defaultMonadDefer = object : IOMonadDefer { }
+
+fun IO.Companion.monadDefer(): MonadDefer<IOPartialOf<Nothing>> =
+  defaultMonadDefer

--- a/arrow-fx/src/main/kotlin/arrow/fx/internal/ForwardCancellable.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/internal/ForwardCancellable.kt
@@ -37,7 +37,7 @@ internal class ForwardCancellable {
     return IO.Async { conn, cb -> loop(conn, cb) }
   }
 
-  fun <E> complete(value: IOOf<E, Unit>): Unit = state.value.let { current ->
+  fun complete(value: IOOf<Nothing, Unit>): Unit = state.value.let { current ->
     when (current) {
       is Active -> {
         value.fix().unsafeRunAsyncEither {}
@@ -45,13 +45,13 @@ internal class ForwardCancellable {
       }
       is Empty -> if (current == init) {
         // If `init`, then `cancel` was not triggered yet
-        if (!state.compareAndSet(current, Active(value.rethrow)))
+        if (!state.compareAndSet(current, Active(value)))
           complete(value)
       } else {
         if (!state.compareAndSet(current, finished))
           complete(value)
         else
-          execute(value.rethrow, current.stack)
+          execute(value, current.stack)
       }
     }
   }

--- a/arrow-fx/src/main/kotlin/arrow/fx/internal/IOBracket.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/internal/IOBracket.kt
@@ -8,7 +8,6 @@ import arrow.fx.IOOf
 import arrow.fx.IOResult
 import arrow.fx.IORunLoop
 import arrow.fx.fix
-import arrow.fx.handleErrorWith
 import arrow.fx.typeclasses.ExitCase2
 import kotlinx.atomicfu.atomic
 

--- a/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Bracket.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Bracket.kt
@@ -39,6 +39,14 @@ sealed class ExitCase2<out E> {
   companion object
 }
 
+fun ExitCase2<Nothing>.toExitCase(): ExitCase<Throwable> =
+  when (this) {
+    ExitCase2.Completed -> ExitCase.Completed
+    ExitCase2.Cancelled -> ExitCase.Cancelled
+    is ExitCase2.Error -> this.error
+    is ExitCase2.Exception -> ExitCase.Error(this.exception)
+  }
+
 /**
  * ank_macro_hierarchy(arrow.fx.typeclasses.Bracket)
  *

--- a/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Concurrent.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Concurrent.kt
@@ -95,7 +95,7 @@ interface Concurrent<F> : Async<F> {
    *     }
    *
    *   //sampleEnd
-   *   IO.concurrent<Nothing>().example().fix().unsafeRunSync()
+   *   IO.concurrent().example().fix().unsafeRunSync()
    * }
    * ```
    *
@@ -133,7 +133,7 @@ interface Concurrent<F> : Async<F> {
    *   }
    *   //sampleEnd
    *
-   *   val r = IO.concurrent<Nothing>().example().fix().unsafeRunSync()
+   *   val r = IO.concurrent().example().fix().unsafeRunSync()
    *   println("Race winner result is: $r")
    * }
    * ```
@@ -173,7 +173,7 @@ interface Concurrent<F> : Async<F> {
    *     }
    *   //sampleEnd
    *
-   *   val r = IO.concurrent<Nothing>().example().fix().unsafeRunSync()
+   *   val r = IO.concurrent().example().fix().unsafeRunSync()
    *   println("Race winner result is: $r")
    * }
    * ```
@@ -290,6 +290,36 @@ interface Concurrent<F> : Async<F> {
    * @see cancellable for a simpler non-suspending version.
    */
   fun <A> cancellableF(k: ((Either<Throwable, A>) -> Unit) -> Kind<F, CancelToken<F>>): Kind<F, A> =
+    // F.asyncF { cb =>
+    //   val state = new AtomicReference[Either[Throwable, Unit] => Unit](null)
+    //   val cb1 = (a: Either[Throwable, A]) => {
+    //     try {
+    //       cb(a)
+    //     } finally {
+    //       // This CAS can only succeed in case the operation is already finished
+    //       // and no cancellation token was installed yet
+    //       if (!state.compareAndSet(null, Callback.dummy1)) {
+    //         val cb2 = state.get()
+    //         state.lazySet(null)
+    //         cb2(Callback.rightUnit)
+    //       }
+    //     }
+    //   }
+    //   // Until we've got a cancellation token, the task needs to be evaluated
+    //   // uninterruptedly, otherwise risking a leak, hence the bracket
+    //   F.bracketCase(k(cb1)) { _ =>
+    //     F.async[Unit] { cb =>
+    //       if (!state.compareAndSet(null, cb)) {
+    //         cb(Callback.rightUnit)
+    //       }
+    //     }
+    //   } { (token, e) =>
+    //     e match {
+    //       case ExitCase.Canceled => token
+    //         case _ => F.unit
+    //     }
+    //   }
+    // }
     asyncF { cb ->
       val state = AtomicRefW<((Either<Throwable, Unit>) -> Unit)?>(null)
       val cb1 = { r: Either<Throwable, A> ->
@@ -347,7 +377,7 @@ interface Concurrent<F> : Async<F> {
    *    }
    *
    *  //sampleEnd
-   *    IO.concurrent<Nothing>().processListInParallel()
+   *    IO.concurrent().processListInParallel()
    *      .fix()
    *      .unsafeRunSync()
    * }
@@ -401,7 +431,7 @@ interface Concurrent<F> : Async<F> {
    *       .map { id -> getUserById(id) }
    *       .parSequence()
    *  //sampleEnd
-   *   IO.concurrent<Nothing>().processInParallel()
+   *   IO.concurrent().processInParallel()
    *     .fix().unsafeRunSync()
    * }
    * ```
@@ -456,7 +486,7 @@ interface Concurrent<F> : Async<F> {
    *   return result
    *   }
    *
-   *   IO.concurrent<Nothing>().example().fix().unsafeRunSync().let(::println)
+   *   IO.concurrent().example().fix().unsafeRunSync().let(::println)
    * }
    * ```
    *
@@ -501,7 +531,7 @@ interface Concurrent<F> : Async<F> {
    *   return result
    *   }
    *
-   *   IO.concurrent<Nothing>().example().fix().unsafeRunSync().let(::println)
+   *   IO.concurrent().example().fix().unsafeRunSync().let(::println)
    * }
    * ```
    *
@@ -891,7 +921,7 @@ interface Concurrent<F> : Async<F> {
    *   return result
    *   }
    *
-   *   IO.concurrent<Nothing>().example().fix().unsafeRunSync().let(::println)
+   *   IO.concurrent().example().fix().unsafeRunSync().let(::println)
    * }
    * ```
    *
@@ -1104,7 +1134,7 @@ interface Concurrent<F> : Async<F> {
    *     }
    *
    *   //sampleEnd
-   *   IO.concurrent<Nothing>().promiseExample()
+   *   IO.concurrent().promiseExample()
    *     .fix().unsafeRunSync()
    * }
    * ```
@@ -1138,7 +1168,7 @@ interface Concurrent<F> : Async<F> {
    *     }
    *
    *   //sampleEnd
-   *   IO.concurrent<Nothing>().promiseExample()
+   *   IO.concurrent().promiseExample()
    *     .fix().unsafeRunSync()
    * }
    * ```
@@ -1173,7 +1203,7 @@ interface Concurrent<F> : Async<F> {
    *     }
    *
    *   //sampleEnd
-   *   IO.concurrent<Nothing>().mvarExample()
+   *   IO.concurrent().mvarExample()
    *     .fix().unsafeRunSync().let(::println)
    * }
    * ```
@@ -1250,7 +1280,7 @@ interface Concurrent<F> : Async<F> {
    *     return world.waitFor(1.seconds, fallbackWorld)
    *   }
    *   //sampleEnd
-   *   IO.concurrent<Nothing>().timedOutWorld()
+   *   IO.concurrent().timedOutWorld()
    *     .fix().unsafeRunSync()
    * }
    * ```
@@ -1280,7 +1310,7 @@ interface Concurrent<F> : Async<F> {
    *     return world.waitFor(3.seconds)
    *   }
    *   //sampleEnd
-   *   IO.concurrent<Nothing>().timedOutWorld()
+   *   IO.concurrent().timedOutWorld()
    *     .fix().unsafeRunSync()
    * }
    * ```

--- a/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/MonadDefer.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/MonadDefer.kt
@@ -54,7 +54,7 @@ interface MonadDefer<F> : MonadThrow<F>, Bracket<F, Throwable> {
    *     }
    *
    *   //sampleEnd
-   *   IO.monadDefer<Nothing>().refExample()
+   *   IO.monadDefer().refExample()
    *     .fix().unsafeRunSync().let(::println)
    * }
    * ```

--- a/arrow-fx/src/test/kotlin/arrow/fx/EffectsSuspendDSLTests.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/EffectsSuspendDSLTests.kt
@@ -196,7 +196,7 @@ class EffectsSuspendDSLTests : UnitSpec() {
       val const = 1
       fxTest {
         IO.fx<Nothing, Int> {
-          val fiber = !IO.effect { const }.fork(IO.dispatchers<Nothing>().default())
+          val fiber = !IO.effect { const }.fork(IO.dispatchers().default())
           val n = !fiber.join()
           n
         }

--- a/arrow-fx/src/test/kotlin/arrow/fx/FlatMapTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/FlatMapTest.kt
@@ -1,0 +1,48 @@
+package arrow.fx
+
+import arrow.core.Either
+import arrow.core.Left
+import arrow.core.test.UnitSpec
+import io.kotlintest.shouldBe
+import arrow.fx.extensions.io.monad.flatMap as ioMonadFlatMap
+import arrow.fx.flatMap as arrowFxFlatMap
+
+class OneError
+class TwoError
+
+class FlatMapTest : UnitSpec() {
+
+  init {
+
+    val one = OneError()
+
+    fun oneIO(): IO<OneError, String> = IO.raiseError(one)
+    fun twoIO(value: String): IO<TwoError, Int> = IO.just(value.toInt())
+
+    "ioMonadFlatMap" {
+      oneIO()
+        .ioMonadFlatMap { twoIO(it) }
+        .unsafeRunSyncEither() shouldBe Either.Left(one)
+    }
+
+    "ioMonadFlatMap and fold" {
+      oneIO()
+        .ioMonadFlatMap { twoIO(it) }
+        .unsafeRunSyncEither()
+        .fold({ it }, { it }) shouldBe one
+    }
+
+    "arrowFxFlatMap" {
+      oneIO()
+        .arrowFxFlatMap { twoIO(it) }
+        .unsafeRunSyncEither() shouldBe Left(one)
+    }
+
+    "arrowFxFlatMap with fold" {
+      oneIO()
+        .arrowFxFlatMap { twoIO(it) }
+        .unsafeRunSyncEither()
+        .fold({ it }, { it }) shouldBe one
+    }
+  }
+}

--- a/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
@@ -17,7 +17,6 @@ import arrow.fx.IO.Companion.just
 import arrow.fx.extensions.fx
 import arrow.fx.extensions.io.async.async
 import arrow.fx.extensions.io.concurrent.concurrent
-import arrow.fx.extensions.io.concurrent.raceN
 import arrow.fx.extensions.io.applicative.applicative
 import arrow.fx.extensions.io.dispatchers.dispatchers
 import arrow.fx.extensions.io.functor.functor
@@ -50,7 +49,7 @@ class IOTest : UnitSpec() {
 
   private val other = newSingleThreadContext("other")
   private val all = newSingleThreadContext("all")
-  private val NonBlocking = IO.dispatchers<Nothing>().default()
+  private val NonBlocking = IO.dispatchers().default()
 
   init {
     testLaws(
@@ -123,7 +122,7 @@ class IOTest : UnitSpec() {
     }
 
     "should time out on unending unsafeRunTimed" {
-      val never = IO.async<Nothing>().never<Int>().fix()
+      val never = IO.async().never<Int>().fix()
       val start = System.currentTimeMillis()
       val received = never.unsafeRunTimed(100.milliseconds)
       val elapsed = System.currentTimeMillis() - start
@@ -360,7 +359,7 @@ class IOTest : UnitSpec() {
     }
 
     "unsafeRunTimed times out with None result" {
-      val never = IO.async<Nothing>().never<Unit>().fix()
+      val never = IO.async().never<Unit>().fix()
       val result = never.unsafeRunTimed(100.milliseconds)
       result shouldBe None
     }
@@ -600,8 +599,8 @@ class IOTest : UnitSpec() {
 
     "forked pair race should run" {
       IO.fx<Either<Int, Int>> {
-        IO.dispatchers<Nothing>().io().raceN(
-          IO.timer<Nothing>().sleep(10.seconds).followedBy(IO.effect { 1 }),
+        IO.raceN(
+          IO.sleep(10.seconds).followedBy(IO.effect { 1 }),
           IO.effect { 3 }
         ).fork().bind().join().bind()
       }.unsafeRunSync() shouldBe 3.right()
@@ -609,9 +608,9 @@ class IOTest : UnitSpec() {
 
     "forked triple race should run" {
       IO.fx<Race3<Int, Int, Int>> {
-        IO.dispatchers<Nothing>().io().raceN(
-          IO.timer<Nothing>().sleep(10.seconds).followedBy(IO.effect { 1 }),
-          IO.timer<Nothing>().sleep(10.seconds).followedBy(IO.effect { 3 }),
+        IO.raceN(
+          IO.sleep(10.seconds).followedBy(IO.effect { 1 }),
+          IO.sleep(10.seconds).followedBy(IO.effect { 3 }),
           IO.effect { 2 }
         ).fork().bind().join().bind()
       }.unsafeRunSync() shouldBe Race3.Third(2)
@@ -643,27 +642,27 @@ class IOTest : UnitSpec() {
     }
 
     "ConcurrentParMap2 left handles null" {
-      IO.concurrent<Nothing>().parMap2(NonBlocking, IO.just<Int?>(null), IO.unit) { _, unit -> unit }
+      IO.concurrent().parMap2(NonBlocking, IO.just<Int?>(null), IO.unit) { _, unit -> unit }
         .fix().unsafeRunSync() shouldBe Unit
     }
 
     "ConcurrentParMap2 right handles null" {
-      IO.concurrent<Nothing>().parMap2(NonBlocking, IO.unit, IO.just<Int?>(null)) { unit, _ -> unit }
+      IO.concurrent().parMap2(NonBlocking, IO.unit, IO.just<Int?>(null)) { unit, _ -> unit }
         .fix().unsafeRunSync() shouldBe Unit
     }
 
     "ConcurrentParMap3 left handles null" {
-      IO.concurrent<Nothing>().parMap3(NonBlocking, IO.just<Int?>(null), IO.unit, IO.unit) { _, unit, _ -> unit }
+      IO.concurrent().parMap3(NonBlocking, IO.just<Int?>(null), IO.unit, IO.unit) { _, unit, _ -> unit }
         .fix().unsafeRunSync() shouldBe Unit
     }
 
     "ConcurrentParMap3 middle handles null" {
-      IO.concurrent<Nothing>().parMap3(NonBlocking, IO.unit, IO.just<Int?>(null), IO.unit) { unit, _, _ -> unit }
+      IO.concurrent().parMap3(NonBlocking, IO.unit, IO.just<Int?>(null), IO.unit) { unit, _, _ -> unit }
         .fix().unsafeRunSync() shouldBe Unit
     }
 
     "ConcurrentParMap3 right handles null" {
-      IO.concurrent<Nothing>().parMap3(NonBlocking, IO.unit, IO.unit, IO.just<Int?>(null)) { unit, _, _ -> unit }
+      IO.concurrent().parMap3(NonBlocking, IO.unit, IO.unit, IO.just<Int?>(null)) { unit, _, _ -> unit }
         .fix().unsafeRunSync() shouldBe Unit
     }
 

--- a/arrow-fx/src/test/kotlin/arrow/fx/MVarTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/MVarTest.kt
@@ -23,7 +23,7 @@ import io.kotlintest.shouldBe
 class MVarTest : UnitSpec() {
 
   fun <A> fx(c: suspend ConcurrentSyntax<IOPartialOf<Nothing>>.() -> A): IO<Nothing, A> =
-    IO.concurrent<Nothing>().fx.concurrent(c).fix()
+    IO.concurrent().fx.concurrent(c).fix()
 
   init {
 

--- a/arrow-fx/src/test/kotlin/arrow/fx/PromiseTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/PromiseTest.kt
@@ -120,7 +120,7 @@ class PromiseTest : UnitSpec() {
       }
 
       "$label - get blocks until set" {
-        Ref(IO.monadDefer<Nothing>(), 0).flatMap { state ->
+        Ref(IO.monadDefer(), 0).flatMap { state ->
           promise.flatMap { modifyGate ->
             promise.flatMap { readGate ->
               modifyGate.get().flatMap { state.update { i -> i * 2 }.flatMap { readGate.complete(0) } }.fork(ctx).flatMap {

--- a/arrow-fx/src/test/kotlin/arrow/fx/QueueTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/QueueTest.kt
@@ -15,7 +15,6 @@ import arrow.core.test.generators.tuple2
 import arrow.core.test.generators.tuple3
 import arrow.fx.extensions.fx
 import arrow.fx.extensions.io.applicative.applicative
-import arrow.fx.extensions.io.async.effectMap
 import arrow.fx.extensions.io.concurrent.concurrent
 import arrow.fx.extensions.io.dispatchers.dispatchers
 import arrow.fx.test.laws.equalUnderTheLaw
@@ -31,13 +30,13 @@ import kotlin.coroutines.CoroutineContext
 class QueueTest : UnitSpec() {
 
   fun <A> fx(c: suspend ConcurrentSyntax<IOPartialOf<Nothing>>.() -> A): IO<Nothing, A> =
-    IO.concurrent<Nothing>().fx.concurrent(c).fix()
+    IO.concurrent().fx.concurrent(c).fix()
 
   init {
 
     fun allStrategyTests(
       label: String,
-      ctx: CoroutineContext = IO.dispatchers<Nothing>().default(),
+      ctx: CoroutineContext = IO.dispatchers().default(),
       queue: (Int) -> IO<Nothing, Queue<IOPartialOf<Nothing>, Int>>
     ) {
 
@@ -336,7 +335,7 @@ class QueueTest : UnitSpec() {
 
     fun strategyAtCapacityTests(
       label: String,
-      ctx: CoroutineContext = IO.dispatchers<Nothing>().default(),
+      ctx: CoroutineContext = IO.dispatchers().default(),
       queue: (Int) -> IO<Nothing, Queue<IOPartialOf<Nothing>, Int>>
     ) {
       "$label - tryOffer returns false over capacity" {
@@ -376,7 +375,7 @@ class QueueTest : UnitSpec() {
     }
 
     fun boundedStrategyTests(
-      ctx: CoroutineContext = IO.dispatchers<Nothing>().default(),
+      ctx: CoroutineContext = IO.dispatchers().default(),
       queue: (Int) -> IO<Nothing, Queue<IOPartialOf<Nothing>, Int>>
     ) {
       val label = "BoundedQueue"
@@ -602,7 +601,7 @@ class QueueTest : UnitSpec() {
     }
 
     fun slidingStrategyTests(
-      ctx: CoroutineContext = IO.dispatchers<Nothing>().default(),
+      ctx: CoroutineContext = IO.dispatchers().default(),
       queue: (Int) -> IO<Nothing, Queue<IOPartialOf<Nothing>, Int>>
     ) {
       val label = "SlidingQueue"
@@ -634,7 +633,7 @@ class QueueTest : UnitSpec() {
     }
 
     fun droppingStrategyTests(
-      ctx: CoroutineContext = IO.dispatchers<Nothing>().default(),
+      ctx: CoroutineContext = IO.dispatchers().default(),
       queue: (Int) -> IO<Nothing, Queue<IOPartialOf<Nothing>, Int>>
     ) {
       val label = "DroppingQueue"
@@ -680,7 +679,7 @@ class QueueTest : UnitSpec() {
     }
 
     fun unboundedStrategyTests(
-      ctx: CoroutineContext = IO.dispatchers<Nothing>().default(),
+      ctx: CoroutineContext = IO.dispatchers().default(),
       queue: (Int) -> IO<Nothing, Queue<IOPartialOf<Nothing>, Int>>
     ) {
       allStrategyTests("UnboundedQueue", ctx, queue)

--- a/arrow-fx/src/test/kotlin/arrow/fx/RefTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/RefTest.kt
@@ -157,7 +157,7 @@ class RefTest : UnitSpec() {
       }
     }
 
-    IO.concurrent<Nothing>().tests(IO.eqK<Nothing>(), Ref.factory(IO.monadDefer()))
-    IO.concurrent<Nothing>().concurrentTests(IO.eqK<Nothing>(), Ref.factory(IO.monadDefer()))
+    IO.concurrent().tests(IO.eqK<Nothing>(), Ref.factory(IO.monadDefer()))
+    IO.concurrent().concurrentTests(IO.eqK<Nothing>(), Ref.factory(IO.monadDefer()))
   }
 }

--- a/arrow-fx/src/test/kotlin/arrow/fx/ResourceTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/ResourceTest.kt
@@ -30,21 +30,21 @@ class ResourceTest : UnitSpec() {
 
     testLaws(
       MonadLaws.laws(
-        Resource.monad(IO.bracket<Nothing>()),
-        Resource.functor(IO.bracket<Nothing>()),
-        Resource.applicative(IO.bracket<Nothing>()),
-        Resource.selective(IO.bracket<Nothing>()),
-        Resource.genK(IO.bracket<Nothing>()),
+        Resource.monad(IO.bracket()),
+        Resource.functor(IO.bracket()),
+        Resource.applicative(IO.bracket()),
+        Resource.selective(IO.bracket()),
+        Resource.genK(IO.bracket()),
         Resource.eqK()
       ),
-      MonoidLaws.laws(Resource.monoid(Int.monoid(), IO.bracket<Nothing>()), Gen.int().map { Resource.just(it, IO.bracket<Nothing>()) }, EQ)
+      MonoidLaws.laws(Resource.monoid(Int.monoid(), IO.bracket()), Gen.int().map { Resource.just(it, IO.bracket()) }, EQ)
     )
 
     "Resource releases resources in reverse order of acquisition" {
       forFew(5, Gen.list(Gen.string())) { l ->
         val released = mutableListOf<String>()
-        l.traverse(Resource.applicative(IO.bracket<Nothing>())) {
-          Resource({ IO { it } }, { r -> IO { released.add(r); Unit } }, IO.bracket<Nothing>())
+        l.traverse(Resource.applicative(IO.bracket())) {
+          Resource({ IO { it } }, { r -> IO { released.add(r); Unit } }, IO.bracket())
         }.fix().use { IO.unit }.fix().unsafeRunSync()
 
         l == released.reversed()

--- a/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
@@ -229,7 +229,7 @@ class ScheduleTest : UnitSpec() {
         val schedule = Schedule(IO.monad(), IO.just(0 as Any?)) { _: Unit, _ -> IO.just(dec.fix()) }
 
         val eff = SideEffect()
-        val ref = Ref(IO.monadDefer<Nothing>(), 0.seconds).fix().unsafeRunSync()
+        val ref = Ref(IO.monadDefer(), 0.seconds).fix().unsafeRunSync()
 
         val res = IO { if (eff.counter >= n) throw RuntimeException("WOOO") else eff.increment() }
           .repeat(IO.monadThrow(), refTimer(ref), schedule)
@@ -250,7 +250,7 @@ class ScheduleTest : UnitSpec() {
         val schedule = Schedule(IO.monad(), IO.just(0 as Any?)) { _: Throwable, _ -> IO.just(dec.fix()) }
 
         val eff = SideEffect()
-        val ref = Ref(IO.monadDefer<Nothing>(), 0.seconds).fix().unsafeRunSync()
+        val ref = Ref(IO.monadDefer(), 0.seconds).fix().unsafeRunSync()
 
         val res = IO {
           if (eff.counter <= n) {


### PR DESCRIPTION
This removes `E` from all cancel tokens. This was left over from an attempt to write partially applied `Bracket` up to `Concurrent` for `IO<E, A>` but it only supports `IO<Nothing, A>`.

This also fixes #149.