### PR TITLE
arrow-fx-android: move Gradle configuration to the module

### DIFF
--- a/arrow-fx-android/build.gradle
+++ b/arrow-fx-android/build.gradle
@@ -1,8 +1,15 @@
+buildscript {
+    repositories {
+        google()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:3.6.0")
+    }
+}
+
 plugins {
     id "maven-publish"
     id "base"
-    id "com.android.library"
-    id "org.jetbrains.kotlin.android"
     id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
@@ -17,6 +24,8 @@ repositories {
 //apply from: "$SUBPROJECT_CONF"
 apply from: "$DOC_CONF"
 //apply from: "$PUBLISH_CONF"
+
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,9 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
-        google()
     }
     dependencies {
         classpath "org.jetbrains.kotlinx:atomicfu-gradle-plugin:$ATOMICFU_VERSION"
-        classpath("com.android.tools.build:gradle:3.6.0")
     }
 }
 


### PR DESCRIPTION
PR on `ab/lifecycle-integration` branch-

Fix one of the TODO items from #158:
* Figure out if it's possible to move the root build.gradle's added config for android to the specific module

I followed this guide: https://developer.android.com/studio/build#build-files