### PR TITLE
Solve #76. Add benchmark comparison

### DIFF
--- a/.github/workflows/build_arrow-fx.yml
+++ b/.github/workflows/build_arrow-fx.yml
@@ -31,13 +31,14 @@ jobs:
     - name: Run benchmark for master branch
       run: |
         git checkout master
+        # TODO: When this file is located on master branch
+        # ./gradlew :arrow-benchmarks-fx:jmhForMasterBranch
         ./gradlew :arrow-benchmarks-fx:jmh
         cp arrow-benchmarks-fx/build/reports/benchmarks.json master-branch.json
     - name: Run benchmark for pull request
       run: |
         git checkout $GITHUB_SHA
-        ./gradlew :arrow-benchmarks-fx:jmh
-        cp arrow-benchmarks-fx/build/reports/benchmarks.json pull-request.json
+        ./gradlew :arrow-benchmarks-fx:jmhForPullRequest
     - name: Run benchmark comparison
       env:
         CI_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_arrow-fx.yml
+++ b/.github/workflows/build_arrow-fx.yml
@@ -28,4 +28,19 @@ jobs:
     - name: Build with Gradle
       run: |
         $BASEDIR/arrow/scripts/project-build.sh $ARROW_LIB
-        ./gradlew :arrow-benchmarks-fx:jmhClasses
+    - name: Run benchmark for master branch
+      run: |
+        git checkout master
+        ./gradlew :arrow-benchmarks-fx:jmh
+        cp arrow-benchmarks-fx/build/reports/benchmarks.json master-branch.json
+    - name: Run benchmark for pull request
+      run: |
+        git checkout $GITHUB_SHA
+        ./gradlew :arrow-benchmarks-fx:jmh
+        cp arrow-benchmarks-fx/build/reports/benchmarks.json pull-request.json
+    - name: Run benchmark comparison
+      env:
+        CI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        export PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d/ -f3)
+        ./gradlew :arrow-benchmarks-fx:compareBenchmarksCI

--- a/.github/workflows/publish_arrow-fx.yml
+++ b/.github/workflows/publish_arrow-fx.yml
@@ -31,7 +31,6 @@ jobs:
     - name: Build with Gradle
       run: |
         $BASEDIR/arrow/scripts/project-build.sh $ARROW_LIB
-        ./gradlew :arrow-benchmarks-fx:jmhClasses
     - name: Publish artifacts
       env:
         BINTRAY_USER: ${{ secrets.BINTRAY_USER }}

--- a/arrow-benchmarks-fx/build.gradle
+++ b/arrow-benchmarks-fx/build.gradle
@@ -1,11 +1,15 @@
 buildscript {
-  repositories {
-    maven { url "https://dl.bintray.com/47deg/hood" }
-  }
-
-  dependencies {
-    classpath "com.47deg:hood:0.8.0"
-  }
+    repositories {
+        maven { url "https://dl.bintray.com/47deg/hood" }
+    }
+    
+    dependencies {
+        classpath "com.47deg:hood:0.8.0"
+    }
+    ext {
+        JMH_RESULT_FOR_MASTER_BRANCH = "$rootDir/master-branch.json"
+        JMH_RESULT_FOR_PULL_REQUEST = "$rootDir/pull-request.json"
+    }
 }
 
 plugins {
@@ -77,9 +81,23 @@ jmhReport {
 
 tasks.jmh.finalizedBy tasks.jmhReport
 
+task jmhForMasterBranch {
+    doLast {
+        jmh.resultsFile = file(JMH_RESULT_FOR_MASTER_BRANCH)
+    }
+    finalizedBy "jmh"
+}
+
+task jmhForPullRequest {
+    doLast {
+        jmh.resultsFile = file(JMH_RESULT_FOR_PULL_REQUEST)
+    }
+    finalizedBy "jmh"
+}
+
 compareBenchmarksCI {
-    previousBenchmarkPath = file("$rootDir/master-branch.json")
-    currentBenchmarkPath = [file("$rootDir/pull-request.json")]
+    previousBenchmarkPath = file(JMH_RESULT_FOR_MASTER_BRANCH)
+    currentBenchmarkPath = [file(JMH_RESULT_FOR_PULL_REQUEST)]
     outputToFile = true
     outputFormat = "json"
     token = System.getenv("CI_TOKEN")

--- a/arrow-benchmarks-fx/build.gradle
+++ b/arrow-benchmarks-fx/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+  repositories {
+    maven { url "https://dl.bintray.com/47deg/hood" }
+  }
+
+  dependencies {
+    classpath "com.47deg:hood:0.8.0"
+  }
+}
+
 plugins {
     id "maven-publish"
     id "base"
@@ -14,6 +24,7 @@ plugins {
 
 apply from: "$SUBPROJECT_CONF"
 apply from: "$DOC_CONF"
+apply plugin: "com.47deg.hood"
 
 dependencies {
     compile project(":arrow-fx")
@@ -65,6 +76,18 @@ jmhReport {
 }
 
 tasks.jmh.finalizedBy tasks.jmhReport
+
+compareBenchmarksCI {
+    previousBenchmarkPath = file("$rootDir/master-branch.json")
+    currentBenchmarkPath = [file("$rootDir/pull-request.json")]
+    outputToFile = true
+    outputFormat = "json"
+    token = System.getenv("CI_TOKEN")
+    repositoryOwner = "arrow-kt"
+    repositoryName = "arrow-fx"
+    pullRequestSha = System.getenv("GITHUB_SHA")
+    pullRequestNumber = System.getenv("PULL_REQUEST_NUMBER")?.toInteger()
+}
 
 repositories {
     maven { url "https://jitpack.io" }


### PR DESCRIPTION
This PR adds benchmark comparison via [Hood](https://47degrees.github.io/hood/) so a comment with the result will be added in every pull request on this repository. 

**See the comment below** as an example. 

That comment will be **updated** with new commits:

![Screenshot from 2020-05-08 19-27-56](https://user-images.githubusercontent.com/22792183/81431817-18602c80-9162-11ea-95c7-f905331407eb.png)

In this case there isn't difference between values because this pull request is just adding the configuration and it's not changing Arrow Fx library.

It only shows `Concurrentqueue` because it's the only benchmark included:

```
jmh {
    include = [
            'arrow.benchmarks.Queue'
    ]
    ...
}
```

For instance, for this configuration:

```
jmh {
    include = [
            'arrow.benchmarks.Async',
            'arrow.benchmarks.Queue'
    ]
    ...
}
```

it would appear data for:

* Async.catsIO
* Async.io
* Async.scalazZIO
* Queue.concurrentQueue

**Default threshold** is being used. However, it can be changed in `compareBenchmarksCI` task configuration: https://47degrees.github.io/hood/gradle/ci/

For the rest of open pull requests, the comment with the results will appear when merging this pull request and then updating those pull requests with master branch.

Thanks to @AdrianRaFo for providing me the guide about it :raised_hands: 