### PR TITLE
Arrow Fx Coroutines

### DIFF
--- a/arrow-fx-coroutines/README.MD
+++ b/arrow-fx-coroutines/README.MD
@@ -1,0 +1,480 @@
+# Arrow Fx Coroutines
+
+Arrow Fx Coroutines offers a suspend DSL with the same semantics and API you find in Arrow Fx's IO, this allows for writing programs using suspend fun directly instead of wrapping in IO.
+It's a functional implementation of Kotlin's coroutine system while providing support for cancellation, error handling, resource handling and all goodies you might be familiar with from other functional effect systems.
+
+Arrow Fx aims to be a battery included functional effects framework, below you can find a small overview of the library.
+A full coverage of all data types and functions can be found [here](LINK DOCS).
+
+### IO<A> vs suspend () -> A
+
+Let's look at two simple concurrent examples that switch context and print the `Thread.currentThread().name`.
+
+```kotlin:ank
+suspend fun getThreadName(): String =
+  Thread.currentThread().name
+
+suspend fun main(): Unit = IO.fx {
+  val t1 = !effect { getThreadName() }.evalOn(Computation) 
+  val t2 = !effect { getThreadName() }.evalOn(BlockingIO)
+  val t3 = !effect { getThreadName() }.evalOn(UI)
+  !effect { println("$t1 ~> $t2 ~> $t3") }
+}.suspended()
+```
+
+becomes
+
+```kotlin:ank
+suspend fun getThreadName(): String =
+  Thread.currentThread().name
+
+suspend fun main(): Unit {
+  val t1 = evalOn(Computation) { getThreadName() }
+  val t2 = evalOn(BlockingIO) { getThreadName() }
+  val t3 = evalOn(UI) { getThreadName() }
+  println("$t1 ~> $t2 ~> $t3")
+}
+```
+
+As you can see we can directly apply `evalOn` to our `suspend fun`, this eliminates the need to wrap explicitly in `IO`.
+Both programs are equivalent in semantics and guarantees, the later will however perform better since it eliminates the wrapping `IO` requires.
+This is possible without losing cancellation support, as explained in the detail here [anchor cancellation].
+
+### IO<Either<E, A>> vs suspend () -> Either<E, A>
+
+When writing functional code style we often want to express our domain errors as clearly as possible, a popular pattern is to return `Either<DomainError, SuccessValue>`.
+Let's assume following domain, and compare two snippets one using `IO<Either<E, A>>` and another `suspend () -> Either<E, A>`.
+
+```kotlin:ank
+inline class Id(val id: Long)
+object PersistenceError
+
+data class User(val email: String, val name: String)
+data class ProcessedUser(val id: Id, val email: String, val name: String)
+
+suspend fun fetchUser(): Either<PersistenceError, User> =
+    Right(User("simon@arrow-kt.io", "Simon"))
+
+suspend fun User.process(): Either<PersistenceError, ProcessedUser> =
+    if (email.contains(Regex("^(.+)@(.+)$"))) Right(ProcessedUser(UUID.V4.squuid(), email, name))
+    else Left(PersistenceError)
+```
+
+#### IO<Either<E, A>>
+
+ ```kotlin:ank
+fun ioProgram(): IO<Either<PersistenceError, ProcessedUser>> =
+  IO.fx {
+    val res = !IO.effect { fetchUser() }
+
+    !res.fold({ error ->
+      IO.just(Either.Left(error))
+    }, { user ->
+      IO.effect { user.process() }
+    })
+  }
+
+// Or unwrapped in `suspend`
+suspend suspendedIOProgram(): Either<PersistenceError, ProcessedUser> =
+  ioProgram().suspended()
+ ```
+
+#### suspend () -> Either<E, A>
+
+```kotlin:ank
+suspend fun either(): Either<PersistenceError, ProcessedUser> =
+  Either.fx {
+    val user = !fetchUser()
+    val processed = !user.process()
+    processed
+  }
+```
+
+#### suspend R.() -> A
+
+We can use extension functions to do functional dependency injection with similar semantics as `Reader` or `Kleisli`.
+They allow us to elegantly define `syntax` for a certain type. Let's see a simple example.
+
+Let's reuse our previous domain of`User`, `ProcessedUser`, but let's introduce `Repo` and `Persistence` layers to mimick what could be a small app with a couple layers.
+
+```kotlin:ank:playground
+interface Repo {
+    suspend fun fetchUsers(): List<User>
+}
+
+interface Persistence {
+    suspend fun User.process(): Either<ProcessingError, ProcessedUser>
+
+    suspend fun List<User>.process(): Either<ProcessingError, List<ProcessedUser>> =
+        Either.fx { map { !it.process() } }
+}
+```
+
+Given the above defined layers we can easily compose them by creating a product which implements the dependencies by delegation.
+This can easily be done manually or with the help of a framework like Dagger to do this wiring automatically.
+
+```kotlin:ank
+class DataModule(
+    persistence: Persistence,
+    repo: Repo
+) : Persistence by persistence, Repo by repo
+```
+
+We can also define top-level functions based on constraints on the receiver.
+Here we define `getProcessUsers` which can only be called where `R` is both `Repo` and `Persistence`.
+
+```kotlin:ank
+/**
+ * Generic top-level function based on syntax enabled by [Persistence] & [Repo] constraint
+ */
+suspend fun <R> R.getProcessUsers(): Either<ProcessingError, List<ProcessedUser>>
+        where R : Repo,
+              R : Persistence = fetchUsers().process()
+```
+
+## Cancellation
+
+The cancellation system exists out of a few simple building blocks.
+
+All operators found in Arrow Fx check for cancellation. In the small example of an infinite sleeping loop below `sleep` checks for cancellation and thus this function also check for cancellation before/and while sleeping.
+
+```kotlin:ank
+tailrec suspend fun sleeper(): Unit {
+  println("I am sleepy. I'm going to nap")
+  sleep(1.seconds)                                     // <-- cancellation check-point
+  println("1 second nap.. Going to sleep some more")
+  sleeper()
+}
+```
+
+#### cancelBoundary()
+
+Calling `suspend fun cancelBoundary()` will check for cancellation, and will gracefully exit in case the effect was cancelled. An example.
+
+```
+suspend fun loop(): Unit {
+  while(true) { 
+	 cancelBoundary() // cancellable computation loop
+    println("I am getting dizzy...")
+  }
+}
+```
+
+This `while` will `loop` until the cancel signal is triggered. Once the cancellation is trigger, this task will gracefully exit through `cancelBoundary()`.
+
+In case you don't want to check for cancellation so often, you can also only install a `cancelBoundary` every n batches.
+The example below defines `repeat` which checks cancellation every `10` repetition.
+
+```kotlin:ank
+tailrec suspend fun repeat(n: Int): Unit {
+  if (n % 10 == 0) cancelBoundary()
+  if (n == 0) Unit
+  else repeat(n - 1)
+}
+```
+
+#### Parallel operations cancellation
+
+All parallel `suspend` operators in Arrow Fx behave in the following way.
+
+1. When one of the parallel task fails, the others are also cancelled since a result cannot be determined. This will allow the other parallel operations to gracefully exit and close their resources before returning.
+
+2. When the resulting `suspend` operation is cancelled than all running fibers inside will also be cancelled so that all paralell running task can gracefully exit and close their resources before returning.
+
+For more documentation on parallel operations see below.
+
+#### Uncancellable
+
+So how can you execute of `suspend fun` with guarantee that it cannot be cancelled. You simply `wrap` it in the `uncancelable` builder and the function will guarantee not to be cancelled. If the progam is already cancelled before, this block will not run and if it gets cancelled during the execution of this block it will exit immediately after.
+
+```kotlin:ank
+suspend fun uncancellableSleep(duration: Duration): Unit =
+  uncancellable { sleep(duration) }
+```
+
+If we now re-implement our previous `sleeper`, than it will behave a little different from before. The cancellation check before and after `uncancellableSleep` but note that the `sleep` istelf will not be cancelled.
+
+```kotlin:ank
+tailrec suspend fun sleeper(): Unit {
+  println("I am sleepy. I'm going to nap")
+   // <-- cancellation check-point
+  uncancellableSleep(1.seconds)
+   // <-- cancellation check-point
+  println("1 second nap.. Going to sleep some more")
+  sleeper()
+}
+```
+
+This also means that our new sleep can back-pressure `timeOutOrNull`.
+
+```kotlin:ank
+suspend main(): Unit {
+  val r = timeOutOrNull(1.seconds) {
+    uncancelable { sleep(2.seconds) }
+  } // r is null, but took 2 seconds.
+}
+```
+
+## Resource Safety
+
+To ensure resource safety we need to take care with cancellation since we don't wont our process to be cancelled but our resources to remain open.
+
+There Arrow Fx offers 2 tools `Resource` and `suspend fun bracketCase`. Any `resource` operations exists out of 3 steps.
+
+1. Acquiring the resource
+2. Using the resource
+3. Releasing the resource with either a result, a `Throwable` or `Cancellation`.
+
+To ensure the resource can be correctly acquired we make the `acquire` & `release` step `uncancelable`.
+If the `bracketCase` was cancelled during `acquire` it'll immediately go to `release`, skipping the `use` step.
+
+`bracketCase` is defined below, in the `release` step you can inspect the `ExitCase` of the `acquire`/`use`.
+
+```
+sealed ExitCase {
+  object Completed: ExitCase()
+  object Cancelled: ExitCase()
+  data class Error(val error: Throwable): ExitCase()
+}
+
+suspend fun <A, B> bracketCase(acquire: suspend () -> A, use: suspend (A) -> B, release: (a, ExitCase) -> B): B
+```
+
+`bracket` is an overload of `bracketCase` that ignores the `ExitCase` value, a simple example.
+We want to create a function to safely create and consume a `DatabaseConnection` that always needs to be closed no matter what the _ExitCase_.
+
+```kotlin:ank
+class DatabaseConnection {
+  suspend fun open(): String = println("Database connection opened")
+  suspend fun close(): String = println("Database connection closed")
+}
+
+suspend fun <A> DatabaseConnection.use(f: suspend (DatabaseConnection) -> A): A =
+  bracket(
+    acquire = { DatabaseConnection().apply { open() } },
+    use = f,
+    release = DatabaseConnection::close
+  )
+```
+
+The difference between `Resource` is that `bracketCase` is simple function, while `Resource` is a data type, both ensure that resources are `acquire`d and `release`d correctly.
+It also forms a `Monad` so you can use it to safely compose `Resource`s, map them or safely traverse `Resource`s.
+
+```kotlin:ank
+suspend fun service(nThreads: Int, name: String): ExecutorService {
+  val threadN = AtomicReference(1)
+  return Executors.newScheduledThreadPool(nThreads) { r ->
+    Thread(r, if (nThreads == 1) name else "$name-${threadNo.incrementAndGet()}")
+    .apply { isDaemon = true}
+  }
+}
+
+suspend fun shutdown(service: ExecutorService): Unit =
+  service.shutdown()
+
+suspend fun singleThreadContext(name: String): Resource<CoroutineContext> =
+  Resource({ service(1, name) }, ::shutdown)
+    .map(ScheduledExecutorService::asCoroutineContext)
+
+suspend fun main(): Unit {
+  singleThreadContext("example-pool").use { ctx ->
+     evalOn(ctx) {
+        println("Running on example-pool: $Thread.currenThread().name")
+     }
+  }
+}
+```
+
+A more advanced `Resource` example that reads 3 `DatabaseConnection`s in parallel
+
+```kotlin:ank
+class File(url: String) {
+  fun open(): File = this
+  suspend fun close(): Unit {}
+  override fun toString(): String = "This file contains some interesting content!"
+}
+
+suspend fun openFile(uri: String): File = File(uri).open()
+
+val resources: List<Resource<File>> =
+ listOf(
+   Resource({ openFile("path1") }, File::close),
+   Resource({ openFile("path2") }, File::close),
+   Resource({ openFile("path3") }, File::close)
+ )
+
+val resource: Resource<List<File>> =
+  resources.sequence(Resource.applicative())
+
+suspend main(): Unit {
+  resource.use { files ->
+    files.parTraverse(IODispatchers.IOPool) { file ->
+       file.toString()
+    }
+  }
+}
+```
+
+### Error Handling
+
+In Kotlin with suspend `try/catch` can safely be used to recover from exceptions.
+
+Simple constructs like `suspend fun Either.catch(f: () -> A): Either<Throwable, A>` are available for nicer syntax when and lifting errors in your domain.
+
+### Retrying and repeating effects
+
+`Schedule` allows you to define and compose powerful yet simple policies, which can be used to either repeat or retry computation. 
+
+A simple example might be to repeat an action `n` times, similar to the `repeat` function in the standard library.
+
+```kotlin:ank
+suspend main(): Unit {
+  repeat(Schedule.recurs<A>(n)) {
+    println("Hello")
+  }
+}
+```
+
+Alternatively we can re-use this `Schedule` to `retry` a `suspend fun` `n` times when it fails.
+
+```kotlin:ank
+suspend main(): Unit {
+  retry(Schedule.recurs<A>(n)) {
+    println("I am going to do nothing but throw a tantrum!")
+    throw RuntimeException("Boom!")
+  }
+}
+```
+
+Additionally a `Schedule` can also produce an output, let's compose our simple `recurs` Schedule to `recur` every `10.seconds` in a `spaced` fashion and collect all outputs along the way.
+
+```kotlin:ank
+fun <A> schedule(): Schedule<A, List<A>> = Schedule {
+  (recurs<A>(10) and spaced(10.seconds)) zipRight collect()
+}
+
+suspend main(): Unit {
+  var count = Atomic(0)
+
+  val history: List<Int> = repeat(schedule<Int>()) {
+    println("Incrementing the ref")
+    count.update(Int::inc)
+  }
+}
+```
+
+## Parallel Ops
+
+
+### ForkConnected
+
+`forkConnected` launches a `suspend () -> A` function in a seperate processes called a `Fiber`, the lifecycle of this process is connected to its parent.
+If the parent cancels that this operation will also be cancelled.
+
+A `Fiber` is a data type that represents a `suspend fun join(): A` and `suspend fun cancel(): Unit` handle.
+
+### ForkScoped
+
+`forkScoped` is a similar construct as `ForkConnected` but instead of automatically connecting to its parent it takes a `suspend () -> Unit` op which triggers the cancellation.
+This can be used as a lower level construct to signal cancellation on a trigger, and wire cancellation with 3rd party frameworks.
+
+```kotlin:ank
+tailrec fun fun sleeper(): Unit {
+  sleep(1.seconds)
+  return sleeper()
+}
+
+
+class AndroidFragnent {
+
+  val cancelPromise = Promise.unsafe<Unit>()
+  
+  override fun onCreateView(bundle: SavedBundleInstance): Unit {
+     suspend {
+       ::sleeper.forkScoped(cancelPromise::get)
+     }.startCoroutine(Continuation(EmptyCoroutineContext) { })
+  }
+  
+  override fun onDestroyView(): Unit {
+    suspend { cancelPromise.complete(Unit) }
+      .startCoroutine(Continuation(EmptyCoroutineContext) { })
+  }
+}
+```
+
+### ParMapN/parTupldN
+
+`parMapN` combines two `suspend` functions given a pure function `(A, B) -> C` in parallel on a given `CoroutineContext`. Both `suspend fun` will guarantee to dispatch on the given `CoroutineContext` before they start running.
+
+It also wires their respective cancellation. That means that cancelling the resulting `suspend fun` will cancel both functions running in parallel inside.
+Additionally, the function does not return until both tasks are finished and their results combined by `f: (A, B) -> C`.
+
+
+### ParTraverse/parSequence
+
+`parTraverse` can be used to traverse any data type that supports `Traverse` such as `List`, `Validated`, `Either`, `Option`, etc.
+It is used to map elements of the same type `A` in parallel. Cancelling the caller `suspend fun` will cancel all running `Fiber`s inside `parTraverse` gracefully. 
+
+### RaceN
+
+`raceN` is similar to `parMapN` except for it only returns the winner of the race, and cancels the loser as soon as the first fiber finishes the race.
+
+#### RacePair/RaceTriple/ForkAndForget
+
+There are a couple of low level constructs available, and they should be used with care!
+
+- racePair/raceTriple like `raceN` races 2 operations, but instead of cancelling the loser it returns the `Fiber` of the loser task
+
+- ForkAndForget launches a task `fa` as a `Fiber` but doesn't connect it's cancellation system
+
+Both operators can safely capture the running `Fiber` and _guarantee_ not leaking using `bracketCase`.
+An example, writing `raceN` in terms of `racePair`.
+
+```kotlin:ank
+suspend fun <A, B> raceN(ctx: CoroutineContext, fa: suspend () -> A, fb: suspend () -> B): Either<A, B> =
+  bracket(
+    acquire = { racePair(ctx, fa, fb) },
+    use = { it.bimap({ (a, _) -> a }, { (_, b) -> b }) },
+    release = {
+      it.bimap(
+        { (_, fiber) -> fiber.cancel() },
+        { (fiber, _) -> fiber.cancel() }
+      )
+    }
+  )
+```
+
+## Arrow Fx Coroutines, KotlinX Coroutines & Kotlin Standard Library
+ 
+### Demystify Coroutine 
+
+Kotlin's standard library defines a `Coroutine` as an instance of a suspendable computation.
+
+In other words, a `Coroutine` is a compiled `suspend () -> A` program wired to a `Continuation`.
+
+Which can be created by using [`kotlin.coroutines.intrinsics.createCoroutineUnintercepted`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines.intrinsics/create-coroutine-unintercepted.html).
+
+So let's take a quick look at an example.
+
+```kotlin:ank
+import kotlin.coroutines.intrinsics.createCoroutineUnintercepted
+
+suspend fun one(): Int = 1
+
+val cont: Continuation<Unit> = ::one
+  .createCoroutineUnintercepted(Continuation(EmptyCoroutineContext, ::println))
+
+cont.resume(Unit)
+```
+
+As you can see here above we create a `Coroutine` using `createCoroutineUnintercepted` which returns us `Continuation<Unit>`.
+Strange, you might've expected a `Coroutine` type but a `Coroutine` is represented by `Continuation<Unit>`.
+
+This `typealias Coroutine = Contination<Unit>` will start running every time you call `resume(Unit)`, which allows you to run the suspend program N times.
+
+### Arrow Fx Coroutines & KotlinX Coroutines
+
+Both Arrow Fx Coroutines & KotlinX Coroutines independently offer an implementation for Kotlin's coroutine system.
+
+As explained in the document above, Arrow Fx Coroutines offers a battery-included functional IO with cancellation support.
+Where KotlinX Coroutines offers an implementation that offers light-weight futures with cancellation support.

--- a/arrow-fx-coroutines/build.gradle
+++ b/arrow-fx-coroutines/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id "maven-publish"
+    id "base"
+    id "org.jetbrains.kotlin.jvm"
+    id "org.jetbrains.kotlin.kapt"
+    id "net.rdrei.android.buildtimetracker"
+    id "org.jetbrains.dokka"
+    id "org.jlleitschuh.gradle.ktlint"
+    id "ru.vyarus.animalsniffer"
+}
+
+apply from: "$SUBPROJECT_CONF"
+apply from: "$DOC_CONF"
+apply from: "$PUBLISH_CONF"
+
+test {
+    useJUnitPlatform()
+}
+
+dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
+    compile "io.arrow-kt:arrow-core:$VERSION_NAME"
+
+    testImplementation "io.kotest:kotest-runner-junit5-jvm:4.0.5" // for kotest framework
+    testImplementation "io.kotest:kotest-assertions-core-jvm:4.0.5" // for kotest core jvm assertions
+    testImplementation "io.kotest:kotest-property-jvm:4.0.5" // for kotest property test
+    testImplementation("io.kotest:kotest-runner-console-jvm:4.0.5")
+}
+
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}

--- a/arrow-fx-coroutines/gradle.properties
+++ b/arrow-fx-coroutines/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Arrow-Fx-Coroutines
+POM_ARTIFACT_ID=arrow-fx-coroutines
+POM_PACKAGING=jar

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Atomic.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Atomic.kt
@@ -1,0 +1,352 @@
+package arrow.fx.coroutines
+
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.getAndUpdate
+import kotlinx.atomicfu.updateAndGet
+
+/**
+ * Creates a [AtomicRef] with a initial value of [A].
+ *
+ * Data type on top of [atomic] to use in parallel functions.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main() {
+ *   val count = Atomic(0)
+ *
+ *   (0 until 20_000).parTraverse {
+ *     count.update(Int::inc)
+ *   }
+ *   println(count.get())
+ * }
+ * ```
+ *
+ * [AtomicRef] also offers some other interesting operators such as [modify], [tryUpdate], [access] & [lens].
+ */
+interface Atomic<A> {
+
+  /**
+   * Obtains the current value.
+   * Since [AtomicRef] is always guaranteed to have a value, the returned action completes immediately after being bound.
+   */
+  suspend fun get(): A
+
+  /**
+   * Sets the current value to [a].
+   * The returned action completes after the reference has been successfully set.
+   */
+  suspend fun set(a: A): Unit
+
+  /**
+   * Replaces the current value with [a], returning the *old* value.
+   */
+  suspend fun getAndSet(a: A): A
+
+  /**
+   * Replaces the current value with [a], returning the *new* value.
+   */
+  suspend fun setAndGet(a: A): A
+
+  /**
+   * Updates the current value using the supplied function [f].
+   *
+   * If another modification occurs between the time the current value is read and subsequently updated,
+   * the modification is retried using the new value. Hence, [f] may be invoked multiple times.
+   */
+  suspend fun update(f: (A) -> A): Unit
+
+  /**
+   * Modifies the current value using the supplied update function and returns the *old* value.
+   *
+   * @see [update], [f] may be invoked multiple times.
+   */
+  suspend fun getAndUpdate(f: (A) -> A): A
+
+  /**
+   * Modifies the current value using the supplied update function and returns the *new* value.
+   *
+   * @see [update], [f] may be invoked multiple times.
+   */
+  suspend fun updateAndGet(f: (A) -> A): A
+
+  /**
+   * Modify allows to inspect the state [A] of the [AtomicRef], update it and extract a different state [B].
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * typealias Id = Int
+   * data class Job(val description: String)
+   *
+   * val initialState = (0 until 10).map { i -> Pair(i, Job("Task #$i")) }
+   *
+   * suspend fun main(): Unit {
+   *   val jobs = Atomic(initialState)
+   *
+   *   val batch = jobs.modify { j ->
+   *     val batch = j.take(5)
+   *     Pair(j.drop(5), batch)
+   *   }
+   *
+   *   batch.forEach { (id, job) ->
+   *     println("Going to work on $job with id $id\n")
+   *   }
+   *
+   *   println("Remaining: ${jobs.get()}")
+   * }
+   * ```
+   */
+  suspend fun <B> modify(f: (A) -> Pair<A, B>): B
+
+  /**
+   * ModifyGet allows to inspect state [A], update it and extract a different state [B].
+   * In contrast to [modify] it a [Pair] of the updated state [A] and the extracted state [B].
+   *
+   * @see [modify] for an example
+   */
+  suspend fun <B> modifyGet(f: (A) -> Pair<A, B>): Pair<A, B>
+
+  /**
+   * Attempts to modify the current value once,
+   *   in contrast to [update] which calls [f] until it succeeds.
+   *
+   * @returns `false` if concurrent modification completes between the time the variable is read and the time it is set.
+   */
+  suspend fun tryUpdate(f: (A) -> A): Boolean
+
+  /**
+   * Like [tryUpdate] but allows the update function to return an output value of type [B].
+   *
+   * @returns `null` if the update fails and [B] otherwise.
+   */
+  suspend fun <B> tryModify(f: (A) -> Pair<A, B>): B?
+
+  /**
+   * Obtain a snapshot of the current value, and a setter for updating it.
+   *
+   * This is useful when you need to execute effects with the original result while still ensuring an atomic update.
+   *
+   * The setter will return `false` if another concurrent call invalidated the snapshot (modified the value).
+   * It will return `true` if setting the value was successful.
+   *
+   * Once it has returned `false` or been used once, a setter never succeeds again.
+   */
+  suspend fun access(): Pair<A, suspend (A) -> Boolean>
+
+  /**
+   * Creates a [AtomicRef] for [B] based on provided a [get] and [set] operation.
+   *
+   * This is useful when you have a [AtomicRef] of a `data class`
+   * and need to work with with certain properties individually.
+   * Or want to hide parts of your domain from a dependency
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * data class Preference(val isEnabled: Boolean)
+   * data class User(val name: String, val age: Int, val preference: Preference)
+   * data class ViewState(val user: User)
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val state: Atomic<ViewState> = Atomic(ViewState(User("Simon", 27, Preference(false))))
+   *   val isEnabled: Atomic<Boolean> =
+   *     state.lens(
+   *       { it.user.preference.isEnabled },
+   *       { state, isEnabled ->
+   *         state.copy(
+   *           user =
+   *           state.user.copy(
+   *             preference =
+   *             state.user.preference.copy(isEnabled = isEnabled)
+   *           )
+   *         )
+   *       }
+   *     )
+   *   isEnabled.set(true)
+   *   println(state.get())
+   * }
+   * ```
+   */
+  fun <B> lens(get: (A) -> B, set: (A, B) -> A): arrow.fx.coroutines.Atomic<B> =
+    LensAtomic(this, get, set)
+
+  companion object {
+
+    /**
+     * Creates a [AtomicRef] with a initial value of [A].
+     *
+     * Data type on top of [atomic] to use in parallel functions.
+     *
+     * ```kotlin:ank:playground
+     * import arrow.fx.coroutines.*
+     *
+     * suspend fun main() {
+     *   val count = Atomic(0)
+     *   (0 until 20_000).parTraverse {
+     *     count.update(Int::inc)
+     *   }
+     *   println(count.get())
+     * }
+     * ```
+     */
+    suspend operator fun <A> invoke(a: A): arrow.fx.coroutines.Atomic<A> = unsafe(a)
+    fun <A> unsafe(a: A): arrow.fx.coroutines.Atomic<A> = DefaultAtomic(a)
+  }
+}
+
+private class DefaultAtomic<A>(a: A) : arrow.fx.coroutines.Atomic<A> {
+
+  private val ar: AtomicRef<A> = atomic(a)
+
+  override suspend fun get(): A =
+    ar.value
+
+  override suspend fun set(a: A): Unit {
+    ar.value = a
+  }
+
+  override suspend fun getAndSet(a: A): A =
+    ar.getAndSet(a)
+
+  override suspend fun setAndGet(a: A): A {
+    ar.value = a
+    return a
+  }
+
+  override suspend fun getAndUpdate(f: (A) -> A): A =
+    ar.getAndUpdate(f)
+
+  override suspend fun updateAndGet(f: (A) -> A): A =
+    ar.updateAndGet(f)
+
+  override suspend fun access(): Pair<A, suspend (A) -> Boolean> {
+    val snapshot = ar.value
+    val hasBeenCalled = AtomicBooleanW(false)
+    val setter: suspend (A) -> Boolean = { a: A ->
+      hasBeenCalled.compareAndSet(false, true) && ar.compareAndSet(snapshot, a)
+    }
+
+    return Pair(snapshot, setter)
+  }
+
+  override suspend fun tryUpdate(f: (A) -> A): Boolean =
+    tryModify { a -> Pair(f(a), Unit) } != null
+
+  override suspend fun <B> tryModify(f: (A) -> Pair<A, B>): B? {
+    val a = ar.value
+    val (u, b) = f(a)
+    return if (ar.compareAndSet(a, u)) b
+    else null
+  }
+
+  override suspend fun update(f: (A) -> A): Unit =
+    modify { a -> Pair(f(a), Unit) }
+
+  override suspend fun <B> modify(f: (A) -> Pair<A, B>): B {
+    tailrec fun go(): B {
+      val a = ar.value
+      val (u, b) = f(a)
+      return if (!ar.compareAndSet(a, u)) go() else b
+    }
+
+    return go()
+  }
+
+  override suspend fun <B> modifyGet(f: (A) -> Pair<A, B>): Pair<A, B> {
+    tailrec fun go(): Pair<A, B> {
+      val a = ar.value
+      val res = f(a)
+      return if (!ar.compareAndSet(a, res.first)) go() else res
+    }
+
+    return go()
+  }
+}
+
+private class LensAtomic<A, B>(
+  private val underlying: arrow.fx.coroutines.Atomic<A>,
+  private val lensGet: (A) -> B,
+  private val lensSet: (A, B) -> A
+) : arrow.fx.coroutines.Atomic<B> {
+
+  override suspend fun setAndGet(a: B): B =
+    underlying.modify { old ->
+      Pair(lensModify(old) { a }, a)
+    }
+
+  override suspend fun getAndUpdate(f: (B) -> B): B =
+    underlying.modify { old ->
+      Pair(lensModify(old, f), lensGet(old))
+    }
+
+  override suspend fun updateAndGet(f: (B) -> B): B =
+    underlying.modify { old ->
+      val new = lensModify(old, f)
+      Pair(new, lensGet(new))
+    }
+
+  override suspend fun get(): B =
+    lensGet(underlying.get())
+
+  override suspend fun set(a: B) {
+    underlying.update { old -> lensModify(old) { a } }
+  }
+
+  override suspend fun getAndSet(a: B): B =
+    underlying.modify { old ->
+      Pair(lensModify(old) { a }, lensGet(old))
+    }
+
+  override suspend fun update(f: (B) -> B) =
+    underlying.update { old -> lensModify(old, f) }
+
+  override suspend fun <C> modify(f: (B) -> Pair<B, C>): C =
+    underlying.modify { old ->
+      val oldB = lensGet(old)
+      val (b, c) = f(oldB)
+      Pair(lensSet(old, b), c)
+    }
+
+  override suspend fun <C> modifyGet(f: (B) -> Pair<B, C>): Pair<B, C> =
+    underlying.modifyGet { old ->
+      val oldB = lensGet(old)
+      val (b, c) = f(oldB)
+      Pair(lensSet(old, b), c)
+    }.let { (a, c) -> Pair(lensGet(a), c) }
+
+  override suspend fun tryUpdate(f: (B) -> B): Boolean =
+    tryModify { b -> Pair(f(b), Unit) } != null
+
+  override suspend fun <C> tryModify(f: (B) -> Pair<B, C>): C? =
+    underlying.tryModify { a ->
+      val oldB = lensGet(a)
+      val (b, result) = f(oldB)
+      Pair(lensSet(a, b), result)
+    }
+
+  override suspend fun access(): Pair<B, suspend (B) -> Boolean> {
+    val snapshotA = underlying.get()
+    val snapshotB = lensGet(snapshotA)
+
+    val setter: suspend (B) -> Boolean = { b: B ->
+      val hasBeenCalled = AtomicBooleanW(false)
+
+      suspend {
+        val called = hasBeenCalled.compareAndSet(false, true)
+
+        underlying.tryModify { a ->
+          if (called && lensGet(a) == snapshotA) Pair(lensSet(a, b), true)
+          else Pair(a, false)
+        } ?: false
+      }.invoke()
+    }
+
+    return Pair(snapshotB, setter)
+  }
+
+  private fun lensModify(s: A, f: (B) -> B): A =
+    lensSet(s, f(lensGet(s)))
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Bracket.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Bracket.kt
@@ -1,0 +1,263 @@
+package arrow.fx.coroutines
+
+import kotlinx.atomicfu.atomic
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+
+sealed class ExitCase {
+  object Completed : ExitCase()
+  object Cancelled : ExitCase()
+  data class Failure(val failure: Throwable) : ExitCase()
+}
+
+/**
+ * Runs [f] in an uncancellable manner.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   //sampleStart
+ *   val n = timeOutOrNull(10.milliseconds) {
+ *     uncancellable { sleep(100.milliseconds) }
+ *   } // takes 100.milliseconds, and returns null
+ *
+ *   //sampleEnd
+ *   println("n: $n")
+ * }
+ * ```
+ */
+suspend fun <A> uncancellable(f: suspend () -> A): A =
+  suspendCoroutineUninterceptedOrReturn sc@{ cont ->
+    val conn = cont.context.connection()
+
+    val deferredRelease = ForwardCancellable()
+    conn.push(deferredRelease.cancel())
+
+    if (conn.isNotCancelled()) {
+      val uncancellable = cont.context + SuspendConnection.uncancellable
+
+      return@sc f.startCoroutineUninterceptedOrReturn(Continuation(uncancellable) {
+        deferredRelease.complete(CancelToken.unit)
+        cont.resumeWith(it)
+      })
+    } else {
+      deferredRelease.complete(CancelToken.unit)
+      COROUTINE_SUSPENDED
+    }
+  }
+
+suspend fun <A> onCancel(
+  fa: suspend () -> A,
+  onCancel: suspend () -> Unit
+): A = guaranteeCase(fa) { case ->
+  when (case) {
+    ExitCase.Cancelled -> onCancel.invoke()
+    else -> Unit
+  }
+}
+
+suspend fun <A> guarantee(
+  fa: suspend () -> A,
+  release: suspend () -> Unit
+): A = guaranteeCase(fa) { release.invoke() }
+
+suspend fun <A> guaranteeCase(
+  fa: suspend () -> A,
+  release: suspend (ExitCase) -> Unit
+): A = bracketCase({ Unit }, { fa.invoke() }, { _, ex -> release(ex) })
+
+suspend fun <A, B> bracket(
+  acquire: suspend () -> A,
+  use: suspend (A) -> B,
+  release: suspend (A) -> Unit
+): B = bracketCase(acquire, use, { a, _ -> release(a) })
+
+suspend fun <A, B> bracketCase(
+  acquire: suspend () -> A,
+  use: suspend (A) -> B,
+  release: suspend (A, ExitCase) -> Unit
+): B = suspendCoroutineUninterceptedOrReturn { cont ->
+  val conn = cont.context.connection()
+
+  val deferredRelease = ForwardCancellable()
+  conn.push(deferredRelease.cancel())
+
+  // Race-condition check, avoiding starting the bracket if the connection
+  // was cancelled already, to ensure that `cancel` really blocks if we
+  // start `acquire` — n.b. `isCancelled` is visible here due to `push`
+
+  if (!conn.isCancelled()) {
+    // Note `acquire` is uncancellable (in other words it is disconnected from our SuspendConnection)
+    val uncancellable = cont.context + SuspendConnection.uncancellable
+
+    val acquiredOrSuspended = acquire.startCoroutineUninterceptedOrReturn(
+      BracketAcquireContinuation(
+        uncancellable,
+        cont,
+        use,
+        release,
+        deferredRelease
+      )
+    )
+
+    if (acquiredOrSuspended != COROUTINE_SUSPENDED) {
+      val usedAndReleasedOrSuspended =
+        launchUseAndRelease(acquiredOrSuspended as A, uncancellable, cont, use, release, deferredRelease)
+
+      if (usedAndReleasedOrSuspended != COROUTINE_SUSPENDED) (usedAndReleasedOrSuspended as Result<B>).fold(
+        { it },
+        { throw it })
+      else COROUTINE_SUSPENDED
+    } else COROUTINE_SUSPENDED
+  } else {
+    deferredRelease.complete(CancelToken.unit)
+    COROUTINE_SUSPENDED
+  }
+}
+
+private class BracketAcquireContinuation<A, B>(
+  val uncancellableContext: CoroutineContext,
+  val uCont: Continuation<B>,
+  val use: suspend (A) -> B,
+  val release: suspend (A, ExitCase) -> Unit,
+  val deferredRelease: ForwardCancellable
+) : Continuation<A> {
+  override val context: CoroutineContext = uncancellableContext
+
+  override fun resumeWith(result: Result<A>) {
+    result.fold({ a ->
+      val usedAndReleasedOrSuspended =
+        launchUseAndRelease(a, uncancellableContext, uCont, use, release, deferredRelease)
+
+      // Use & Release immediately returned
+      if (usedAndReleasedOrSuspended != COROUTINE_SUSPENDED) {
+        uCont.resumeWith(usedAndReleasedOrSuspended as Result<B>)
+      }
+    }, { e -> uCont.resumeWith(Result.failure(e)) })
+  }
+}
+
+/**
+ * Launches `use`, and register `release` to run afterwards.
+ *
+ * Returns either immediately [Result] after `release` ran,
+ * or [COROUTINE_SUSPENDED] in the case the `Coroutine` suspended.
+ */
+private fun <A, B> launchUseAndRelease(
+  a: A,
+  uncancellableContext: CoroutineContext,
+  uCont: Continuation<B>,
+  use: suspend (A) -> B,
+  release: suspend (A, ExitCase) -> Unit,
+  deferredRelease: ForwardCancellable
+): Any? {
+  val fb = suspend { use(a) }
+  val frame = BracketUseContinuation(a, uCont, release, uncancellableContext)
+  deferredRelease.complete(frame.cancel)
+
+  val x = try {
+    val res = fb.startCoroutineUninterceptedOrReturn(frame)
+    if (res == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
+    else Result.success(res as B)
+  } catch (e: Throwable) {
+    Result.failure<B>(e.nonFatalOrThrow())
+  }
+
+  return launchRelease(a, x, uCont, release, uncancellableContext)
+}
+
+/**
+ * `Continuation` that registers a `release` function to be executed after its `resumeWith` is called.
+ * It's cancel signal needs to be registered to it's `uCont.context.connection()` using [ForwardCancellable].
+ */
+private class BracketUseContinuation<A, B>(
+  val a: A,
+  val uCont: Continuation<B>,
+  val release: suspend (A, ExitCase) -> Unit,
+  val uncancellableContext: CoroutineContext
+) : Continuation<B> {
+
+  override val context: CoroutineContext = uCont.context
+
+  // Guard used for thread-safety, to ensure the idempotency
+  // of the release; otherwise `release` can be called twice
+  private val waitsForResult = atomic(true)
+
+  suspend fun release(c: ExitCase): Unit = release(a, c)
+
+  private suspend fun applyRelease(e: ExitCase): Unit {
+    if (waitsForResult.compareAndSet(true, false)) release(e)
+    else Unit
+  }
+
+  val cancel: CancelToken = CancelToken { applyRelease(ExitCase.Cancelled) }
+
+  override fun resumeWith(result: Result<B>) {
+    val releasedOrSuspended = try {
+      launchRelease(a, result, uCont, release, uncancellableContext)
+    } catch (e: Throwable) {
+      Result.failure<B>(e.nonFatalOrThrow())
+    }
+
+    if (releasedOrSuspended != COROUTINE_SUSPENDED) uCont.resumeWith(releasedOrSuspended as Result<B>)
+  }
+}
+
+/**
+ * Returns either a [Result] of [B] or [COROUTINE_SUSPENDED].
+ *
+ * Result of B can be:
+ *  - Result [B] of `use` or [Throwable] of `release`
+ *  - Result [Throwable] of `use`, optionally composed with the [Throwable] of `release`
+ *  => `Unit` result of `release` is **always** ignored.
+ */
+private fun <A, B> launchRelease(
+  a: A,
+  result: Result<B>,
+  uCont: Continuation<B>,
+  release: suspend (A, ExitCase) -> Unit,
+  uncancellableContext: CoroutineContext
+): Any? {
+  val active = AtomicBooleanW(true)
+
+  val frame = BracketReleaseContinuation(result, uCont, uncancellableContext)
+  val released = suspend {
+    result.fold(
+      { if (active.compareAndSet(true, false)) release(a, ExitCase.Completed) },
+      { e -> if (active.compareAndSet(true, false)) release(a, ExitCase.Failure(e)) }
+    )
+  }
+
+  return try {
+    val res = released.startCoroutineUninterceptedOrReturn(frame)
+    if (res == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
+    else result
+  } catch (e2: Throwable) { // Should compose this error with `Result<B>`
+    Result.failure<B>(result.fold({ e2 }, { e -> Platform.composeErrors(e, e2) }))
+  }
+}
+
+@Suppress("RESULT_CLASS_IN_RETURN_TYPE")
+private class BracketReleaseContinuation<B>(
+  val b: Result<B>,
+  val uCont: Continuation<B>,
+  uncancellableContext: CoroutineContext
+) : Continuation<Unit> {
+
+  override val context: CoroutineContext = uncancellableContext
+
+  override fun resumeWith(result: Result<Unit>) {
+    // Release returned `Unit` or `Throwable`
+    val res = b.fold({
+      result.fold({ b }, { e -> Result.failure(e) })
+    }, { e ->
+      result.fold({ b }, { e2 -> Result.failure(Platform.composeErrors(e, e2)) })
+    })
+
+    uCont.resumeWith(res)
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
@@ -1,0 +1,456 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import arrow.fx.coroutines.CircuitBreaker.State.Closed
+import arrow.fx.coroutines.CircuitBreaker.State.Open
+
+class CircuitBreaker constructor(
+  private val state: AtomicRefW<State>,
+  private val maxFailures: Int,
+  private val resetTimeout: Duration,
+  private val exponentialBackoffFactor: Double,
+  private val maxResetTimeout: Duration,
+  private val onRejected: suspend () -> Unit,
+  private val onClosed: suspend () -> Unit,
+  private val onHalfOpen: suspend () -> Unit,
+  private val onOpen: suspend () -> Unit
+) {
+
+  /** Returns the current [CircuitBreaker.State], meant for debugging purposes.
+   */
+  suspend fun state(): State = state.value
+
+  /**
+   * Awaits for this `CircuitBreaker` to be [CircuitBreaker.State.Closed].
+   *
+   * If this `CircuitBreaker` is already in a closed state, then
+   * it returns immediately, otherwise it will wait (asynchronously) until
+   * the `CircuitBreaker` switches to the [CircuitBreaker.Closed]
+   * state again.
+   */
+  suspend fun awaitClose(): Unit =
+    when (val curr = state.value) {
+      is Closed -> Unit
+      is Open -> curr.awaitClose.get()
+      is State.HalfOpen -> curr.awaitClose.get()
+    }
+
+  /** Returns a new task that upon execution will execute the given
+   * task, but with the protection of this circuit breaker.
+   */
+  tailrec suspend fun <A> protect(fa: suspend () -> A): A =
+    when (val curr = state.value) {
+      is Closed -> {
+        val attempt = try {
+          Either.Right(fa.invoke())
+        } catch (e: Throwable) {
+          Either.Left(e)
+        }
+        markOrResetFailures(attempt)
+      }
+      is Open -> {
+        val now = System.currentTimeMillis()
+        if (now >= curr.expiresAt) {
+          // The Open state has expired, so we are letting just one
+          // task to execute, while transitioning into HalfOpen
+          if (!state.compareAndSet(
+              curr,
+              State.HalfOpen(curr.resetTimeout, curr.awaitClose)
+            )
+          ) protect(fa) // retry!
+          else attemptReset(fa, curr.resetTimeout, curr.awaitClose, curr.startedAt)
+        } else {
+          // Open isn't expired, so we need to fail
+          val expiresInMillis = curr.expiresAt - now
+          onRejected.invoke()
+          throw ExecutionRejected(
+            "Rejected because the CircuitBreaker is in the Open state, attempting to close in $expiresInMillis millis",
+            curr
+          )
+        }
+      }
+      is State.HalfOpen -> {
+        // CircuitBreaker is in HalfOpen state, which means we still reject all
+        // tasks, while waiting to see if our reset attempt succeeds or fails
+        onRejected.invoke()
+        throw ExecutionRejected("Rejected because the CircuitBreaker is in the HalfOpen state", curr)
+      }
+    }
+
+  /** Function for counting failures in the `Closed` state,
+   * triggering the `Open` state if necessary.
+   */
+  private tailrec suspend fun <A> markOrResetFailures(result: Either<Throwable, A>): A =
+    when (val curr = state.value) {
+      is Closed -> {
+        when (result) {
+          is Either.Right -> {
+            if (curr.failures == 0) result.b
+            else { // In case of success, must reset the failures counter!
+              val update = Closed(0)
+              if (!state.compareAndSet(curr, update)) markOrResetFailures(result) // retry?
+              else result.b
+            }
+          }
+          is Either.Left -> {
+            // In case of failure, we either increment the failures counter,
+            // or we transition in the `Open` state.
+            if (curr.failures + 1 < maxFailures) {
+              // It's fine, just increment the failures count
+              val update = Closed(curr.failures + 1)
+              if (!state.compareAndSet(curr, update)) markOrResetFailures(result) // retry?
+              else throw result.a
+            } else {
+              // N.B. this could be canceled, however we don't care
+              val now = System.currentTimeMillis()
+              // We've gone over the permitted failures threshold,
+              // so we need to open the circuit breaker
+              val update = Open(now, resetTimeout, Promise())
+              if (!state.compareAndSet(curr, update)) markOrResetFailures(result) // retry
+              else {
+                onOpen.invoke()
+                throw result.a
+              }
+            }
+          }
+        }
+      }
+      else -> result.fold({ throw it }, ::identity)
+    }
+
+  /** Internal function that is the handler for the reset attempt when
+   * the circuit breaker is in `HalfOpen`. In this state we can
+   * either transition to `Closed` in case the attempt was
+   * successful, or to `Open` again, in case the attempt failed.
+   *
+   * @param task is the task to execute, along with the attempt
+   *        handler attached
+   * @param resetTimeout is the last timeout applied to the previous
+   *        `Open` state, to be multiplied by the backoff factor in
+   *        case the attempt fails and it needs to transition to
+   *        `Open` again
+   */
+  private suspend fun <A> attemptReset(
+    task: suspend () -> A,
+    resetTimeout: Duration,
+    awaitClose: Promise<Unit>,
+    lastStartedAt: Long
+  ): A =
+    bracketCase(
+      acquire = onHalfOpen,
+      use = { task.invoke() },
+      release = { _, exit ->
+        when (exit) {
+          is ExitCase.Cancelled -> {
+            // We need to return to Open state
+            // otherwise we get stuck in Half-Open (see https://github.com/monix/monix/issues/1080 )
+            state.value = Open(lastStartedAt, resetTimeout, awaitClose)
+            onOpen.invoke()
+          }
+          ExitCase.Completed -> {
+            // While in HalfOpen only a reset attempt is allowed to update
+            // the state, so setting this directly is safe
+            state.value = Closed(0)
+            awaitClose.complete(Unit)
+            onClosed.invoke()
+          }
+          is ExitCase.Failure -> {
+            // Failed reset, which means we go back in the Open state with new expiry val nextTimeout
+            val value = (resetTimeout.millis * exponentialBackoffFactor).toLong().milliseconds
+            val nextTimeout =
+              if (/*maxResetTimeout.isFinite &&*/ value.nanoseconds > maxResetTimeout.nanoseconds) maxResetTimeout
+              else value
+            val ts = System.currentTimeMillis()
+            state.value = Open(ts, nextTimeout, awaitClose)
+            onOpen.invoke()
+          }
+        }
+      }
+    )
+
+  /** Returns a new circuit breaker that wraps the state of the source
+   * and that upon a task being rejected will execute the given
+   * `callback`.
+   *
+   * Useful for gathering stats.
+   *
+   * NOTE: calling this method multiple times will create a circuit
+   * breaker that will call multiple callbacks, thus the callback
+   * given is cumulative with other specified callbacks.
+   *
+   * @param callback is to be executed when tasks get rejected
+   * @return a new circuit breaker wrapping the state of the source
+   */
+  fun doOnRejectedTask(callback: suspend () -> Unit): CircuitBreaker =
+    CircuitBreaker(
+      state = state,
+      maxFailures = maxFailures,
+      resetTimeout = resetTimeout,
+      exponentialBackoffFactor = exponentialBackoffFactor,
+      maxResetTimeout = maxResetTimeout,
+      onRejected = suspend { onRejected.invoke(); callback.invoke() },
+      onClosed = onClosed,
+      onHalfOpen = onHalfOpen,
+      onOpen = onOpen
+    )
+
+  /** Returns a new circuit breaker that wraps the state of the source
+   * and that will fire the given callback upon the circuit breaker
+   * transitioning to the [CircuitBreaker.Closed Closed] state.
+   *
+   * Useful for gathering stats.
+   *
+   * NOTE: calling this method multiple times will create a circuit
+   * breaker that will call multiple callbacks, thus the callback
+   * given is cumulative with other specified callbacks.
+   *
+   * @param callback is to be executed when the state evolves into `Closed`
+   * @return a new circuit breaker wrapping the state of the source
+   */
+  fun doOnClosed(callback: suspend () -> Unit): CircuitBreaker =
+    CircuitBreaker(
+      state = state,
+      maxFailures = maxFailures,
+      resetTimeout = resetTimeout,
+      exponentialBackoffFactor = exponentialBackoffFactor,
+      maxResetTimeout = maxResetTimeout,
+      onRejected = onRejected,
+      onClosed = suspend { onClosed.invoke(); callback.invoke(); },
+      onHalfOpen = onHalfOpen,
+      onOpen = onOpen
+    )
+
+  /** Returns a new circuit breaker that wraps the state of the source
+   * and that will fire the given callback upon the circuit breaker
+   * transitioning to the [CircuitBreaker.HalfOpen HalfOpen]
+   * state.
+   *
+   * Useful for gathering stats.
+   *
+   * NOTE: calling this method multiple times will create a circuit
+   * breaker that will call multiple callbacks, thus the callback
+   * given is cumulative with other specified callbacks.
+   *
+   * @param callback is to be executed when the state evolves into `HalfOpen`
+   * @return a new circuit breaker wrapping the state of the source
+   */
+  fun doOnHalfOpen(callback: suspend () -> Unit): CircuitBreaker =
+    CircuitBreaker(
+      state = state,
+      maxFailures = maxFailures,
+      resetTimeout = resetTimeout,
+      exponentialBackoffFactor = exponentialBackoffFactor,
+      maxResetTimeout = maxResetTimeout,
+      onRejected = onRejected,
+      onClosed = onClosed,
+      onHalfOpen = suspend { onHalfOpen.invoke(); callback.invoke() },
+      onOpen = onOpen
+    )
+
+  /** Returns a new circuit breaker that wraps the state of the source
+   * and that will fire the given callback upon the circuit breaker
+   * transitioning to the [CircuitBreaker.Open Open] state.
+   *
+   * Useful for gathering stats.
+   *
+   * NOTE: calling this method multiple times will create a circuit
+   * breaker that will call multiple callbacks, thus the callback
+   * given is cumulative with other specified callbacks.
+   *
+   * @param callback is to be executed when the state evolves into `Open`
+   * @return a new circuit breaker wrapping the state of the source
+   */
+  fun doOnOpen(callback: suspend () -> Unit): CircuitBreaker =
+    CircuitBreaker(
+      state = state,
+      maxFailures = maxFailures,
+      resetTimeout = resetTimeout,
+      exponentialBackoffFactor = exponentialBackoffFactor,
+      maxResetTimeout = maxResetTimeout,
+      onRejected = onRejected,
+      onClosed = onClosed,
+      onHalfOpen = onHalfOpen,
+      onOpen = suspend { onOpen.invoke(); callback.invoke() }
+    )
+
+  /**
+   *
+   * The initial state when initializing a [CircuitBreaker] is [Closed].
+   *
+   * The available states:
+   *
+   *  - [Closed] in case tasks are allowed to go through
+   *  - [Open] in case the circuit breaker is active and rejects incoming tasks
+   *  - [HalfOpen] in case a reset attempt was triggered and it is waiting for
+   *    the result in order to evolve in [Closed], or back to [Open]
+   */
+  sealed class State {
+
+    /** The initial [State] of the [CircuitBreaker]. While in this
+     * state the circuit breaker allows tasks to be executed.
+     *
+     * Contract:
+     *
+     *  - Exceptions increment the `failures` counter
+     *  - Successes reset the failure count to zero
+     *  - When the `failures` counter reaches the `maxFailures` count,
+     *    the breaker is tripped into the `Open` state
+     *
+     * @param failures is the current failures count
+     */
+    class Closed(val failures: Int) : State() {
+      override fun hashCode(): Int =
+        failures.hashCode()
+
+      override fun equals(other: Any?): Boolean =
+        if (other is Closed) failures == other.failures
+        else false
+
+      override fun toString(): String =
+        "Closed(failures=$failures)"
+    }
+
+    /** [State] of the [CircuitBreaker] in which the circuit
+     * breaker rejects all tasks with an [ExecutionRejected].
+     *
+     * Contract:
+     *
+     *  - all tasks fail fast with [ExecutionRejected]
+     *  - after the configured `resetTimeout`, the circuit breaker
+     *    enters a [HalfOpen] state, allowing one task to go through
+     *    for testing the connection
+     *
+     * @param startedAt is the timestamp in milliseconds since the
+     *        epoch when the transition to `Open` happened
+     *
+     * @param resetTimeout is the current `resetTimeout` that is
+     *        applied to this `Open` state, to be multiplied by the
+     *        exponential backoff factor for the next transition from
+     *        `HalfOpen` to `Open`, in case the reset attempt fails
+     *
+     * @param awaitClose is a [Promise] that will get completed
+     *        when the `CircuitBreaker` switches to the `Closed` state again
+     */
+    class Open(val startedAt: Long, val resetTimeout: Duration, internal val awaitClose: Promise<Unit>) : State() {
+
+      /** The timestamp in milliseconds since the epoch, specifying
+       * when the `Open` state is to transition to [HalfOpen].
+       *
+       * It is calculated as:
+       * `startedAt + resetTimeout.millis`
+       */
+      val expiresAt: Long = startedAt + resetTimeout.millis
+
+      override fun equals(other: Any?): Boolean =
+        if (other is Open) this.startedAt == startedAt &&
+          this.resetTimeout == resetTimeout &&
+          this.expiresAt == expiresAt
+        else false
+
+      override fun toString(): String =
+        "CircuitBreaker.State.Open(startedAt=$startedAt, resetTimeout=$resetTimeout, expiresAt=$expiresAt)"
+
+      override fun hashCode(): Int {
+        var result = startedAt.hashCode()
+        result = 31 * result + resetTimeout.hashCode()
+        result = 31 * result + expiresAt.hashCode()
+        return result
+      }
+    }
+
+    /** [State] of the [CircuitBreaker] in which the circuit
+     * breaker has already allowed a task to go through, as a reset
+     * attempt, in order to test the connection.
+     *
+     * Contract:
+     *
+     *  - The first task when `Open` has expired is allowed through
+     *    without failing fast, just before the circuit breaker is
+     *    evolved into the `HalfOpen` state
+     *  - All tasks attempted in `HalfOpen` fail-fast with an exception
+     *    just as in [Open] state
+     *  - If that task attempt succeeds, the breaker is reset back to
+     *    the `Closed` state, with the `resetTimeout` and the
+     *    `failures` count also reset to initial values
+     *  - If the first call fails, the breaker is tripped again into
+     *    the `Open` state (the `resetTimeout` is multiplied by the
+     *    exponential backoff factor)
+     *
+     * @param resetTimeout is the current `resetTimeout` that was
+     *        applied to the previous `Open` state, to be multiplied by
+     *        the exponential backoff factor for the next transition to
+     *        `Open`, in case the reset attempt fails
+     *
+     * @param awaitClose is a [Promise] that will get completed
+     *        when the `CircuitBreaker` switches to the `Closed` state again
+     */
+    class HalfOpen(val resetTimeout: Duration, internal val awaitClose: Promise<Unit>) : State() {
+      override fun hashCode(): Int =
+        resetTimeout.hashCode()
+
+      override fun equals(other: Any?): Boolean =
+        if (other is HalfOpen) resetTimeout == other.resetTimeout
+        else false
+
+      override fun toString(): String =
+        "Closed(failures=$resetTimeout)"
+    }
+  }
+
+  class ExecutionRejected(val reason: String, val state: State) : Throwable()
+
+  companion object {
+    /**
+     * @param maxFailures is the maximum count for failures before
+     *        opening the circuit breaker
+     *
+     * @param resetTimeout is the timeout to wait in the `Open` state
+     *        before attempting a close of the circuit breaker (but without
+     *        the backoff factor applied)
+     *
+     * @param exponentialBackoffFactor is a factor to use for resetting
+     *        the `resetTimeout` when in the `HalfOpen` state, in case
+     *        the attempt to `Close` fails
+     *
+     * @param maxResetTimeout is the maximum timeout the circuit breaker
+     *        is allowed to use when applying the `exponentialBackoffFactor`
+     *
+     * @param onRejected is a callback for signaling rejected tasks, so
+     *         every time a task execution is attempted and rejected in
+     *         [CircuitBreaker.Open] or [CircuitBreaker.HalfOpen]
+     *         states
+     *
+     * @param onClosed is a callback for signaling transitions to the [CircuitBreaker.State.Closed] state
+     *
+     * @param onHalfOpen is a callback for signaling transitions to [CircuitBreaker.State.HalfOpen]
+     *
+     * @param onOpen is a callback for signaling transitions to [CircuitBreaker.State.Open]
+     *
+     */
+    suspend fun of(
+      maxFailures: Int,
+      resetTimeout: Duration,
+      exponentialBackoffFactor: Double = 1.0,
+      maxResetTimeout: Duration = Duration.INFINITE,
+      onRejected: suspend () -> Unit = suspend { Unit },
+      onClosed: suspend () -> Unit = suspend { Unit },
+      onHalfOpen: suspend () -> Unit = suspend { Unit },
+      onOpen: suspend () -> Unit = suspend { Unit }
+    ): CircuitBreaker? =
+      if (maxFailures >= 0 && resetTimeout.amount > 0 &&
+        exponentialBackoffFactor > 0 && maxResetTimeout.amount > 0
+      ) {
+        CircuitBreaker(
+          state = AtomicRefW(Closed(0)),
+          maxFailures = maxFailures,
+          resetTimeout = resetTimeout,
+          exponentialBackoffFactor = exponentialBackoffFactor,
+          maxResetTimeout = maxResetTimeout,
+          onRejected = onRejected,
+          onClosed = onClosed,
+          onHalfOpen = onHalfOpen,
+          onOpen = onOpen
+        )
+      } else null
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ConcurrentVar.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ConcurrentVar.kt
@@ -1,0 +1,463 @@
+package arrow.fx.coroutines
+
+import arrow.fx.coroutines.DefaultConcurrentVar.Companion.State.WaitForPut
+import arrow.fx.coroutines.DefaultConcurrentVar.Companion.State.WaitForTake
+import kotlinx.atomicfu.atomic
+
+/**
+ * [ConcurrentVar] is a mutable concurrent safe variable which is either `empty` or contains a `single value` of type [A].
+ *
+ * When trying to [put] or [take], it'll suspend when it's respectively [isEmpty] or [isNotEmpty].
+ *
+ * There are also operators that return immediately, [tryTake] & [tryPut],
+ * since checking [isEmpty] could be outdated immediately.
+ *
+ * [ConcurrentVar] is appropriate for building synchronization primitives and performing simple inter-thread communications.
+ * i.e. in situations where you want to `suspend` until the [ConcurrentVar] is initialised with a value [A].
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun fibonacci(n: Int, prev: Int = 0, next: Int = 1): Int =
+ *     when (n) {
+ *       0 -> prev
+ *       1 -> next
+ *       else -> fibonacci(n - 1, next, prev + next)
+ *     }
+ *
+ * suspend fun main(): Unit {
+ *   val mvar = ConcurrentVar.empty<Int>()
+ *
+ *   ForkConnected {
+ *     val asyncFib = fibonacci(50)
+ *     mvar.put(asyncFib)
+ *   }
+ *
+ *  val r = mvar.take() // suspend until Fork puts result in MVar
+ *  println(r)
+ * }
+ * ```
+ */
+interface ConcurrentVar<A> {
+
+  /**
+   * Returns true if there are no elements. Otherwise false.
+   * This may be outdated immediately,
+   *   use [tryPut] or [tryTake] to [put] & [take] without suspending.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val empty = ConcurrentVar.empty<Int>().isEmpty()
+   *   val full = ConcurrentVar(10).isEmpty()
+   *   //sampleEnd
+   *   println("empty: $empty, full: $full")
+   * }
+   *```
+   *
+   */
+  suspend fun isEmpty(): Boolean
+
+  /**
+   * Returns true if there no elements. Otherwise false.
+   * This may be outdated immediately,
+   *   use [tryPut] or [tryTake] to [put] & [take] without suspending.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val empty = ConcurrentVar.empty<Int>().isNotEmpty()
+   *   val full = ConcurrentVar(10).isNotEmpty()
+   *   //sampleEnd
+   *   println("empty: $empty, full: $full")
+   * }
+   *```
+   */
+  suspend fun isNotEmpty(): Boolean
+
+  /**
+   * Puts [A] in the [ConcurrentVar] if it is empty,
+   * or suspends if full until the given value is next in line to be consumed by [take].
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val mvar = ConcurrentVar.empty<Int>()
+   *   mvar.put(5)
+   *   val none = timeOutOrNull(1.seconds) {
+   *     mvar.put(10)
+   *   }
+   *   val res = mvar.take()
+   *   //sampleEnd
+   *   println("none: $none, res: $res")
+   * }
+   *```
+   *
+   * @see [tryPut] for an operator that doesn't suspend if the [ConcurrentVar] is filled.
+   */
+  suspend fun put(a: A): Unit
+
+  /**
+   * Tries to put [A] in the [ConcurrentVar] if it is empty,
+   * returns immediately with true if successfully put the value in the [ConcurrentVar] or false otherwise.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val mvar = ConcurrentVar.empty<Int>()
+   *   val succeed = mvar.tryPut(5)
+   *   val failed = mvar.tryPut(10)
+   *   val res = mvar.take()
+   *   //sampleEnd
+   *   println("succeed: $succeed, failed: $failed, res: $res")
+   * }
+   *```
+   *
+   * @see [tryPut] for an operator that doesn't suspend if the [ConcurrentVar] is filled.
+   */
+  suspend fun tryPut(a: A): Boolean
+
+  /**
+   * Empties the [ConcurrentVar] if full, returning the value,
+   * or suspend until a value is available.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   * //sampleStart
+   * val mvar = ConcurrentVar(5)
+   * val five = mvar.take()
+   * val none = timeOutOrNull(1.seconds) {
+   *   mvar.take()
+   * }
+   * //sampleEnd
+   * println("five: $five, none: $none")
+   * }
+   *```
+   */
+  suspend fun take(): A
+
+  /**
+   * Try to take the value of [ConcurrentVar],
+   * returns a value immediately if the [ConcurrentVar] is not empty or null otherwise.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val mvar = ConcurrentVar(5)
+   *   val value = mvar.tryTake()
+   *   val empty = mvar.tryTake()
+   *   //sampleEnd
+   *   println("value: $value, empty: $empty")
+   * }
+   *```
+   */
+  suspend fun tryTake(): A?
+
+  /**
+   * Read the current value without emptying the MVar,
+   * assuming there is one, or otherwise it suspends until there is a value available.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val mvar = ConcurrentVar.empty<Int>()
+   *
+   *   val none = timeOutOrNull(1.seconds) {
+   *     mvar.read()
+   *   }
+   *   mvar.put(10)
+   *   val read1 = mvar.read()
+   *   val read2 =mvar.read()
+   *   //sampleEnd
+   *   println("none: $none, read1: $read1, read2: $read2")
+   * }
+   *```
+   */
+  suspend fun read(): A
+
+  companion object {
+    /** Builds an [ConcurrentVar] instance with an [initial] value. */
+    suspend operator fun <A> invoke(initial: A): ConcurrentVar<A> =
+      DefaultConcurrentVar(DefaultConcurrentVar.Companion.State(initial))
+
+    /** Returns an empty [ConcurrentVar] instance. */
+    suspend fun <A> empty(): ConcurrentVar<A> =
+      DefaultConcurrentVar(DefaultConcurrentVar.Companion.State.empty())
+
+    fun <A> unsafe(initial: A): ConcurrentVar<A> =
+      DefaultConcurrentVar(DefaultConcurrentVar.Companion.State(initial))
+
+    fun <A> unsafeEmpty(): ConcurrentVar<A> =
+      DefaultConcurrentVar(DefaultConcurrentVar.Companion.State.empty())
+  }
+}
+
+internal sealed class Maybe<out A> {
+  object None : Maybe<Nothing>()
+  data class Just<A>(val value: A) : Maybe<A>()
+}
+
+internal fun <A> Maybe<A>.orElse(f: () -> Maybe<A>): Maybe<A> =
+  when (this) {
+    Maybe.None -> f()
+    is Maybe.Just -> this
+  }
+
+internal fun <A> Maybe<A>.getOrElse(f: () -> A): A =
+  when (this) {
+    Maybe.None -> f()
+    is Maybe.Just -> this.value
+  }
+
+internal fun <A> A?.toMaybe(): Maybe<A> =
+  if (this == null) Maybe.None else Maybe.Just(this) as Maybe<A>
+
+private class DefaultConcurrentVar<A> constructor(initial: State<A>) : ConcurrentVar<A> {
+
+  private val state = atomic(initial)
+
+  override suspend fun isEmpty(): Boolean =
+    when (state.value) {
+      is WaitForPut -> true
+      is WaitForTake -> false
+    }
+
+  override suspend fun isNotEmpty(): Boolean =
+    when (state.value) {
+      is WaitForPut -> false
+      is WaitForTake -> true
+    }
+
+  override suspend fun put(a: A): Unit =
+    if (tryPut(a)) Unit
+    else {
+      cancelBoundary()
+      cancellableF { cb -> unsafePut(a, cb) }
+    }
+
+  override suspend fun tryPut(a: A): Boolean =
+    unsafeTryPut(a)
+
+  override suspend fun take(): A =
+    when (val m = unsafeTryTake()) {
+      Maybe.None -> cancellableF(::unsafeTake)
+      is Maybe.Just -> m.value
+    }
+
+  override suspend fun tryTake(): A? =
+    when (val m = unsafeTryTake()) {
+      Maybe.None -> null
+      is Maybe.Just -> m.value
+    }
+
+  override suspend fun read(): A =
+    cancellable(::unsafeRead)
+
+  private tailrec suspend fun unsafeTryPut(a: A): Boolean =
+    when (val current = state.value) {
+      is WaitForTake -> false
+      is WaitForPut -> {
+        var first: Listener<A>? = null
+        val update: State<A> = if (current.takes.isEmpty()) {
+          State(a)
+        } else {
+          first = current.takes.values.first()
+          val rest = current.takes.entries.drop(1)
+          if (rest.isEmpty()) State.empty()
+          else WaitForPut(emptyMap(), rest.toMap())
+        }
+
+        if (!state.compareAndSet(current, update)) {
+          unsafeTryPut(a)
+        } else if (first != null || current.reads.isNotEmpty()) {
+          callPutAndAllReaders(a, first, current.reads)
+        } else true
+      }
+    }
+
+  private tailrec suspend fun unsafePut(a: A, onPut: Listener<Unit>): CancelToken =
+    when (val current = state.value) {
+      is WaitForTake -> {
+        val id = Token()
+        val newMap = current.listeners + Pair(id, Pair(a, onPut))
+        if (state.compareAndSet(current, WaitForTake(current.value, newMap))) CancelToken { unsafeCancelPut(id) }
+        else unsafePut(a, onPut)
+      }
+      is WaitForPut -> {
+        var first: Listener<A>? = null
+        val update = if (current.takes.isEmpty()) {
+          State(a)
+        } else {
+          first = current.takes.values.first()
+          val rest = current.takes.entries.drop(1)
+          if (rest.isEmpty()) State.empty()
+          else WaitForPut(emptyMap(), rest.toMap())
+        }
+
+        if (state.compareAndSet(current, update)) {
+          if (first != null || current.reads.isNotEmpty()) {
+            callPutAndAllReaders(a, first, current.reads)
+            onPut(Result.success(Unit))
+            CancelToken.unit
+          } else {
+            onPut(Result.success(Unit))
+            CancelToken.unit
+          }
+        } else unsafePut(a, onPut)
+      }
+    }
+
+  private tailrec fun unsafeCancelPut(id: Token): Unit =
+    when (val current = state.value) {
+      is WaitForTake -> {
+        val update = current.copy(listeners = current.listeners - id)
+        if (state.compareAndSet(current, update)) Unit
+        else unsafeCancelPut(id)
+      }
+      is WaitForPut -> Unit
+    }
+
+  private tailrec suspend fun unsafeTryTake(): Maybe<A> =
+    when (val current = state.value) {
+      is WaitForTake -> {
+        if (current.listeners.isEmpty()) {
+          if (state.compareAndSet(current, State.empty())) Maybe.Just(current.value)
+          else unsafeTryTake()
+        } else {
+          val (ax, notify) = current.listeners.values.first()
+          val xs = current.listeners.entries.drop(1)
+          val update = WaitForTake(ax, xs.toMap())
+          if (state.compareAndSet(current, update)) {
+            notify(Result.success(Unit))
+            Maybe.Just(current.value)
+          } else {
+            unsafeTryTake()
+          }
+        }
+      }
+      is WaitForPut -> Maybe.None
+    }
+
+  private tailrec suspend fun unsafeTake(onTake: Listener<A>): CancelToken =
+    when (val current = state.value) {
+      is WaitForTake -> {
+        if (current.listeners.isEmpty()) {
+          if (state.compareAndSet(current, State.empty())) {
+            onTake(Result.success(current.value))
+            CancelToken.unit
+          } else {
+            unsafeTake(onTake)
+          }
+        } else {
+          val (ax, notify) = current.listeners.values.first()
+          val xs = current.listeners.entries.drop(1)
+          if (state.compareAndSet(current, WaitForTake(ax, xs.toMap()))) {
+            notify(Result.success(Unit))
+            onTake(Result.success(current.value))
+            CancelToken.unit
+          } else unsafeTake(onTake)
+        }
+      }
+      is WaitForPut -> {
+        val id = Token()
+        val newQueue = current.takes + Pair(id, onTake)
+        if (state.compareAndSet(current, WaitForPut(current.reads, newQueue))) CancelToken { unsafeCancelTake(id) }
+        else unsafeTake(onTake)
+      }
+    }
+
+  private tailrec fun unsafeCancelTake(id: Token): Unit =
+    when (val current = state.value) {
+      is WaitForPut -> {
+        val newMap = current.takes - id
+        val update = WaitForPut(current.reads, newMap)
+        if (state.compareAndSet(current, update)) Unit
+        else unsafeCancelTake(id)
+      }
+      is WaitForTake -> Unit
+    }
+
+  private tailrec fun unsafeRead(onRead: Listener<A>): CancelToken =
+    when (val current = state.value) {
+      is WaitForTake -> {
+        onRead(Result.success(current.value))
+        CancelToken.unit
+      }
+      is WaitForPut -> {
+        val id = Token()
+        val newReads = current.reads + Pair(id, onRead)
+        if (state.compareAndSet(current, WaitForPut(newReads, current.takes))) CancelToken { unsafeCancelRead(id) }
+        else unsafeRead(onRead)
+      }
+    }
+
+  private tailrec fun unsafeCancelRead(id: Token): Unit =
+    when (val current = state.value) {
+      is WaitForPut -> {
+        val newMap = current.reads - id
+        val update = WaitForPut(newMap, current.takes)
+        if (state.compareAndSet(current, update)) Unit
+        else unsafeCancelRead(id)
+      }
+      is WaitForTake -> Unit
+    }
+
+  private suspend fun callPutAndAllReaders(
+    a: A,
+    put: Listener<A>?,
+    reads: Map<Token, Listener<A>>
+  ): Boolean {
+    val value = Result.success(a)
+    reads.values.callAll(value)
+
+    return if (put != null) {
+      put(value)
+      true
+    } else true
+  }
+
+  // For streaming a value to a whole `reads` collection
+  private suspend fun Iterable<Listener<A>>.callAll(value: Result<A>): Unit =
+    forEach { cb -> cb(value) }
+
+  companion object {
+    internal sealed class State<out A> {
+      companion object {
+        private val ref = WaitForPut<Any>(emptyMap(), emptyMap())
+        operator fun <A> invoke(a: A): State<A> = WaitForTake(a, emptyMap())
+
+        @Suppress("UNCHECKED_CAST")
+        fun <A> empty(): State<A> = ref as State<A>
+      }
+
+      data class WaitForPut<A>(val reads: Map<Token, Listener<A>>, val takes: Map<Token, Listener<A>>) : State<A>()
+      data class WaitForTake<A>(val value: A, val listeners: Map<Token, Pair<A, Listener<Unit>>>) : State<A>()
+    }
+  }
+}
+
+internal typealias Listener<A> = (Result<A>) -> Unit
+
+internal fun <K, V> List<Map.Entry<K, V>>.toMap(): Map<K, V> =
+  when (size) {
+    0 -> emptyMap()
+    else -> LinkedHashMap<K, V>(size).apply {
+      for ((key, value) in this@toMap) {
+        put(key, value)
+      }
+    }
+  }

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Duration.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Duration.kt
@@ -1,0 +1,69 @@
+package arrow.fx.coroutines
+
+import java.util.concurrent.TimeUnit
+
+// TODO replace with kotlin.time
+data class Duration(val amount: Long, val timeUnit: TimeUnit) {
+  val nanoseconds: Long by lazy { timeUnit.toNanos(amount) }
+  val millis: Long by lazy { timeUnit.toMillis(amount) }
+
+  companion object {
+    // Actually limited to 9223372036854775807 days, so unless you are very patient, it is unlimited ;-)
+    val INFINITE = Duration(amount = Long.MAX_VALUE, timeUnit = TimeUnit.DAYS)
+  }
+
+  operator fun times(i: Int) = Duration(amount * i, timeUnit)
+
+  operator fun plus(d: Duration): Duration = run {
+    val comp = timeUnit.compareTo(d.timeUnit)
+    when {
+      comp == 0 -> Duration(amount + d.amount, timeUnit) // Same unit
+      comp < 0 -> this + Duration(timeUnit.convert(d.amount, d.timeUnit), timeUnit) // Convert to same unit then add
+      else -> d + this // Swap this and d to add to the smaller unit
+    }
+  }
+}
+
+operator fun Int.times(d: Duration) = d * this
+
+val Long.days: Duration
+  get() = Duration(this, TimeUnit.DAYS)
+
+val Int.days: Duration
+  get() = Duration(this.toLong(), TimeUnit.DAYS)
+
+val Long.hours: Duration
+  get() = Duration(this, TimeUnit.HOURS)
+
+val Int.hours: Duration
+  get() = Duration(this.toLong(), TimeUnit.HOURS)
+
+val Long.microseconds: Duration
+  get() = Duration(this, TimeUnit.MICROSECONDS)
+
+val Int.microseconds: Duration
+  get() = Duration(this.toLong(), TimeUnit.MICROSECONDS)
+
+val Long.minutes: Duration
+  get() = Duration(this, TimeUnit.MINUTES)
+
+val Int.minutes: Duration
+  get() = Duration(this.toLong(), TimeUnit.MINUTES)
+
+val Long.milliseconds: Duration
+  get() = Duration(this, TimeUnit.MILLISECONDS)
+
+val Int.milliseconds: Duration
+  get() = Duration(this.toLong(), TimeUnit.MILLISECONDS)
+
+val Long.nanoseconds: Duration
+  get() = Duration(this, TimeUnit.NANOSECONDS)
+
+val Int.nanoseconds: Duration
+  get() = Duration(this.toLong(), TimeUnit.NANOSECONDS)
+
+val Long.seconds: Duration
+  get() = Duration(this, TimeUnit.SECONDS)
+
+val Int.seconds: Duration
+  get() = Duration(this.toLong(), TimeUnit.SECONDS)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Fiber.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Fiber.kt
@@ -1,0 +1,133 @@
+package arrow.fx.coroutines
+
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+
+/**
+ * [Fiber] represents a pure value that contains a running `suspend () -> A`.
+ *
+ * You can think of fibers as being lightweight threads, a Fiber being a
+ * concurrency primitive for doing cooperative multi-tasking.
+ */
+interface Fiber<A> {
+
+  suspend fun join(): A
+  suspend fun cancel(): Unit
+
+  companion object {
+
+    /**
+     * [Fiber] constructor.
+     *
+     * @param join task that will trigger the cancellation.
+     * @param cancel task that will await for the completion of the underlying Fiber.
+     */
+    operator fun <A> invoke(join: suspend () -> A, cancel: CancelToken): Fiber<A> = object : Fiber<A> {
+      override suspend fun join(): A = join()
+      override suspend fun cancel(): Unit = cancel.invoke()
+      override fun toString(): String = "Fiber(join= $join, cancel= $cancel)"
+    }
+  }
+}
+
+internal fun <A> Fiber(promise: UnsafePromise<A>, conn: SuspendConnection): Fiber<A> =
+  Fiber({ promise.join() }, conn.cancelToken())
+
+/**
+ * Launches a new suspendable cancellable coroutine within a [Fiber].
+ * It does so by connecting the created [Fiber]'s cancellation to the parent.
+ * If the parent gets cancelled, then this [Fiber] will also get cancelled.
+ *
+ * You can [Fiber.join] or [Fiber.cancel] the computation.
+ * Cancelling this [Fiber] **will not** cancel its parent.
+ */
+suspend fun <A> ForkConnected(ctx: CoroutineContext = ComputationPool, f: suspend () -> A): Fiber<A> =
+  suspendCoroutineUninterceptedOrReturn { cont ->
+    val conn = cont.context.connection()
+
+    val promise = UnsafePromise<A>()
+    // A new SuspendConnection, because its cancellation is now decoupled from our current one.
+    val conn2 = SuspendConnection()
+    conn.push(conn2.cancelToken())
+    f.startCoroutineCancellable(CancellableContinuation(ctx, conn2, promise::complete))
+    Fiber(promise, conn2)
+  }
+
+suspend fun <A> (suspend () -> A).forkConnected(ctx: CoroutineContext = ComputationPool): Fiber<A> =
+  ForkConnected(ctx, this)
+
+/**
+ * Launches a new suspendable cancellable coroutine within a [Fiber].
+ * It does so by connecting the created [Fiber]'s cancellation to the provided [interruptWhen].
+ * If the [interruptWhen] signal gets triggered, then this [Fiber] will get cancelled.
+ *
+ * You can still cancel the [Fiber] independent from the [interruptWhen] token,
+ * whichever one comes first cancels the [Fiber].
+ *
+ * This function is meant to integrate with 3rd party cancellation system such as Android.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * tailrec suspend fun parallelProcess(): Unit {
+ *   println(System.currentTimeMillis())
+ *   sleep(1.seconds)
+ *   parallelProcess()
+ * }
+ *
+ * suspend fun main(): Unit {
+ *   val switch = Promise<Unit>()
+ *   val switcher = suspend {
+ *     sleep(5.seconds)
+ *     switch.complete(Unit)
+ *   }
+ *
+ *   ::parallelProcess.forkScoped(interruptWhen = switch::get)
+ *   switcher.forkConnected()
+ * }
+ * ```
+ */
+suspend fun <A> ForkScoped(
+  ctx: CoroutineContext = ComputationPool,
+  interruptWhen: suspend () -> Unit,
+  f: suspend () -> A
+): Fiber<A> = suspendCoroutineUninterceptedOrReturn { cont ->
+  val conn = cont.context.connection()
+
+  val promise = UnsafePromise<A>()
+  // A new SuspendConnection, because its cancellation is now decoupled from our current one.
+  val conn2 = SuspendConnection()
+  conn.push(conn2.cancelToken())
+
+  suspend { // Launch cancelation trigger system concurrently
+    ForkConnected { interruptWhen.invoke(); conn2.cancel() }
+    f.invoke() // Fire actual operation
+  }.startCoroutineCancellable(CancellableContinuation(ctx, conn2, promise::complete))
+
+  Fiber(promise, conn2)
+}
+
+suspend fun <A> (suspend () -> A).forkScoped(
+  ctx: CoroutineContext = ComputationPool,
+  interruptWhen: suspend () -> Unit
+): Fiber<A> = ForkScoped(ctx, interruptWhen, this)
+
+/**
+ * Launches a new suspendable cancellable coroutine within a [Fiber].
+ * You can [Fiber.join] or [Fiber.cancel] the computation.
+ *
+ * **BEWARE** you immediately leak the [Fiber] when launching without connection control.
+ * Use [ForkConnected] or safely launch the fiber as a [Resource] or using [Fiber].
+ *
+ * @see ForkConnected for a fork operation that wires cancellation to its parent in a safe way.
+ */
+suspend fun <A> (suspend () -> A).forkAndForget(ctx: CoroutineContext = ComputationPool): Fiber<A> {
+  val promise = UnsafePromise<A>()
+  // A new SuspendConnection, because its cancellation is now decoupled from our current one.
+  val conn = SuspendConnection()
+  startCoroutineCancellable(CancellableContinuation(ctx, conn, promise::complete))
+  return Fiber(promise, conn)
+}
+
+suspend fun <A> ForkAndForget(ctx: CoroutineContext = ComputationPool, f: suspend () -> A): Fiber<A> =
+  f.forkAndForget(ctx)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ForwardCancellable.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ForwardCancellable.kt
@@ -1,0 +1,98 @@
+package arrow.fx.coroutines
+
+import kotlinx.atomicfu.atomic
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * ForwardCancellable can be used to forward cancellation when you want to inject an uncancelable piece of logic.
+ * I.e. is used in `bracket` and `guaranteeCase` to schedule the `cancel` frame.
+ */
+internal class ForwardCancellable {
+
+  private val state = atomic(init)
+
+  fun cancel(): CancelToken {
+    fun loop(conn: SuspendConnection, cb: (Result<Unit>) -> Unit): Unit = state.value.let { current ->
+      when (current) {
+        is State.Empty ->
+          if (!state.compareAndSet(current, State.Empty(listOf(cb) + current.stack))) loop(conn, cb)
+          else Unit
+
+        is State.Active -> {
+          state.lazySet(finished) // GC purposes
+          // Platform.trampoline { }
+          current.token.cancel.startCoroutineCancellable(CancellableContinuation(EmptyCoroutineContext, conn, cb))
+        }
+      }
+    }
+
+    return CancelToken {
+      suspendCoroutine { cont ->
+        loop(cont.context.connection(), cont::resumeWith)
+      }
+    }
+  }
+
+  fun complete(value: Disposable): Unit =
+    complete(CancelToken { value.invoke() })
+
+  fun complete(value: CancelToken): Unit = state.value.let { current ->
+    when (current) {
+      is State.Active -> {
+        Platform.unsafeRunSync(value.cancel)
+        throw IllegalStateException(current.toString())
+      }
+      is State.Empty -> if (current == init) {
+        // If `init`, then `cancel` was not triggered yet
+        if (!state.compareAndSet(current, State.Active(value)))
+          complete(value)
+      } else {
+        if (!state.compareAndSet(current, finished))
+          complete(value)
+        else
+          execute(value, current.stack)
+      }
+    }
+  }
+
+  companion object {
+
+    /**
+     * Models the internal state of [ForwardCancellable]:
+     *
+     *  - on start, the state is [Empty] of `Nil`, aka [init]
+     *  - on `cancel`, if no token was assigned yet, then the state will
+     *    remain [Empty] with a non-nil `List[Callback]`
+     *  - if a `CancelToken` is provided without `cancel` happening,
+     *    then the state transitions to [Active] mode
+     *  - on `cancel`, if the state was [Active], or if it was [Empty],
+     *    regardless, the state transitions to `Active(IO.unit)`, aka [finished]
+     */
+    private sealed class State {
+      data class Empty(val stack: List<(Result<Unit>) -> Unit>) : State()
+      data class Active(val token: CancelToken) : State()
+    }
+
+    private val init: State = State.Empty(listOf())
+    private val finished: State = State.Active(CancelToken.unit)
+
+    private fun execute(token: CancelToken, stack: List<(Result<Unit>) -> Unit>): Unit =
+//      Platform.trampoline {
+      token.cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r ->
+        val errors = stack.fold(emptyList<Throwable>()) { acc, cb ->
+          try {
+            cb(r)
+            acc
+          } catch (t: Throwable) {
+            acc + t.nonFatalOrThrow()
+          }
+        }
+        // AsyncErrorHandler for exceptions from running CancelToken.
+        if (errors.isNotEmpty()) throw Platform.composeErrors(errors.first(), errors.drop(1))
+        else Unit
+      })
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/IQueue.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/IQueue.kt
@@ -1,0 +1,106 @@
+package arrow.fx.coroutines
+
+/**
+ *  Port of `scala.collection.immutable.Queue`
+ * `Queue` objects implement data structures that allow to
+ *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
+ *
+ *  `Queue` is implemented as a pair of `List`s, one containing the ''in'' elements and the other the ''out'' elements.
+ *  Elements are added to the ''in'' list and removed from the ''out'' list. When the ''out'' list runs dry, the
+ *  queue is pivoted by replacing the ''out'' list by ''in.reverse'', and ''in'' by ''Nil''.
+ */
+internal class IQueue<A> internal constructor(
+  private val listIn: List<A>,
+  private val listOut: List<A>
+) : Iterable<A> {
+
+  private fun <A> Iterable<A>.tail() = drop(1)
+  private fun cons(a: A, l: List<A>): List<A> = listOf(a) + l
+
+  fun isEmpty(): Boolean = listIn.isEmpty() && listOut.isEmpty()
+
+  fun isNotEmpty(): Boolean = listIn.isNotEmpty() || listOut.isNotEmpty()
+
+  fun first(): A =
+    firstOrNull() ?: throw NoSuchElementException("first on empty queue")
+
+  fun firstOrNull(): A? =
+    when {
+      listOut.isNotEmpty() -> listOut.first()
+      listIn.isNotEmpty() -> listIn.last()
+      else -> null
+    }
+
+  fun tail(): IQueue<A> =
+    tailOrNull() ?: throw NoSuchElementException("tail on empty queue")
+
+  fun tailOrNull(): IQueue<A>? =
+    when {
+      listOut.isNotEmpty() -> IQueue(listIn, listOut.tail())
+      listIn.isNotEmpty() -> IQueue(emptyList(), listIn.reversed().tail())
+      else -> null
+    }
+
+  fun all(p: (A) -> Boolean): Boolean =
+    listIn.all(p) && listOut.all(p)
+
+  fun exists(p: (A) -> Boolean): Boolean =
+    listIn.any(p) || listOut.any(p)
+
+  fun length(): Int = listIn.size + listOut.size
+
+  fun enqueue(elem: A): IQueue<A> =
+    IQueue(cons(elem, listIn), listOut)
+
+  fun enqueue(elems: Iterable<A>): IQueue<A> =
+    IQueue(elems.reversed() + listIn, listOut)
+
+  fun prepend(elem: A): IQueue<A> =
+    IQueue(listIn, cons(elem, listOut))
+
+  fun dequeue(): Pair<A, IQueue<A>> =
+    when {
+      listOut.isEmpty() && listIn.isNotEmpty() -> {
+        val rev = listIn.reversed()
+        Pair(rev.first(), IQueue(emptyList(), rev.tail()))
+      }
+      listOut.isNotEmpty() -> Pair(listOut.first(), IQueue(listIn, listOut.tail()))
+      else -> throw NoSuchElementException("dequeue on empty queue")
+    }
+
+  fun drop(n: Int): IQueue<A> = when {
+    listOut.isEmpty() && listIn.isNotEmpty() -> IQueue(emptyList(), listIn.reversed().drop(n))
+    listOut.isNotEmpty() -> IQueue(listIn, listOut.drop(n))
+    else -> throw NoSuchElementException("dequeue on empty queue")
+  }
+
+  fun dequeueOrNull(): Pair<A, IQueue<A>>? =
+    if (isEmpty()) null
+    else dequeue()
+
+  fun filter(p: (A) -> Boolean): IQueue<A> =
+    IQueue(listIn.filter(p), listOut.filter(p))
+
+  fun filterNot(p: (A) -> Boolean): IQueue<A> =
+    IQueue(listIn.filterNot(p), listOut.filterNot(p))
+
+  override fun toString(): String =
+    "Queue(${listIn.joinToString(separator = ", ")}, ${listOut.joinToString(separator = ", ")})"
+
+  companion object {
+    @Suppress("UNCHECKED_CAST")
+    fun <A> empty(): IQueue<A> = EmptyQueue as IQueue<A>
+    operator fun <A> invoke(vararg a: A): IQueue<A> = IQueue(emptyList(), a.toList())
+    operator fun <A> invoke(a: A): IQueue<A> = IQueue(emptyList(), listOf(a))
+    operator fun <A> invoke(a: List<A>): IQueue<A> = IQueue(emptyList(), a)
+  }
+
+  override fun iterator(): Iterator<A> = toList().iterator()
+
+  fun toList(): List<A> = listOut + listIn.reversed()
+}
+
+internal infix fun <A> A.prependTo(q: IQueue<A>): IQueue<A> =
+  q.prepend(this)
+
+private val EmptyQueue: IQueue<Nothing> = IQueue(emptyList(), emptyList())

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt
@@ -1,0 +1,98 @@
+package arrow.fx.coroutines
+
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Sequence all tasks in [n] parallel processes and return the result
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <A> Iterable<suspend () -> A>.parSequenceN(n: Long): List<A> =
+  parSequenceN(ComputationPool, n)
+
+/**
+ * Sequence all tasks in [n] parallel processes and return the result
+ * Cancelling this operation cancels all running tasks.
+ *
+ * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parSequence for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+suspend fun <A> Iterable<suspend () -> A>.parSequenceN(ctx: CoroutineContext, n: Long): List<A> {
+  val s = Semaphore(n)
+  return parTraverse(ctx) {
+    s.withPermit { it.invoke() }
+  }
+}
+
+/**
+ * Sequence all tasks in parallel and return the result
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <A> Iterable<suspend () -> A>.parSequence(): List<A> =
+  parTraverse { it.invoke() }
+
+/**
+ * Sequence all tasks in parallel and return the result
+ * Cancelling this operation cancels all running tasks.
+ *
+ * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parSequence for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+suspend fun <A> Iterable<suspend () -> A>.parSequence(ctx: CoroutineContext): List<A> =
+  parTraverse(ctx) { it.invoke() }
+
+/**
+ * Traverse this [Iterable] and run mapper [f] in [n] parallel processes.
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <A, B> Iterable<A>.parTraverseN(n: Long, f: suspend (A) -> B): List<B> {
+  val s = Semaphore(n)
+  return parTraverse(ComputationPool) { a ->
+    s.withPermit { f(a) }
+  }
+}
+
+/**
+ * Traverse this [Iterable] and run [f] in parallel on [ctx].
+ * Cancelling this operation cancels all running tasks.
+ *
+ * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parTraverseN for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+suspend fun <A, B> Iterable<A>.parTraverseN(ctx: CoroutineContext, n: Long, f: suspend (A) -> B): List<B> {
+  val s = Semaphore(n)
+  return parTraverse(ctx) { a ->
+    s.withPermit { f(a) }
+  }
+}
+
+/**
+ * Traverse this [Iterable] and and run all mappers [f] in parallel.
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <A, B> Iterable<A>.parTraverse(f: suspend (A) -> B): List<B> =
+  parTraverse(ComputationPool, f)
+
+/**
+ * Traverse this [Iterable] and and run all mappers [f] on [CoroutineContext].
+ * Cancelling this operation cancels all running tasks.
+ *
+ * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parTraverse for a function that ensures it runs in parallel on the [ComputationPool].
+ */ // Foldable impl, more performant implementations can be done for other data types
+suspend fun <A, B> Iterable<A>.parTraverse(ctx: CoroutineContext, f: suspend (A) -> B): List<B> =
+  if (ctx === EmptyCoroutineContext || ctx[ContinuationInterceptor] == null) map { a -> f(a) }
+  else toList().foldRight(suspend { emptyList<B>() }) { a, acc ->
+    suspend {
+      parMapN(ctx, { f(a) }, { acc.invoke() }) { (a, b) -> listOf(a) + b }
+    }
+  }.invoke()

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTupledN.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTupledN.kt
@@ -1,0 +1,255 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Parallel maps [fa], [fb] in parallel on [ComputationPool].
+ * Cancelling this operation cancels both operations running in parallel.
+ *
+ * @see parMapN for the same function that can race on any [CoroutineContext].
+ */
+suspend fun <A, B, C> parMapN(fa: suspend () -> A, fb: suspend () -> B, f: (Pair<A, B>) -> C): C =
+  f(parTupledN(ComputationPool, fa, fb))
+
+/**
+ * Parallel maps [fa], [fb], [fc] in parallel on [ComputationPool].
+ * Cancelling this operation cancels both operations running in parallel.
+ *
+ * @see parMapN for the same function that can race on any [CoroutineContext].
+ */
+suspend fun <A, B, C, D> parMapN(
+  fa: suspend () -> A,
+  fb: suspend () -> B,
+  fc: suspend () -> C,
+  f: (Triple<A, B, C>) -> D
+): D =
+  f(parTupledN(ComputationPool, fa, fb, fc))
+
+/**
+ * Parallel maps [fa], [fb] on the provided [CoroutineContext].
+ * Cancelling this operation cancels both tasks running in parallel.
+ *
+ * **WARNING** this function forks [fa], [fb] but if it runs in parallel depends
+ * on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parMapN for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+suspend fun <A, B, C> parMapN(
+  ctx: CoroutineContext,
+  fa: suspend () -> A,
+  fb: suspend () -> B,
+  f: (Pair<A, B>) -> C
+): C =
+  f(parTupledN(ctx, fa, fb))
+
+/**
+ * Parallel maps [fa], [fb], [fc] on the provided [CoroutineContext].
+ * Cancelling this operation cancels both tasks running in parallel.
+ *
+ * **WARNING** this function forks [fa], [fb] & [fc] but if it runs in parallel depends
+ * on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parMapN for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+suspend fun <A, B, C, D> parMapN(
+  ctx: CoroutineContext,
+  fa: suspend () -> A,
+  fb: suspend () -> B,
+  fc: suspend () -> C,
+  f: (Triple<A, B, C>) -> D
+): D =
+  f(parTupledN(ctx, fa, fb, fc))
+
+/**
+ * Tuples [fa], [fb] in parallel on [ComputationPool].
+ * Cancelling this operation cancels both operations running in parallel.
+ *
+ * @see parTupledN for the same function that can race on any [CoroutineContext].
+ */
+suspend fun <A, B> parTupledN(fa: suspend () -> A, fb: suspend () -> B): Pair<A, B> =
+  parTupledN(ComputationPool, fa, fb)
+
+/**
+ * Tuples [fa], [fb], [fc] in parallel on [ComputationPool].
+ * Cancelling this operation cancels both tasks running in parallel.
+ *
+ * @see parTupledN for the same function that can race on any [CoroutineContext].
+ */
+suspend fun <A, B, C> parTupledN(fa: suspend () -> A, fb: suspend () -> B, fc: suspend () -> C): Triple<A, B, C> =
+  parTupledN(ComputationPool, fa, fb, fc)
+
+/**
+ * Tuples [fa], [fb] on the provided [CoroutineContext].
+ * Cancelling this operation cancels both tasks running in parallel.
+ *
+ * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parTupledN for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+@Suppress("UNCHECKED_CAST")
+suspend fun <A, B> parTupledN(
+  ctx: CoroutineContext,
+  fa: suspend () -> A,
+  fb: suspend () -> B
+): Pair<A, B> =
+  suspendCoroutine { cont ->
+    val conn = cont.context.connection()
+    val cb = cont::resumeWith
+
+    // Used to store Throwable, Either<A, B> or empty (null). (No sealed class used for a slightly better performing ParMap2)
+    val state = AtomicRefW<Any?>(null)
+
+    val connA = SuspendConnection()
+    val connB = SuspendConnection()
+
+    conn.pushPair(connA, connB)
+
+    fun complete(a: A, b: B) {
+      conn.pop()
+      cb(
+        try {
+          Result.success(Pair(a, b))
+        } catch (e: Throwable) {
+          Result.failure<Pair<A, B>>(e.nonFatalOrThrow())
+        }
+      )
+    }
+
+    fun sendException(other: SuspendConnection, e: Throwable) = when (state.getAndSet(e)) {
+      is Throwable -> Unit // Do nothing we already finished
+      else -> other.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r ->
+        conn.pop()
+        cb(Result.failure<Pair<A, B>>(r.fold({ e }, { e2 -> Platform.composeErrors(e, e2) })))
+      })
+    }
+
+    fa.startCoroutineCancellable(CancellableContinuation(ctx, connA) { resA ->
+      resA.fold({ a ->
+        when (val oldState = state.getAndSet(Either.Left(a))) {
+          null -> Unit // Wait for B
+          is Throwable -> Unit // ParMapN already failed and A was cancelled.
+          is Either.Left<*> -> Unit // Already state.getAndSet
+          is Either.Right<*> -> complete(a, (oldState as Either.Right<B>).b)
+        }
+      }, { e ->
+        sendException(connB, e)
+      })
+    })
+
+    fb.startCoroutineCancellable(CancellableContinuation(ctx, connB) { resB ->
+      resB.fold({ b ->
+        when (val oldState = state.getAndSet(Either.Right(b))) {
+          null -> Unit // Wait for A
+          is Throwable -> Unit // ParMapN already failed and B was cancelled.
+          is Either.Right<*> -> Unit // IO cannot finish twice
+          is Either.Left<*> -> complete((oldState as Either.Left<A>).a, b)
+        }
+      }, { e ->
+        sendException(connA, e)
+      })
+    })
+  }
+
+/**
+ * Tuples [fa], [fb] & [fc] on the provided [CoroutineContext].
+ * Cancelling this operation cancels both tasks running in parallel.
+ *
+ * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parTupledN for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+suspend fun <A, B, C> parTupledN(
+  ctx: CoroutineContext,
+  fa: suspend () -> A,
+  fb: suspend () -> B,
+  fc: suspend () -> C
+): Triple<A, B, C> =
+  suspendCoroutine { cont ->
+    val conn = cont.context.connection()
+    val cb = cont::resumeWith
+
+    val state: AtomicRefW<Triple<A?, B?, C?>?> = AtomicRefW(null)
+    val active = AtomicBooleanW(true)
+
+    val connA = SuspendConnection()
+    val connB = SuspendConnection()
+    val connC = SuspendConnection()
+
+    // Composite cancellable that cancels all ops.
+    // NOTE: conn.pop() called when cb gets called below in complete.
+    conn.push(listOf(connA.cancelToken(), connB.cancelToken(), connC.cancelToken()))
+
+    fun complete(a: A, b: B, c: C) {
+      conn.pop()
+      cb(Result.success(Triple(a, b, c)))
+    }
+
+    fun tryComplete(result: Triple<A?, B?, C?>?): Unit {
+      result?.let { (a, b, c) ->
+        a?.let {
+          b?.let {
+            c?.let {
+              complete(a, b, c)
+            }
+          }
+        }
+      } ?: Unit
+    }
+
+    fun sendException(other: SuspendConnection, other2: SuspendConnection, e: Throwable) =
+      if (active.getAndSet(false)) { // We were already cancelled so don't do anything.
+        other.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r1 ->
+          other2.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r2 ->
+            conn.pop()
+            cb(Result.failure(r1.fold({
+              r2.fold({ e }, { e3 -> Platform.composeErrors(e, e3) })
+            }, { e2 ->
+              r2.fold({ Platform.composeErrors(e, e2) }, { e3 -> Platform.composeErrors(e, e2, e3) })
+            })))
+          })
+        })
+      } else Unit
+
+    // Can be started with a `startCancellableCoroutine` builder instead.
+    fa.startCoroutineCancellable(CancellableContinuation(ctx, connA) { resA ->
+      resA.fold({ a ->
+        val newState = state.updateAndGet { current ->
+          current?.copy(first = a) ?: Triple(a, null, null)
+        }
+        tryComplete(newState)
+      }, { e ->
+        sendException(connB, connC, e)
+      })
+    })
+
+    fb.startCoroutineCancellable(CancellableContinuation(ctx, connB) { resB ->
+      resB.fold({ b ->
+        val newState = state.updateAndGet { current ->
+          current?.copy(second = b) ?: Triple(null, b, null)
+        }
+        tryComplete(newState)
+      }, { e ->
+        sendException(connA, connC, e)
+      })
+    })
+
+    fc.startCoroutineCancellable(CancellableContinuation(ctx, connC) { resC ->
+      resC.fold({ c ->
+        val newState = state.updateAndGet { current ->
+          current?.copy(third = c) ?: Triple(null, null, c)
+        }
+        tryComplete(newState)
+      }, { e ->
+        sendException(connA, connC, e)
+      })
+    })
+  }

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Platform.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Platform.kt
@@ -1,0 +1,277 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.updateAndGet
+import java.util.concurrent.locks.AbstractQueuedSynchronizer
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+
+internal open class ArrowInternalException(
+  override val message: String =
+    "Arrow-kt internal error. Please let us know and create a ticket at https://github.com/arrow-kt/arrow/issues/new/choose"
+) : RuntimeException(message)
+
+private const val initialIndex: Int = 0
+private const val chunkSize: Int = 8
+
+object Platform {
+
+  @Suppress("UNCHECKED_CAST")
+  internal class ArrayStack<A> {
+
+    private val initialArray: Array<Any?> = arrayOfNulls<Any?>(chunkSize)
+    private val modulo = chunkSize - 1
+    private var array = initialArray
+    private var index = initialIndex
+
+    /** Returns `true` if the stack is empty. */
+    fun isEmpty(): Boolean =
+      index == 0 && (array.getOrNull(0) == null)
+
+    /** Pushes an item on the stack. */
+    fun push(a: A) {
+      if (index == modulo) {
+        val newArray = arrayOfNulls<Any?>(chunkSize)
+        newArray[0] = array
+        array = newArray
+        index = 1
+      } else {
+        index += 1
+      }
+      array[index] = a
+    }
+
+    /** Pushes an entire iterator on the stack. */
+    fun pushAll(cursor: Iterator<A>) {
+      while (cursor.hasNext()) push(cursor.next())
+    }
+
+    /** Pushes an entire iterable on the stack. */
+    fun pushAll(seq: Iterable<A>) {
+      pushAll(seq.iterator())
+    }
+
+    /** Pushes the contents of another stack on this stack. */
+    fun pushAll(stack: ArrayStack<A>) {
+      pushAll(stack.iteratorReversed())
+    }
+
+    /** Pops an item from the stack (in LIFO order).
+     *
+     * Returns `null` in case the stack is empty.
+     */
+    fun pop(): A? {
+      if (index == 0) {
+        if (array.getOrNull(0) != null) {
+          array = array[0] as Array<Any?>
+          index = modulo
+        } else {
+          return null
+        }
+      }
+      val result = array[index] as A
+      // GC purposes
+      array[index] = null
+      index -= 1
+      return result
+    }
+
+    /** Builds an iterator out of this stack. */
+    @Suppress("IteratorNotThrowingNoSuchElementException")
+    fun iteratorReversed(): Iterator<A> =
+      object : Iterator<A> {
+        private var array = this@ArrayStack.array
+        private var index = this@ArrayStack.index
+
+        override fun hasNext(): Boolean =
+          index > 0 || (array.getOrNull(0) != null)
+
+        override fun next(): A {
+          if (index == 0) {
+            array = array[0] as Array<Any?>
+            index = modulo
+          }
+          val result = array[index] as A
+          index -= 1
+          return result
+        }
+      }
+
+    fun isNotEmpty(): Boolean =
+      !isEmpty()
+  }
+
+  inline fun <A> onceOnly(crossinline f: (A) -> Unit): (A) -> Unit {
+    val wasCalled = AtomicBooleanW(false)
+
+    return { a ->
+      if (!wasCalled.getAndSet(true)) {
+        f(a)
+      }
+    }
+  }
+
+  internal inline fun <A> onceOnly(conn: SuspendConnection, crossinline f: (A) -> Unit): (A) -> Unit {
+    val wasCalled = AtomicBooleanW(false)
+
+    return { a ->
+      if (!wasCalled.getAndSet(true)) {
+        conn.pop()
+        f(a)
+      }
+    }
+  }
+
+  internal fun <A> unsafeRunSync(f: suspend () -> A): A {
+    val latch = OneShotLatch()
+    var ref: Either<Throwable, A>? = null
+    f.startCoroutine(Continuation(EmptyCoroutineContext) { a ->
+      ref = a.fold({ aa -> Either.Right(aa) }, { t -> Either.Left(t) })
+      latch.releaseShared(1)
+    })
+
+    latch.acquireSharedInterruptibly(1)
+
+    return when (val either = ref) {
+      is Either.Left -> throw either.a
+      is Either.Right -> either.b
+      null -> throw ArrowInternalException("Suspend execution should yield a valid result")
+    }
+  }
+
+  internal fun <A> unsafeRunSync(startOn: CoroutineContext, f: suspend () -> A): A {
+    val latch = OneShotLatch()
+    var ref: Either<Throwable, A>? = null
+    f.startCoroutine(Continuation(startOn) { a ->
+      ref = a.fold({ aa -> Either.Right(aa) }, { t -> Either.Left(t) })
+      latch.releaseShared(1)
+    })
+
+    latch.acquireSharedInterruptibly(1)
+
+    return when (val either = ref) {
+      is Either.Left -> throw either.a
+      is Either.Right -> either.b
+      null -> throw ArrowInternalException("Suspend execution should yield a valid result")
+    }
+  }
+
+  /**
+   * Composes multiple errors together, meant for those cases in which error suppression, due to a second error being
+   * triggered, is not acceptable.
+   *
+   * On top of the JVM this function uses Throwable#addSuppressed, available since Java 7. On top of JavaScript the
+   * function would return a CompositeException.
+   */
+  fun composeErrors(first: Throwable, vararg rest: Throwable): Throwable {
+    rest.forEach { if (it != first) first.addSuppressed(it) }
+    return first
+  }
+
+  /**
+   * Composes multiple errors together, meant for those cases in which error suppression, due to a second error being
+   * triggered, is not acceptable.
+   *
+   * On top of the JVM this function uses Throwable#addSuppressed, available since Java 7. On top of JavaScript the
+   * function would return a CompositeException.
+   */
+  fun composeErrors(first: Throwable, rest: List<Throwable>): Throwable {
+    rest.forEach { if (it != first) first.addSuppressed(it) }
+    return first
+  }
+}
+
+private class OneShotLatch : AbstractQueuedSynchronizer() {
+  override fun tryAcquireShared(ignored: Int): Int =
+    if (state != 0) {
+      1
+    } else {
+      -1
+    }
+
+  override fun tryReleaseShared(ignore: Int): Boolean {
+    state = 1
+    return true
+  }
+}
+
+class AtomicRefW<A>(a: A) {
+  private val atomicRef = atomic(a)
+
+  var value: A
+    set(a) {
+      atomicRef.value = a
+    }
+    get() = atomicRef.value
+
+  fun getAndSet(a: A) = atomicRef.getAndSet(a)
+
+  fun updateAndGet(function: (A) -> A) = atomicRef.updateAndGet(function)
+
+  fun compareAndSet(expect: A, update: A) = atomicRef.compareAndSet(expect, update)
+
+  fun lazySet(a: A) = atomicRef.lazySet(a)
+
+  override fun toString(): String = value.toString()
+}
+
+class AtomicBooleanW(a: Boolean) {
+  private val ref = atomic(a)
+
+  var value: Boolean
+    set(a) {
+      ref.value = a
+    }
+    get() = ref.value
+
+  fun getAndSet(a: Boolean) = ref.getAndSet(a)
+
+  fun updateAndGet(function: (Boolean) -> Boolean) = ref.updateAndGet(function)
+
+  fun compareAndSet(expect: Boolean, update: Boolean) = ref.compareAndSet(expect, update)
+
+  fun lazySet(a: Boolean) = ref.lazySet(a)
+
+  override fun toString(): String = value.toString()
+}
+
+class AtomicIntW(a: Int) {
+  private val atomicRef = atomic(a)
+
+  var value: Int
+    set(a) {
+      atomicRef.value = a
+    }
+    get() = atomicRef.value
+
+  fun getAndSet(a: Int) = atomicRef.getAndSet(a)
+
+  fun getAndAdd(delta: Int) = atomicRef.getAndAdd(delta)
+
+  fun addAndGet(delta: Int) = atomicRef.addAndGet(delta)
+
+  fun getAndIncrement() = atomicRef.getAndIncrement()
+
+  fun getAndDecrement() = atomicRef.getAndDecrement()
+
+  fun incrementAndGet() = atomicRef.incrementAndGet()
+
+  fun decrementAndGet() = atomicRef.decrementAndGet()
+
+  fun updateAndGet(function: (Int) -> Int) = atomicRef.updateAndGet(function)
+
+  fun compareAndSet(expect: Int, update: Int) = atomicRef.compareAndSet(expect, update)
+
+  fun lazySet(a: Int) = atomicRef.lazySet(a)
+
+  override fun toString(): String = value.toString()
+}
+
+fun Throwable.nonFatalOrThrow(): Throwable =
+  when (this) {
+    is VirtualMachineError, is ThreadDeath, is InterruptedException, is LinkageError -> throw this
+    else -> this
+  }

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Promise.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Promise.kt
@@ -1,0 +1,164 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import arrow.fx.coroutines.DefaultPromise.State.Complete
+import arrow.fx.coroutines.DefaultPromise.State.Pending
+import arrow.fx.coroutines.Promise.AlreadyFulfilled
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+
+/**
+ * When made, a [Promise] is empty. Until it is fulfilled, which can only happen once.
+ *
+ * A [Promise] that a value of type [A] will be provided later.
+ */
+interface Promise<A> {
+
+  /**
+   * Get or throw the promised value, use `attempt` when throwing is not required.
+   * Suspends until the promised value is available.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val promise = Promise<Int>()
+   *
+   *   timeOutOrNull(2.seconds) {
+   *     promise.get()
+   *   }.also { println("I timed out: $it") }
+   *
+   *   promise.complete(5)
+   *   println(promise.get())
+   *   //sampleEnd
+   * }
+   * ```
+   */
+  suspend fun get(): A
+
+  /**
+   * Try get the promised value, it returns `null` if promise is not fulfilled yet.
+   * Returns [A] if promise is fulfilled.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val promise = Promise<Int>()
+   *   val empty = promise.tryGet()
+   *   promise.complete(1)
+   *   val full = promise.tryGet()
+   *   //sampleEnd
+   *   println("empty: $empty, full: $full")
+   * }
+   * ```
+   */
+  suspend fun tryGet(): A?
+
+  /**
+   * Completes, or fulfills, the promise with the specified value [A].
+   * Returns [Promise.AlreadyFulfilled] in [Either.Left] if the promise is already fulfilled.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val p = Promise<Int>()
+   *   p.complete(1)
+   *   val r1 = p.get()
+   *   val failed = p.complete(2)
+   *   val r2 = p.get()
+   *   //sampleEnd
+   *   println("r1: $r1, failed: $failed, r2: $r2")
+   * }
+   * ```
+   */
+  suspend fun complete(a: A): Either<AlreadyFulfilled, Unit>
+
+  companion object {
+    fun <A> unsafe(): Promise<A> = DefaultPromise()
+    suspend operator fun <A> invoke(): Promise<A> = unsafe()
+  }
+
+  object AlreadyFulfilled {
+    internal val left: Either<AlreadyFulfilled, Nothing> = Either.Left(this)
+  }
+}
+
+internal class DefaultPromise<A> : Promise<A> {
+
+  internal sealed class State<out A> {
+    data class Pending<A>(val joiners: Map<Token, (Result<A>) -> Unit>) : State<A>()
+    data class Complete<A>(val value: A) : State<A>()
+  }
+
+  private val state: AtomicRef<State<A>> = atomic(Pending(emptyMap()))
+
+  override suspend fun get(): A =
+    when (val current = state.value) {
+      is Complete -> current.value
+      is Pending -> cancellable { cb ->
+        val id = unsafeRegister(cb)
+        CancelToken { unregister(id) }
+      }
+    }
+
+  override suspend fun tryGet(): A? =
+    when (val current = state.value) {
+      is Complete -> current.value
+      is Pending -> null
+      is Error -> null
+    }
+
+  override suspend fun complete(a: A): Either<AlreadyFulfilled, Unit> =
+    unsafeTryComplete(a)
+
+  private tailrec suspend fun unsafeTryComplete(a: A): Either<AlreadyFulfilled, Unit> =
+    when (val current = state.value) {
+      is Complete -> AlreadyFulfilled.left
+      is Error -> AlreadyFulfilled.left
+      is Pending -> {
+        if (state.compareAndSet(current, Complete(a))) {
+          val joiners = current.joiners.values
+          if (joiners.isNotEmpty()) {
+            joiners.callAll(Result.success(a))
+          }
+          Either.Right(Unit)
+        } else unsafeTryComplete(a)
+      }
+    }
+
+  private fun Iterable<(Result<A>) -> Unit>.callAll(value: Result<A>): Unit =
+    forEach { cb -> cb(value) }
+
+  @Suppress("RESULT_CLASS_WITH_NULLABLE_OPERATOR")
+  private fun unsafeRegister(cb: (Result<A>) -> Unit): Token {
+    val id = Token()
+    register(id, cb)?.let(cb)
+    return id
+  }
+
+  @Suppress("RESULT_CLASS_IN_RETURN_TYPE")
+  private tailrec fun register(id: Token, cb: (Result<A>) -> Unit): Result<A>? =
+    when (val current = state.value) {
+      is Complete -> Result.success(current.value)
+      is Pending -> {
+        val updated = Pending(current.joiners + Pair(id, cb))
+        if (state.compareAndSet(current, updated)) null
+        else register(id, cb)
+      }
+    }
+
+  private tailrec fun unregister(id: Token): Unit = when (val current = state.value) {
+    is Complete -> Unit
+    is Error -> Unit
+    is Pending -> {
+      val updated = Pending(current.joiners - id)
+      if (state.compareAndSet(current, updated)) Unit
+      else unregister(id)
+    }
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Race2.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Race2.kt
@@ -1,0 +1,86 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Races the participants [fa], [fb] in parallel on the [ComputationPool].
+ * The winner of the race cancels the other participants,
+ * cancelling the operation cancels all participants.
+ *
+ * @see raceN for the same function that can race on any [CoroutineContext].
+ */
+suspend fun <A, B> raceN(fa: suspend () -> A, fb: suspend () -> B): Either<A, B> =
+  raceN(ComputationPool, fa, fb)
+
+/**
+ * Races the participants [fa], [fb] on the provided [CoroutineContext].
+ * The winner of the race cancels the other participants,
+ * cancelling the operation cancels all participants.
+ *
+ * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see raceN for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+suspend fun <A, B> raceN(ctx: CoroutineContext, fa: suspend () -> A, fb: suspend () -> B): Either<A, B> {
+  fun <T, U> onSuccess(
+    isActive: AtomicBooleanW,
+    main: SuspendConnection,
+    other: SuspendConnection,
+    cb: (Result<Either<T, U>>) -> Unit,
+    r: Either<T, U>
+  ): Unit =
+    if (isActive.getAndSet(false)) {
+      other.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r2 ->
+        main.pop()
+        r2.fold({
+          cb(Result.success(r))
+        }, { e ->
+          cb(Result.failure(e))
+        })
+      })
+    } else Unit
+
+  fun onError(
+    active: AtomicBooleanW,
+    cb: (Result<Nothing>) -> Unit,
+    main: SuspendConnection,
+    other: SuspendConnection,
+    err: Throwable
+  ): Unit =
+    if (active.getAndSet(false)) {
+      other.cancelToken().cancel.startCoroutine(Continuation(ComputationPool) { r2: Result<Unit> ->
+        main.pop()
+        cb(Result.failure(r2.fold({ err }, { Platform.composeErrors(err, it) })))
+      })
+    } else Unit
+
+  return suspendCoroutine { cont ->
+    val conn = cont.context.connection()
+    val active = AtomicBooleanW(true)
+    val connA = SuspendConnection()
+    val connB = SuspendConnection()
+    conn.pushPair(connA, connB)
+
+    fa.startCoroutineCancellable(CancellableContinuation(ctx, connA) { result ->
+      result.fold({
+        onSuccess(active, conn, connB, cont::resumeWith, Either.Left(it))
+      }, {
+        onError(active, cont::resumeWith, conn, connB, it)
+      })
+    })
+
+    fb.startCoroutineCancellable(CancellableContinuation(ctx, connB) { result ->
+      result.fold({
+        onSuccess(active, conn, connA, cont::resumeWith, Either.Right(it))
+      }, {
+        onError(active, cont::resumeWith, conn, connA, it)
+      })
+    })
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Race3.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Race3.kt
@@ -1,0 +1,140 @@
+package arrow.fx.coroutines
+
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.coroutines.suspendCoroutine
+
+sealed class Race3<out A, out B, out C> {
+  data class First<A>(val winner: A) : Race3<A, Nothing, Nothing>()
+  data class Second<B>(val winner: B) : Race3<Nothing, B, Nothing>()
+  data class Third<C>(val winner: C) : Race3<Nothing, Nothing, C>()
+
+  inline fun <D> fold(
+    ifA: (A) -> D,
+    ifB: (B) -> D,
+    ifC: (C) -> D
+  ): D = when (this) {
+    is First -> ifA(winner)
+    is Second -> ifB(winner)
+    is Third -> ifC(winner)
+  }
+}
+
+/**
+ * Races the participants [fa], [fb] & [fc] in parallel on the [ComputationPool].
+ * The winner of the race cancels the other participants,
+ * cancelling the operation cancels all participants.
+ *
+ * @see raceN for the same function that can race on any [CoroutineContext].
+ */
+suspend fun <A, B, C> raceN(
+  fa: suspend () -> A,
+  fb: suspend () -> B,
+  fc: suspend () -> C
+): Race3<A, B, C> = raceN(ComputationPool, fa, fb, fc)
+
+/**
+ * Races the participants [fa], [fb] & [fc] on the provided [CoroutineContext].
+ * The winner of the race cancels the other participants,
+ * cancelling the operation cancels all participants.
+ *
+ * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see raceN for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+suspend fun <A, B, C> raceN(
+  ctx: CoroutineContext,
+  fa: suspend () -> A,
+  fb: suspend () -> B,
+  fc: suspend () -> C
+): Race3<A, B, C> {
+  fun onSuccess(
+    isActive: AtomicBooleanW,
+    main: SuspendConnection,
+    other2: SuspendConnection,
+    other3: SuspendConnection,
+    cb: (Result<Race3<A, B, C>>) -> Unit,
+    r: Race3<A, B, C>
+  ): Unit = if (isActive.getAndSet(false)) {
+    other2.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r2 ->
+      other3.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r3 ->
+        main.pop()
+        r2.fold({
+          r3.fold({ cb(Result.success(r)) }, { e -> cb(Result.failure(e)) })
+        }, { e ->
+          r3.fold({ cb(Result.failure(e)) }, { e2 -> cb(Result.failure(Platform.composeErrors(e, e2))) })
+        })
+      })
+    })
+  } else Unit
+
+  fun onError(
+    active: AtomicBooleanW,
+    cb: (Result<Nothing>) -> Unit,
+    main: SuspendConnection,
+    other2: SuspendConnection,
+    other3: SuspendConnection,
+    err: Throwable
+  ): Unit = if (active.getAndSet(false)) {
+    other2.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r2 ->
+      other3.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r3 ->
+        main.pop()
+        cb(
+          Result.failure(
+            r2.fold({
+              r3.fold({
+                err
+              }, { err3 ->
+                Platform.composeErrors(err, err3)
+              })
+            }, { err2 ->
+              r3.fold({
+                Platform.composeErrors(err, err2)
+              }, { err3 ->
+                Platform.composeErrors(err, err2, err3)
+              })
+            })
+          )
+        )
+      })
+    })
+  } else Unit
+
+  return suspendCoroutine { cont ->
+    val conn = cont.context.connection()
+
+    val active = AtomicBooleanW(true)
+    val connA = SuspendConnection()
+    val connB = SuspendConnection()
+    val connC = SuspendConnection()
+
+    conn.push(listOf(connA.cancelToken(), connB.cancelToken(), connC.cancelToken()))
+
+    fa.startCoroutineCancellable(CancellableContinuation(ctx, connA) { result ->
+      result.fold({
+        onSuccess(active, conn, connB, connC, cont::resumeWith, Race3.First(it))
+      }, {
+        onError(active, cont::resumeWith, conn, connB, connC, it)
+      })
+    })
+
+    fb.startCoroutineCancellable(CancellableContinuation(ctx, connB) { result ->
+      result.fold({
+        onSuccess(active, conn, connA, connC, cont::resumeWith, Race3.Second(it))
+      }, {
+        onError(active, cont::resumeWith, conn, connA, connC, it)
+      })
+    })
+
+    fc.startCoroutineCancellable(CancellableContinuation(ctx, connC) { result ->
+      result.fold({
+        onSuccess(active, conn, connA, connB, cont::resumeWith, Race3.Third(it))
+      }, {
+        onError(active, cont::resumeWith, conn, connA, connB, it)
+      })
+    })
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RacePair.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RacePair.kt
@@ -1,0 +1,99 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.coroutines.suspendCoroutine
+
+typealias RacePair<A, B> = Either<Pair<A, Fiber<B>>, Pair<Fiber<A>, B>>
+
+suspend fun <A, B> racePair(fa: suspend () -> A, fb: suspend () -> B): RacePair<A, B> =
+  racePair(ComputationPool, fa, fb)
+
+/**
+ * Race two tasks concurrently within a new suspend fun.
+ * Race results in a winner and the other, yet to finish task running in a [Fiber].
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   //sampleStart
+ *   val res = racePair({ never<Int>() }, { "Hello World!" })
+ *   val r = when(res) {
+ *     is Either.Left -> "never cannot win race"
+ *     is Either.Right -> res.b
+ *   }
+ *   //sampleEnd
+ *   println("Race winner result is: $r")
+ * }
+ * ```
+ *
+ * @param ctx [CoroutineContext] to execute the source [fa] & [fb] on.
+ * @param fa task to participate in the race
+ * @param fb task to participate in the race
+ * @return either [Either.Left] with product of the winner's result [ƒa] and still running task [fb],
+ *   or [Either.Right] with product of running task [ƒa] and the winner's result [fb].
+ *
+ * @see [arrow.fx.coroutines.raceN] for a simpler version that cancels loser.
+ */
+suspend fun <A, B> racePair(
+  ctx: CoroutineContext,
+  fa: suspend () -> A,
+  fb: suspend () -> B
+): RacePair<A, B> = suspendCoroutine { cont ->
+  val conn = cont.context.connection()
+  val active = AtomicBooleanW(true)
+
+  // Cancellable connection for the left value
+  val connA = SuspendConnection()
+  val promiseA = UnsafePromise<A>()
+
+  // Cancellable connection for the right value
+  val connB = SuspendConnection()
+  val promiseB = UnsafePromise<B>()
+
+  conn.pushPair(connA, connB)
+
+  fa.startCoroutineCancellable(CancellableContinuation(ctx, connA) { result ->
+    result.fold({ a ->
+      if (active.getAndSet(false)) {
+        conn.pop()
+        cont.resumeWith(Result.success(Either.Left(Pair(a, Fiber(promiseB, connB)))))
+      } else {
+        promiseA.complete(Result.success(a))
+      }
+    }, { error ->
+      if (active.getAndSet(false)) { // if an error finishes first, stop the race.
+        connB.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r2 ->
+          conn.pop()
+          cont.resumeWith(Result.failure(r2.fold({ error }, { Platform.composeErrors(error, it) })))
+        })
+      } else {
+        promiseA.complete(Result.failure(error))
+      }
+    })
+  })
+
+  fb.startCoroutineCancellable(CancellableContinuation(ctx, connB) { result ->
+    result.fold({ b ->
+      if (active.getAndSet(false)) {
+        conn.pop()
+        cont.resumeWith(Result.success(Either.Right(Pair(Fiber(promiseA, connA), b))))
+      } else {
+        promiseB.complete(Result.success(b))
+      }
+    }, { error ->
+      if (active.getAndSet(false)) { // if an error finishes first, stop the race.
+        connA.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r2 ->
+          conn.pop()
+          cont.resumeWith(Result.failure(r2.fold({ error }, { Platform.composeErrors(error, it) })))
+        })
+      } else {
+        promiseB.complete(Result.failure(error))
+      }
+    })
+  })
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RaceTriple.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RaceTriple.kt
@@ -1,0 +1,138 @@
+package arrow.fx.coroutines
+
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.coroutines.suspendCoroutine
+
+sealed class RaceTriple<A, B, C> {
+  data class First<A, B, C>(val winner: A, val fiberB: Fiber<B>, val fiberC: Fiber<C>) : RaceTriple<A, B, C>()
+  data class Second<A, B, C>(val fiberA: Fiber<A>, val winner: B, val fiberC: Fiber<C>) : RaceTriple<A, B, C>()
+  data class Third<A, B, C>(val fiberA: Fiber<A>, val fiberB: Fiber<B>, val winner: C) : RaceTriple<A, B, C>()
+
+  inline fun <D> fold(
+    ifA: (A, Fiber<B>, Fiber<C>) -> D,
+    ifB: (Fiber<A>, B, Fiber<C>) -> D,
+    ifC: (Fiber<A>, Fiber<B>, C) -> D
+  ): D = when (this) {
+    is First -> ifA(winner, fiberB, fiberC)
+    is Second -> ifB(fiberA, winner, fiberC)
+    is Third -> ifC(fiberA, fiberB, winner)
+  }
+}
+
+suspend fun <A, B, C> raceTriple(fa: suspend () -> A, fb: suspend () -> B, fc: suspend () -> C): RaceTriple<A, B, C> =
+  raceTriple(ComputationPool, fa, fb, fc)
+
+/**
+ * Race two tasks concurrently within a new suspend fun.
+ * Race results in a winner and the other, yet to finish task running in a [Fiber].
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   //sampleStart
+ *   val res = raceTriple({ never<Int>() }, { never<Int>() }, { "Hello World!" })
+ *   val r = when(res) {
+ *     is RaceTriple.First -> "never cannot win race"
+ *     is RaceTriple.Second -> "never cannot win race"
+ *     is RaceTriple.Third -> res.winner
+ *   }
+ *   //sampleEnd
+ *   println("Race winner result is: $r")
+ * }
+ * ```
+ *
+ * @param ctx [CoroutineContext] to execute the source [fa], [fb] & [fc] on.
+ * @param fa task to participate in the race
+ * @param fb task to participate in the race
+ * @param fc task to participate in the race
+ * @return either [RaceTriple.First] with product of the winner's result [ƒa] and still running tasks [fb] & [fc],
+ *   or [RaceTriple.Second] with product of running tasks [ƒa] & [fc]  and the winner's result [fb],
+ *   or [RaceTriple.Third] with product of running tasks [ƒa] & [fb]  and the winner's result [fc].
+ *
+ * @see [arrow.fx.coroutines.raceN] for a simpler version that cancels loser.
+ */
+suspend fun <A, B, C> raceTriple(
+  ctx: CoroutineContext,
+  fa: suspend () -> A,
+  fb: suspend () -> B,
+  fc: suspend () -> C
+): RaceTriple<A, B, C> = suspendCoroutine { cont ->
+  val conn = cont.context.connection()
+  val active = AtomicBooleanW(true)
+
+  // Cancellable connection for the left value
+  val connA = SuspendConnection()
+  val promiseA = UnsafePromise<A>()
+
+  // Cancellable connection for the right value
+  val connB = SuspendConnection()
+  val promiseB = UnsafePromise<B>()
+
+  // Cancellable connection for the right value
+  val connC = SuspendConnection()
+  val promiseC = UnsafePromise<C>()
+
+  conn.push(listOf(connA.cancelToken(), connB.cancelToken(), connC.cancelToken()))
+
+  fun <A> onError(
+    error: Throwable,
+    connB: SuspendConnection,
+    connC: SuspendConnection,
+    promise: UnsafePromise<A>
+  ): Unit {
+    if (active.getAndSet(false)) { // if an error finishes first, stop the race.
+      connB.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r2 ->
+        connC.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r3 ->
+          conn.pop()
+
+          val errorResult = r2.fold({
+            r3.fold({ error }, { e3 -> Platform.composeErrors(error, e3) })
+          }, { e2 ->
+            r3.fold({ Platform.composeErrors(error, e2) }, { e3 -> Platform.composeErrors(error, e2, e3) })
+          })
+
+          cont.resumeWith(Result.failure(errorResult))
+        })
+      })
+    } else {
+      promise.complete(Result.failure(error))
+    }
+  }
+
+  fa.startCoroutineCancellable(CancellableContinuation(ctx, connA) { result ->
+    result.fold({ a ->
+      if (active.getAndSet(false)) {
+        conn.pop()
+        cont.resumeWith(Result.success(RaceTriple.First(a, Fiber(promiseB, connB), Fiber(promiseC, connC))))
+      } else {
+        promiseA.complete(Result.success(a))
+      }
+    }, { error -> onError(error, connB, connC, promiseA) })
+  })
+
+  fb.startCoroutineCancellable(CancellableContinuation(ctx, connB) { result ->
+    result.fold({ b ->
+      if (active.getAndSet(false)) {
+        conn.pop()
+        cont.resumeWith(Result.success(RaceTriple.Second(Fiber(promiseA, connA), b, Fiber(promiseC, connC))))
+      } else {
+        promiseB.complete(Result.success(b))
+      }
+    }, { error -> onError(error, connA, connC, promiseB) })
+  })
+
+  fc.startCoroutineCancellable(CancellableContinuation(ctx, connC) { result ->
+    result.fold({ c ->
+      if (active.getAndSet(false)) {
+        conn.pop()
+        cont.resumeWith(Result.success(RaceTriple.Third(Fiber(promiseA, connA), Fiber(promiseB, connB), c)))
+      } else {
+        promiseC.complete(Result.success(c))
+      }
+    }, { error -> onError(error, connA, connB, promiseC) })
+  })
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Resource.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Resource.kt
@@ -1,0 +1,314 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+
+/**
+ * [Resource] models resource allocation and releasing. It is especially useful when multiple resources that depend on each other
+ *  need to be acquired and later released in reverse order.
+ *
+ * When a resource is created one can make use of [use] to run a computation with the resource. The finalizers are then
+ *  guaranteed to run afterwards in reverse order of acquisition.
+ *
+ * Consider the following use case:
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * object Consumer
+ * object Handle
+ *
+ * class Service(val handle: Handle, val consumer: Consumer)
+ *
+ * suspend fun createConsumer(): Consumer = Consumer.also { println("Creating consumer") }
+ * suspend fun createDBHandle(): Handle = Handle.also { println("Creating db handle") }
+ * suspend fun createFancyService(consumer: Consumer, handle: Handle): Service =
+ *   Service(handle, consumer).also { println("Creating service") }
+ *
+ * suspend fun closeConsumer(consumer: Consumer): Unit = println("Closed consumer")
+ * suspend fun closeDBHandle(handle: Handle): Unit = println("Closed db handle")
+ * suspend fun shutDownFancyService(service: Service): Unit = println("Closed service")
+ *
+ * //sampleStart
+ * val program = suspend {
+ *   val consumer = createConsumer()
+ *   val handle = createDBHandle()
+ *   val service = createFancyService(consumer, handle)
+ *
+ *   // use service
+ *   // <...>
+ *
+ *   // we are done, now onto releasing resources
+ *   shutDownFancyService(service)
+ *   closeDBHandle(handle)
+ *   closeConsumer(consumer)
+ * }
+ * // sampleEnd
+ * suspend fun main(): Unit = program.invoke()
+ * ```
+ * Here we are creating and then using a service that has a dependency on two resources: A database handle and a consumer of some sort. All three resources need to be closed in the correct order at the end.
+ * However this program is quite bad! It does not guarantee release if something failed in between and keeping track of acquisition order is unnecessary overhead.
+ *
+ * That is where `Resource` comes in:
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * object Consumer
+ * object Handle
+ *
+ * class Service(val handle: Handle, val consumer: Consumer)
+ *
+ * suspend fun createConsumer(): Consumer = Consumer.also { println("Creating consumer") }
+ * suspend fun createDBHandle(): Handle = Handle.also { println("Creating db handle") }
+ * suspend fun createFancyService(consumer: Consumer, handle: Handle): Service =
+ *   Service(handle, consumer).also { println("Creating service") }
+ *
+ * suspend fun closeConsumer(consumer: Consumer): Unit = println("Closed consumer")
+ * suspend fun closeDBHandle(handle: Handle): Unit = println("Closed db handle")
+ * suspend fun shutDownFancyService(service: Service): Unit = println("Closed service")
+ *
+ * //sampleStart
+ * val resourceProgram = suspend {
+ *   Resource(::createConsumer, ::closeConsumer)
+ *     .zip(Resource(::createDBHandle, ::closeDBHandle))
+ *     .flatMap { (consumer, handle) ->
+ *       Resource({ createFancyService(consumer, handle) }, { service -> shutDownFancyService(service) })
+ *     }.use { service ->
+ *       // use service
+ *       // <...>
+ *       Unit
+ *     }
+ * }
+ * // sampleEnd
+ *
+ * suspend fun main(): Unit = resourceProgram.invoke()
+ * ```
+ *
+ * All three programs do exactly the same with varying levels of simplicity and overhead. `Resource` uses `Bracket` under the hood but provides a nicer monadic interface for creating and releasing resources in order, whereas bracket is great for one-off acquisitions but becomes more complex with nested resources.
+ **/
+sealed class Resource<out A> {
+
+  /**
+   * Use the created resource
+   * When done will run all finalizers
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun acquireResource(): Int = 42.also { println("Getting expensive resource") }
+   * suspend fun releaseResource(r: Int): Unit = println("Releasing expensive resource: $r")
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   Resource(::acquireResource, ::releaseResource)
+   *     .use { println("Expensive resource under use! $it") }
+   *   //sampleEnd
+   * }
+   * ```
+   */
+  @Suppress("UNCHECKED_CAST")
+  suspend infix fun <B> use(f: suspend (A) -> B): B =
+    useLoop(this as Resource<Any?>, f as suspend (Any?) -> Any?, emptyList()) as B
+
+  fun <B> map(f: (A) -> B): Resource<B> =
+    flatMap { a -> just(f(a)) }
+
+  fun <B> ap(ff: Resource<(A) -> B>): Resource<B> =
+    flatMap { res -> ff.map { it(res) } }
+
+  /**
+   * Create a new resource [B] from a resource [A] by mapping [f].
+   *
+   * This is useful when you need to create a resource that depends on other resources.
+   *
+   * ```kotlin:ank
+   * import arrow.fx.coroutines.*
+   *
+   * object Consumer
+   * object DBHandle
+   * data class DatabaseConsumer(val db: DBHandle, val consumer: Consumer)
+   *
+   * fun consumer(): Resource<Consumer> = Resource({ Consumer }, { _ -> println("Closed consumer") })
+   * fun dhHandle(): Resource<DBHandle> = Resource({ DBHandle }, { _ -> println("Closed db handle") })
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   consumer()
+   *     .zip(dhHandle())
+   *     .flatMap { (consumer, dbHandle) ->
+   *       Resource(
+   *         { DatabaseConsumer(dbHandle, consumer) },
+   *         { _ -> println("Closed DatabaseConsumer") }
+   *       )
+   *     }.use { println("Expensive resource under use! $it") }
+   *   //sampleEnd
+   * }
+   * ```
+   */
+  fun <B> flatMap(f: (A) -> Resource<B>): Resource<B> =
+    Bind(this, f)
+
+  fun <B, C> map2(other: Resource<B>, combine: (A, B) -> C): Resource<C> =
+    flatMap { r ->
+      other.map { r2 -> combine(r, r2) }
+    }
+
+  fun <B> zip(other: Resource<B>): Resource<Pair<A, B>> =
+    map2(other, ::Pair)
+
+  internal class Bind<A, B>(val source: Resource<A>, val f: (A) -> Resource<B>) : Resource<B>()
+
+  internal class Allocate<A>(
+    val acquire: suspend () -> A,
+    val release: suspend (A, ExitCase) -> Unit
+  ) : Resource<A>()
+
+  internal class Defer<A>(val resource: suspend () -> Resource<A>) : Resource<A>()
+
+  companion object {
+    /**
+     * Construct a [Resource] from a allocating function [acquire] and a release function [release].
+     *
+     * ```kotlin:ank:playground
+     * import arrow.fx.coroutines.*
+     *
+     * suspend fun acquireResource(): Int = 42.also { println("Getting expensive resource") }
+     * suspend fun releaseResource(r: Int): Unit = println("Releasing expensive resource: $r")
+     *
+     * suspend fun main(): Unit {
+     *   //sampleStart
+     *   val resource = Resource(::acquireResource, ::releaseResource)
+     *   resource.use {
+     *     println("Expensive resource under use! $it")
+     *   }
+     *   //sampleEnd
+     * }
+     * ```
+     */
+    operator fun <A> invoke(
+      acquire: suspend () -> A,
+      release: suspend (A, ExitCase) -> Unit
+    ): Resource<A> = Allocate(acquire, release)
+
+    /**
+     * Construct a [Resource] from a allocating function [acquire] and a release function [release].
+     *
+     * @see [use] For a version that provides an [ExitCase] to [release]
+     */
+    operator fun <A> invoke(
+      acquire: suspend () -> A,
+      release: suspend (A) -> Unit
+    ): Resource<A> = invoke(acquire, { r, _ -> release(r) })
+
+    /**
+     * Create a [Resource] from a pure value [A].
+     */
+    fun <A> just(r: A): Resource<A> =
+      Resource({ r }, { _, _ -> Unit })
+
+    fun <A> defer(f: suspend () -> Resource<A>): Resource<A> =
+      Resource.Defer(f)
+
+    @Suppress("UNCHECKED_CAST")
+    fun <A, B> tailRecM(a: A, f: (A) -> Resource<Either<A, B>>): Resource<B> {
+      fun loop(r: Resource<Either<A, B>>): Resource<B> = when (r) {
+        is Bind<*, *> -> Bind(
+          r.source as Resource<A>,
+          (r.f as (A) -> Resource<Either<A, B>>).andThen(::loop)
+        )
+        is Allocate -> Defer {
+          val res = r.acquire.invoke()
+          when (res) {
+            is Either.Left -> {
+              r.release(res, ExitCase.Completed)
+              tailRecM(res.a, f)
+            }
+            is Either.Right -> Allocate({ res.b }, { _, ec -> r.release(res, ec) })
+          }
+        }
+        is Defer -> Defer { loop(r.resource.invoke()) }
+      }
+
+      return loop(f(a))
+    }
+  }
+
+  private suspend fun continueLoop(
+    current: Resource<Any?>,
+    use: suspend (Any?) -> Any?,
+    stack: List<(Any?) -> Resource<Any?>>
+  ): Any? = useLoop(current, use, stack)
+
+  // Interpreter that knows how to evaluate a Resource data structure
+  // Maintains its own stack for dealing with Bind chains
+  @Suppress("UNCHECKED_CAST")
+  private tailrec suspend fun useLoop(
+    current: Resource<Any?>,
+    use: suspend (Any?) -> Any?,
+    stack: List<(Any?) -> Resource<Any?>>
+  ): Any? =
+    when (current) {
+      is Defer -> useLoop(current.resource.invoke(), use, stack)
+      is Bind<*, *> ->
+        useLoop(current.source as Resource<Any?>, use, listOf(current.f as (Any?) -> Resource<Any?>) + stack)
+      is Allocate -> bracketCase(
+        acquire = current.acquire,
+        use = { a ->
+          when {
+            stack.isEmpty() -> use(a)
+            else -> continueLoop(stack.first()(a), use, stack.drop(1))
+          }
+        },
+        release = { a, exitCase -> current.release(a, exitCase) }
+      )
+    }
+}
+
+/**
+ * Marker for `suspend () -> A` to be marked as the [Use] action of a [Resource].
+ * Offers a convenient DSL to use [Resource] for simple resources.
+ *
+ * ```kotlin:ank
+ * import arrow.fx.coroutines.*
+ *
+ * class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ * }
+ *
+ * suspend fun openFile(uri: String): File = File(uri).open()
+ * suspend fun closeFile(file: File): Unit = file.close()
+ * suspend fun fileToString(file: File): String = file.toString()
+ *
+ * suspend fun main(): Unit {
+ *   val res = resource {
+ *     openFile("data.json")
+ *   } release { file ->
+ *     closeFile(file)
+ *   } use { file ->
+ *     fileToString(file)
+ *   }
+ *
+ *   println(res)
+ * }
+ * ```
+ */
+inline class Use<A>(internal val acquire: suspend () -> A)
+
+/**
+ * Marks an [acquire] operation as the [Resource.use] step of a [Resource].
+ */
+fun <A> resource(acquire: suspend () -> A): Use<A> = Use(acquire)
+
+/**
+ * Composes a [release] action to a [Resource.use] action creating a [Resource].
+ */
+infix fun <A> Use<A>.release(release: suspend (A) -> Unit): Resource<A> =
+  Resource(acquire, release)
+
+/**
+ * Composes a [releaseCase] action to a [Resource.use] action creating a [Resource].
+ */
+infix fun <A> Use<A>.releaseCase(release: suspend (A, ExitCase) -> Unit): Resource<A> =
+  Resource(acquire, release)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Schedule.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Schedule.kt
@@ -1,0 +1,831 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.left
+import arrow.core.right
+import arrow.fx.coroutines.Schedule.ScheduleImpl
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+import kotlin.random.Random
+
+/**
+ * # Retrying and repeating effects
+ *
+ * A common demand when working with effects is to retry or repeat them when certain circumstances happen. Usually, the retrial or repetition does not happen right away; rather, it is done based on a policy. For instance, when fetching content from a network request, we may want to retry it when it fails, using an exponential backoff algorithm, for a maximum of 15 seconds or 5 attempts, whatever happens first.
+ *
+ * [Schedule] allows you to define and compose powerful yet simple policies, which can be used to either repeat or retry computation.
+ *
+ * The two core methods of running a schedule are:
+ * - __retry__: The effect is executed once, and if it fails, it will be reattempted based on the scheduling policy passed as an argument. It will stop if the effect ever succeeds, or the policy determines it should not be reattempted again.
+ * - __repeat__: The effect is executed once, and if it succeeds, it will be executed again based on the scheduling policy passed as an argument. It will stop if the effect ever fails, or the policy determines it should not be executed again. It will return the last internal state of the scheduling policy, or the error that happened running the effect.
+ *
+ * ## Constructing a policy:
+ *
+ * Constructing a simple schedule which recurs 10 times until it succeeds:
+ * ```kotlin:ank
+ * import arrow.fx.coroutines.*
+ *
+ * fun <A> recurTenTimes() = Schedule.recurs<A>(10)
+ * ```
+ *
+ * A more complex schedule
+ *
+ * ```kotlin:ank
+ * import arrow.fx.coroutines.*
+ *
+ * fun <A> complexPolicy(): Schedule<A, List<A>> =
+ *   Schedule.exponential<A>(10.milliseconds).whileOutput { it.nanoseconds < 60.seconds.nanoseconds }
+ *     .andThen(Schedule.spaced<A>(60.seconds) and Schedule.recurs(100)).jittered()
+ *     .zipRight(Schedule.identity<A>().collect())
+ * ```
+ *
+ * This policy will recur with exponential backoff as long as the delay is less than 60 seconds and then continue with a spaced delay of 60 seconds.
+ * The delay is also randomized slightly to avoid coordinated backoff from multiple services.
+ * Finally we also collect every input to the schedule and return it. When used with [retry] this will return a list of exceptions that occured on failed attempts.
+ *
+ * ## Common use cases
+ *
+ * Common use cases
+ * Once we have building blocks and ways to combine them, let’s see how we can use them to solve some use cases.
+ *
+ * ### Repeating an effect and dealing with its result
+ *
+ * When we repeat an effect, we do it as long as it keeps providing successful results and the scheduling policy tells us to keep recursing. But then, there is a question on what to do with the results provided by each iteration of the repetition.
+ *
+ * There are at least 3 possible things we would like to do:
+ *
+ * - Discard all results; i.e., return `Unit`.
+ * - Discard all intermediate results and just keep the last produced result.
+ * - Keep all intermediate results.
+ *
+ * Assuming we have an suspend effect in, and we want to repeat it 3 times after its first successful execution, we can do:
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   var counter = 0
+ *   //sampleStart
+ *   val res = repeat(Schedule.recurs(3)) {
+ *     println("Run: ${counter++}")
+ *   }
+ *   //sampleEnd
+ *   println(res)
+ * }
+ * ```
+ *
+ * However, when running this new effect, its output will be the number of iterations it has performed, as stated in the documentation of the function. Also notice that we did not handle the error case, there are overloads [repeatOrElse] and [repeatOrElseEither] which offer that capability, [repeat] will just rethrow any error encountered.
+ *
+ * If we want to discard the values provided by the repetition of the effect, we can combine our policy with [Schedule.unit], using the [zipLeft] or [zipRight] combinators, which will keep just the output of one of the policies:
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   var counter = 0
+ *   //sampleStart
+ *   val res = repeat(Schedule.unit<Unit>() zipLeft Schedule.recurs(3)) {
+ *     println("Run: ${counter++}")
+ *   }
+ *   // equal to
+ *   val res2 = repeat(Schedule.recurs<Unit>(3) zipRight Schedule.unit()) {
+ *     println("Run: ${counter++}")
+ *   }
+ *   //sampleEnd
+ *   println(res)
+ *   println(res2)
+ * }
+ * ```
+ *
+ * Following the same strategy, we can zip it with the [Schedule.identity] policy to keep only the last provided result by the effect.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   var counter = 0
+ *   //sampleStart
+ *   val res = repeat(Schedule.identity<Int>() zipLeft Schedule.recurs(3)) {
+ *     println("Run: ${counter++}"); counter
+ *   }
+ *   // equal to
+ *   val res2 = repeat(Schedule.recurs<Int>(3) zipRight Schedule.identity<Int>()) {
+ *     println("Run: ${counter++}"); counter
+ *   }
+ *   //sampleEnd
+ *   println(res)
+ *   println(res2)
+ * }
+ * ```
+ *
+ * Finally, if we want to keep all intermediate results, we can zip the policy with [Schedule.collect]:
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   var counter = 0
+ *   //sampleStart
+ *   val res = repeat(Schedule.collect<Int>() zipLeft Schedule.recurs(3)) {
+ *     println("Run: ${counter++}")
+ *     counter
+ *   }
+ *   // equal to
+ *   val res2 = repeat(Schedule.recurs<Int>(3) zipRight Schedule.collect<Int>()) {
+ *     println("Run: ${counter++}")
+ *     counter
+ *   }
+ *   //sampleEnd
+ *   println(res)
+ *   println(res2)
+ * }
+ * ```
+ *
+ * ## Repeating an effect until/while it produces a certain value
+ *
+ * We can make use of the policies doWhile or doUntil to repeat an effect while or until its produced result matches a given predicate.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   var counter = 0
+ *   //sampleStart
+ *   val res = repeat(Schedule.doWhile<Int>{ it <= 3 }) {
+ *     println("Run: ${counter++}"); counter
+ *   }
+ *   //sampleEnd
+ *   println(res)
+ * }
+ * ```
+ *
+ * ## Exponential backoff retries
+ *
+ * A common algorithm to retry effectful operations, as network requests, is the exponential backoff algorithm. There is a scheduling policy that implements this algorithm and can be used as:
+ *
+ * ```kotlin:ank
+ * import arrow.fx.coroutines.*
+ *
+ * val exponential = Schedule.exponential<Unit>(250.milliseconds)
+ * ```
+ */
+sealed class Schedule<Input, Output> {
+
+  /**
+   * Change the output of a schedule. Does not alter the decision of the schedule.
+   */
+  abstract fun <B> map(f: (Output) -> B): Schedule<Input, B>
+
+  /**
+   * Change the input of the schedule. May alter a schedules decision if it is based on input.
+   */
+  abstract fun <B> contramap(f: suspend (B) -> Input): Schedule<B, Output>
+
+  /**
+   * Conditionally check on both the input and the output whether or not to continue.
+   */
+  abstract fun <A : Input> check(pred: suspend (A, Output) -> Boolean): Schedule<A, Output>
+
+  /**
+   * Invert the decision of a schedule.
+   */
+  abstract operator fun not(): Schedule<Input, Output>
+
+  /**
+   * Combine with another schedule by combining the result and the delay of the [Decision] with the functions [f] and [g]
+   */
+  abstract fun <A : Input, B> combineWith(
+    other: Schedule<A, B>,
+    f: (Boolean, Boolean) -> Boolean,
+    g: (Duration, Duration) -> Duration
+  ): Schedule<A, Pair<Output, B>>
+
+  /**
+   * Always retry a schedule regardless of the decision made prior to invoking this method.
+   */
+  abstract fun forever(): Schedule<Input, Output>
+
+  /**
+   * Execute one schedule after the other. When the first schedule ends, it continues with the second.
+   */
+  abstract infix fun <A : Input, B> andThen(other: Schedule<A, B>): Schedule<A, Either<Output, B>>
+
+  /**
+   * Change the delay of a resulting [Decision] based on the [Output] and the produced delay.
+   */
+  abstract fun modifyDelay(f: suspend (Output, Duration) -> Duration): Schedule<Input, Output>
+
+  /**
+   * Run a effectful handler on every input. Does not alter the decision.
+   */
+  abstract fun logInput(f: suspend (Input) -> Unit): Schedule<Input, Output>
+
+  /**
+   * Run a effectful handler on every output. Does not alter the decision.
+   */
+  abstract fun logOutput(f: suspend (Output) -> Unit): Schedule<Input, Output>
+
+  /**
+   * Accumulate the results of a schedule by folding over them effectfully.
+   */
+  abstract fun <C> foldM(
+    initial: suspend () -> C,
+    f: suspend (C, Output) -> C
+  ): Schedule<Input, C>
+
+  /**
+   * Compose this schedule with the other schedule by piping the output of this schedule
+   *  into the input of the other.
+   */
+  abstract infix fun <B> pipe(other: Schedule<Output, B>): Schedule<Input, B>
+
+  /**
+   * Combine two with different input and output using and. Continues when both continue and uses the maximum delay.
+   */
+  abstract infix fun <A, B> tupled(other: Schedule<A, B>): Schedule<Pair<Input, A>, Pair<Output, B>>
+
+  /**
+   * Combine two schedules with different input and output and conditionally choose between the two.
+   * Continues when the chosen schedule continues and uses the chosen schedules delay.
+   */
+  abstract infix fun <A, B> choose(other: Schedule<A, B>): Schedule<Either<Input, A>, Either<Output, B>>
+
+  fun unit(): Schedule<Input, Unit> =
+    map { Unit }
+
+  /**
+   * Change the result of a [Schedule] to always be [b]
+   */
+  fun <B> const(b: B): Schedule<Input, B> = map { b }
+
+  /**
+   * Continue or stop the schedule based on the output
+   */
+  fun whileOutput(f: suspend (Output) -> Boolean): Schedule<Input, Output> =
+    check { _, output -> f(output) }
+
+  /**
+   * Continue or stop the schedule based on the input
+   */
+  fun <A : Input> whileInput(f: suspend (A) -> Boolean): Schedule<A, Output> =
+    check { input, _ -> f(input) }
+
+  /**
+   * `untilOutput(f) = whileOutput(f).not()`
+   */
+  fun untilOutput(f: suspend (Output) -> Boolean): Schedule<Input, Output> =
+    !whileOutput(f)
+
+  /**
+   * `untilInput(f) = whileInput(f).not()`
+   */
+  fun <A : Input> untilInput(f: suspend (A) -> Boolean): Schedule<A, Output> =
+    !whileInput(f)
+
+  fun <B, C> dimap(f: suspend (B) -> Input, g: (Output) -> C): Schedule<B, C> =
+    contramap(f).map(g)
+
+  /**
+   * Combine two schedules. Continues only when both continue and chooses the maximum delay.
+   */
+  infix fun <A : Input, B> and(other: Schedule<A, B>): Schedule<A, Pair<Output, B>> =
+    combineWith(other, { a, b -> a && b }, { a, b -> max(a.nanoseconds, b.nanoseconds).nanoseconds })
+
+  /**
+   * Combine two schedules. Continues if one continues and chooses the minimum delay
+   */
+  infix fun <A : Input, B> or(other: Schedule<A, B>): Schedule<A, Pair<Output, B>> =
+    combineWith(other, { a, b -> a || b }, { a, b -> min(a.nanoseconds, b.nanoseconds).nanoseconds })
+
+  /**
+   * Combine two schedules with [and] but throw away the left schedule's result
+   */
+  infix fun <A : Input, B> zipRight(other: Schedule<A, B>): Schedule<A, B> =
+    (this and other).map { it.second }
+
+  /**
+   * Combine two schedules with [and] but throw away the right schedule's result
+   */
+  infix fun <A : Input, B> zipLeft(other: Schedule<A, B>): Schedule<A, Output> =
+    (this and other).map { it.first }
+
+  /**
+   * Adjust the delay of a schedule's [Decision]
+   */
+  fun delayed(f: suspend (Duration) -> Duration): Schedule<Input, Output> =
+    modifyDelay { _, duration -> f(duration) }
+
+  /**
+   * Add random jitter to a schedule.
+   * The argument [genRand] is supposed to be a computation with when run returns
+   *  doubles. An example would be the following [IO] `IO { Random.nextDouble() }`.
+   *
+   * This is done to push the source of randomness to the caller which makes the function
+   *  jittered deterministic and testable.
+   *
+   * The result returned by [genRand] is multiplied with the current duration.
+   */
+  fun jittered(genRand: suspend () -> Double): Schedule<Input, Output> =
+    modifyDelay { _, duration ->
+      val n = genRand.invoke()
+      (duration.nanoseconds * n).roundToLong().nanoseconds
+    }
+
+  fun jittered(): Schedule<Input, Output> =
+    jittered(suspend { Random.nextDouble(0.0, 1.0) })
+
+  /**
+   * Non-effectful version of [foldM].
+   */
+  fun <C> fold(initial: C, f: suspend (C, Output) -> C): Schedule<Input, C> =
+    foldM(suspend { initial }) { acc, o -> f(acc, o) }
+
+  /**
+   * Accumulate the results of every execution to a list
+   */
+  fun collect(): Schedule<Input, List<Output>> =
+    fold(emptyList()) { acc, o -> acc + listOf(o) }
+
+  /**
+   * Infix variant of pipe with reversed order.
+   */
+  infix fun <B> compose(other: Schedule<B, Input>): Schedule<B, Output> =
+    (other pipe this)
+
+  // Dependent type emulation
+  @Suppress("UNCHECKED_CAST")
+  internal class ScheduleImpl<State, Input, Output>(
+    val initialState: suspend () -> State,
+    val update: suspend (a: Input, s: State) -> Decision<State, Output>
+  ) : Schedule<Input, Output>() {
+
+    override fun <B> map(f: (Output) -> B): Schedule<Input, B> =
+      ScheduleImpl(initialState) { i, s -> update(i, s).mapRight(f) }
+
+    override fun <B> contramap(f: suspend (B) -> Input): Schedule<B, Output> =
+      ScheduleImpl(initialState) { i, s -> update(f(i), s) }
+
+    override fun <A : Input> check(pred: suspend (A, Output) -> Boolean): Schedule<A, Output> =
+      updated { f ->
+        { a: A, s: State ->
+          val dec = f(a, s)
+          if (dec.cont) pred(a, dec.finish.value()).let { dec.copy(cont = it) }
+          else dec
+        }
+      }
+
+    override fun <A : Input, B> combineWith(
+      other: Schedule<A, B>,
+      f: (Boolean, Boolean) -> Boolean,
+      g: (Duration, Duration) -> Duration
+    ): Schedule<A, Pair<Output, B>> = (other as ScheduleImpl<Any?, A, B>).let { other ->
+      ScheduleImpl(suspend { Pair(initialState.invoke(), other.initialState.invoke()) }) { i, s: Pair<State, Any?> ->
+        update(i, s.first).combineWith(other.update(i, s.second), f, g)
+      }
+    }
+
+    override fun forever(): Schedule<Input, Output> = updated { f ->
+      { a: Input, s: State ->
+        val dec = f(a, s)
+        if (dec.cont) dec
+        else {
+          val state = this@ScheduleImpl.initialState.invoke()
+          dec.copy(cont = true, state = state)
+        }
+      }
+    }
+
+    override operator fun not(): Schedule<Input, Output> =
+      updated { f ->
+        { a: Input, s: State ->
+          !f(a, s)
+        }
+      }
+
+    override fun <A : Input, B> andThen(other: Schedule<A, B>): Schedule<A, Either<Output, B>> =
+      ScheduleImpl<Either<State, Any?>, A, Either<Output, B>>(suspend { Either.Left(initialState.invoke()) }) { i, s ->
+        (other as ScheduleImpl<Any?, A, B>)
+        s.fold({ s ->
+          val dec = this@ScheduleImpl.update(i, s)
+          if (dec.cont) dec.bimap({ it.left() }, { it.left() })
+          else {
+            val newState = other.initialState.invoke()
+            val newDec = other.update(i, newState)
+            newDec.bimap({ it.right() }, { it.right() })
+          }
+        }, { s ->
+          other.update(i, s).bimap({ it.right() }, { it.right() })
+        })
+      }
+
+    override fun modifyDelay(f: suspend (Output, Duration) -> Duration): Schedule<Input, Output> =
+      updated { update ->
+        { a: Input, s: State ->
+          val step = update(a, s)
+          val d = f(step.finish.value(), step.delay)
+          step.copy(delay = d)
+        }
+      }
+
+    override fun logInput(f: suspend (Input) -> Unit): Schedule<Input, Output> =
+      updated { update ->
+        { a: Input, s: State ->
+          update(a, s).also { f(a) }
+        }
+      }
+
+    override fun logOutput(f: suspend (Output) -> Unit): Schedule<Input, Output> =
+      updated { update ->
+        { a: Input, s: State ->
+          update(a, s).also { f(it.finish.value()) }
+        }
+      }
+
+    override fun <C> foldM(initial: suspend () -> C, f: suspend (C, Output) -> C): Schedule<Input, C> =
+      ScheduleImpl(suspend { Pair(initialState.invoke(), initial.invoke()) }) { i, s ->
+        val dec = update(i, s.first)
+        val c = if (dec.cont) f(s.second, dec.finish.value()) else s.second
+        dec.bimap({ s -> Pair(s, c) }, { c })
+      }
+
+    override infix fun <B> pipe(other: Schedule<Output, B>): Schedule<Input, B> =
+      (other as ScheduleImpl<Any?, Output, B>).let { other ->
+        ScheduleImpl(suspend { Pair(initialState.invoke(), other.initialState.invoke()) }) { i, s ->
+          val dec1 = update(i, s.first)
+          val dec2 = other.update(dec1.finish.value(), s.second)
+          dec1.combineWith(dec2, { a, b -> a && b }, { a, b -> a + b }).mapRight { it.second }
+        }
+      }
+
+    override infix fun <A, B> tupled(other: Schedule<A, B>): Schedule<Pair<Input, A>, Pair<Output, B>> =
+      (other as ScheduleImpl<Any?, A, B>).let { other ->
+        ScheduleImpl(suspend { Pair(initialState.invoke(), other.initialState.invoke()) }) { i, s ->
+          val dec1 = update(i.first, s.first)
+          val dec2 = other.update(i.second, s.second)
+          dec1.combineWith(dec2, { a, b -> a && b }, { a, b -> max(a.nanoseconds, b.nanoseconds).nanoseconds })
+        }
+      }
+
+    override infix fun <A, B> choose(other: Schedule<A, B>): Schedule<Either<Input, A>, Either<Output, B>> =
+      (other as ScheduleImpl<Any?, A, B>).let { other ->
+        ScheduleImpl(suspend { Pair(initialState.invoke(), other.initialState.invoke()) }) { i, s ->
+          i.fold({
+            update(it, s.first).mapLeft { Pair(it, s.second) }.mapRight { it.left() }
+          }, {
+            other.update(it, s.second).mapLeft { Pair(s.first, it) }.mapRight { it.right() }
+          })
+        }
+      }
+
+    /**
+     * Schedule state machine update function
+     */
+    fun <A : Input, B> updated(
+      f: (suspend (A, State) -> Decision<State, Output>) -> (suspend (A, State) -> Decision<State, B>)
+    ): Schedule<A, B> = ScheduleImpl(initialState) { a, s ->
+      f { i, s -> update(i, s) }(a, s)
+    }
+
+    /**
+     * Inspect and change the [Decision] of a [Schedule]. Also given access to the input.
+     */
+    fun <A : Input, B> reconsider(f: suspend (A, Decision<State, Output>) -> Decision<State, B>): Schedule<A, B> =
+      updated { update ->
+        { a: A, s: State ->
+          val dec = update(a, s)
+          f(a, dec)
+        }
+      }
+
+    /**
+     * Run an effect with a [Decision]. Does not alter the decision.
+     */
+    fun <A : Input> onDecision(fa: suspend (A, Decision<State, Output>) -> Unit): Schedule<A, Output> =
+      updated { f ->
+        { a: A, s: State ->
+          f(a, s).also { fa(a, it) }
+        }
+      }
+  }
+
+  /**
+   * A single decision. Contains the decision to continue, the delay, the new state and the (lazy) result of a Schedule.
+   */
+  data class Decision<out A, out B>(val cont: Boolean, val delay: Duration, val state: A, val finish: Eval<B>) {
+
+    operator fun not(): Decision<A, B> =
+      copy(cont = !cont)
+
+    fun <C, D> bimap(f: (A) -> C, g: (B) -> D): Decision<C, D> =
+      Decision(cont, delay, f(state), finish.map(g))
+
+    fun <C> mapLeft(f: (A) -> C): Decision<C, B> =
+      bimap(f, ::identity)
+
+    fun <D> mapRight(g: (B) -> D): Decision<A, D> =
+      bimap(::identity, g)
+
+    fun <C, D> combineWith(
+      other: Decision<C, D>,
+      f: (Boolean, Boolean) -> Boolean,
+      g: (Duration, Duration) -> Duration
+    ): Decision<Pair<A, C>, Pair<B, D>> = Decision(
+      f(cont, other.cont),
+      g(delay, other.delay),
+      Pair(state, other.state),
+      finish.flatMap { first -> other.finish.map { second -> Pair(first, second) } }
+    )
+
+    override fun equals(other: Any?): Boolean =
+      if (other !is Decision<*, *>) false
+      else cont == other.cont &&
+        state == other.state &&
+        delay.nanoseconds == other.delay.nanoseconds &&
+        finish.value() == other.finish.value()
+
+    companion object {
+      fun <A, B> cont(d: Duration, a: A, b: Eval<B>): Decision<A, B> = Decision(true, d, a, b)
+      fun <A, B> done(d: Duration, a: A, b: Eval<B>): Decision<A, B> = Decision(false, d, a, b)
+    }
+  }
+
+  companion object {
+
+    /**
+     * Invoke constructor to manually define a schedule. If you need this, please consider adding it to arrow or suggest
+     *  a change to avoid using this manual method.
+     */
+    operator fun <S, A, B> invoke(
+      initial: suspend () -> S,
+      update: suspend (a: A, s: S) -> Decision<S, B>
+    ): Schedule<A, B> =
+      ScheduleImpl(initial, update)
+
+    /**
+     * Creates a schedule that continues without delay and just returns its input.
+     */
+    fun <A> identity(): Schedule<A, A> = invoke({ Unit }) { a, s ->
+      Decision.cont(0.seconds, s, Eval.now(a))
+    }
+
+    /**
+     * Creates a schedule that continues without delay and always returns Unit
+     */
+    fun <A> unit(): Schedule<A, Unit> =
+      identity<A>().unit()
+
+    /**
+     * Create a schedule that unfolds effectfully using a seed value [c] and a unfold function [f].
+     * This keeps the current state (the current seed) as [State] and runs the unfold function on every
+     *  call to update. This schedule always continues without delay and returns the current state.
+     */
+    fun <I, A> unfoldM(c: suspend () -> A, f: suspend (A) -> A): Schedule<I, A> =
+      invoke(c) { _: I, acc ->
+        val a = f(acc)
+        Decision.cont(0.seconds, a, Eval.now(a))
+      }
+
+    /**
+     * Non-effectful variant of [unfoldM]
+     */
+    fun <I, A> unfold(c: A, f: (A) -> A): Schedule<I, A> =
+      unfoldM(suspend { c }) { f(it) }
+
+    /**
+     * Create a schedule that continues forever and returns the number of iterations.
+     */
+    fun <A> forever(): Schedule<A, Int> =
+      unfold(0) { it + 1 }
+
+    /**
+     * Create a schedule that continues n times and returns the number of iterations.
+     */
+    fun <A> recurs(n: Int): Schedule<A, Int> =
+      invoke(suspend { 0 }) { _: A, acc ->
+        if (acc < n) Decision.cont(0.seconds, acc + 1, Eval.now(acc + 1))
+        else Decision.done(0.seconds, acc, Eval.now(acc))
+      }
+
+    /**
+     * Create a schedule that only ever retries once.
+     */
+    fun <A> once(): Schedule<A, Unit> = recurs<A>(1).unit()
+
+    /**
+     * Create a schedule that never retries.
+     */
+    fun <A> never(): Schedule<A, Nothing> =
+      invoke(suspend { arrow.fx.coroutines.never<Unit>() }) { _, _ ->
+        Decision(false, 0.nanoseconds, Unit, Eval.later { throw IllegalArgumentException("Impossible") })
+      }
+
+    /**
+     * Create a schedule that uses another schedule to generate the delay of this schedule.
+     * Continues for as long as [delaySchedule] continues and adds the output of [delaySchedule] to
+     *  the delay that [delaySchedule] produced. Also returns the full delay as output.
+     *
+     * A common use case is to define a unfolding schedule and use the result to change the delay.
+     *  For an example see the implementation of [spaced], [linear], [fibonacci] or [exponential]
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <A> delayed(delaySchedule: Schedule<A, Duration>): Schedule<A, Duration> =
+      (delaySchedule.modifyDelay { a, b -> a + b } as ScheduleImpl<Any?, A, Duration>)
+        .reconsider { _, dec -> dec.copy(finish = Eval.now(dec.delay)) }
+
+    /**
+     * Create a schedule which collects all it's inputs in a list
+     */
+    fun <A> collect(): Schedule<A, List<A>> =
+      identity<A>().collect()
+
+    /**
+     * Create a schedule that continues as long as [đ] returns true.
+     */
+    fun <A> doWhile(f: suspend (A) -> Boolean): Schedule<A, A> =
+      identity<A>().whileInput(f)
+
+    /**
+     * Create a schedule that continues until [đ] returns true.
+     */
+    fun <A> doUntil(f: suspend (A) -> Boolean): Schedule<A, A> =
+      identity<A>().untilInput(f)
+
+    /**
+     * Create a schedule with an effectful handler on the input.
+     */
+    fun <A> logInput(f: suspend (A) -> Unit): Schedule<A, A> =
+      identity<A>().logInput(f)
+
+    /**
+     * Create a schedule with an effectful handler on the output.
+     */
+    fun <A> logOutput(f: suspend (A) -> Unit): Schedule<A, A> =
+      identity<A>().logOutput(f)
+
+    /**
+     * Create a schedule that returns its delay.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <A> delay(): Schedule<A, Duration> =
+      (forever<A>() as ScheduleImpl<Int, A, Int>).reconsider { _: A, decision ->
+        Decision(
+          cont = decision.cont,
+          delay = decision.delay,
+          state = decision.state,
+          finish = Eval.now(decision.delay)
+        )
+      }
+
+    /**
+     * Create a schedule that returns its decisions
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <A> decision(): Schedule<A, Boolean> =
+      (forever<A>() as ScheduleImpl<Int, A, Int>).reconsider { _: A, decision ->
+        Decision(
+          cont = decision.cont,
+          delay = decision.delay,
+          state = decision.state,
+          finish = Eval.now(decision.cont)
+        )
+      }
+
+    /**
+     * Create a schedule that continues with fixed delay.
+     */
+    fun <A> spaced(interval: Duration): Schedule<A, Int> =
+      forever<A>().delayed { d -> d + interval }
+
+    /**
+     * Create a schedule that continues with increasing delay by adding the last two delays.
+     */
+    fun <A> fibonacci(one: Duration): Schedule<A, Duration> =
+      delayed(
+        unfold<A, Pair<Duration, Duration>>(Pair(0.seconds, one)) { (del, acc) ->
+          Pair(acc, del + acc)
+        }.map { it.first }
+      )
+
+    /**
+     * Create a schedule which increases its delay linear by n * base where n is the number of
+     *  executions.
+     */
+    fun <A> linear(base: Duration): Schedule<A, Duration> =
+      delayed(
+        forever<A>().map { base * it }
+      )
+
+    /**
+     * Create a schedule that increases its delay exponentially with a given factor and base.
+     * Delay can be calculated as [base] * factor ^ n where n is the number of executions.
+     */
+    fun <A> exponential(base: Duration, factor: Double = 2.0): Schedule<A, Duration> =
+      delayed(
+        forever<A>().map { base * factor.pow(it).roundToInt() }
+      )
+  }
+}
+
+/**
+ * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
+ * Returns the last output from the policy or raises an error if a repeat failed.
+ */
+suspend fun <A, B> repeat(
+  schedule: Schedule<A, B>,
+  fa: suspend () -> A
+): B = repeatOrElse(schedule, fa) { e, _ -> throw e }
+
+/**
+ * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
+ * Also offers a function to handle errors if they are encountered during repetition.
+ */
+suspend fun <A, B> repeatOrElse(
+  schedule: Schedule<A, B>,
+  fa: suspend () -> A,
+  orElse: suspend (Throwable, B?) -> B
+): B = repeatOrElseEither(schedule, fa, orElse).fold(::identity, ::identity)
+
+/**
+ * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
+ * Also offers a function to handle errors if they are encountered during repetition.
+ */
+@Suppress("UNCHECKED_CAST")
+suspend fun <A, B, C> repeatOrElseEither(
+  schedule: Schedule<A, B>,
+  fa: suspend () -> A,
+  orElse: suspend (Throwable, B?) -> C
+): Either<C, B> {
+  (schedule as ScheduleImpl<Any?, A, B>)
+  var last: (() -> B)? = null // We haven't seen any input yet
+  var state: Any? = schedule.initialState.invoke()
+
+  while (true) {
+    cancelBoundary()
+    try {
+      val a = fa.invoke()
+      val step = schedule.update(a, state)
+      if (!step.cont) return Either.Right(step.finish.value())
+      else {
+        sleep(step.delay)
+
+        // Set state before looping again
+        last = { step.finish.value() }
+        state = step.state
+      }
+    } catch (e: Throwable) {
+      return Either.Left(orElse(e.nonFatalOrThrow(), last?.invoke()))
+    }
+  }
+}
+
+/**
+ * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
+ * Returns the result of the effect if if it was successful or re-raises the last error encountered when the schedule ends.
+ */
+suspend fun <A, B> retry(
+  schedule: Schedule<A, B>,
+  fa: suspend () -> A
+): A = retryOrElse(schedule, fa) { e, _ -> throw e }
+
+/**
+ * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
+ * Also offers a function to handle errors if they are encountered during retrial.
+ */
+suspend fun <A, B> retryOrElse(
+  schedule: Schedule<A, B>,
+  fa: suspend () -> A,
+  orElse: suspend (Throwable, B) -> A
+): A = retryOrElseEither(schedule, fa, orElse).fold(::identity, ::identity)
+
+/**
+ * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
+ * Also offers a function to handle errors if they are encountered during retrial.
+ */
+@Suppress("UNCHECKED_CAST")
+suspend fun <A, B, C> retryOrElseEither(
+  schedule: Schedule<A, B>,
+  fa: suspend () -> A,
+  orElse: suspend (Throwable, B) -> C
+): Either<C, A> {
+  (schedule as ScheduleImpl<Any?, Throwable, B>)
+
+  var dec: Schedule.Decision<Any?, B>
+  var state: Any? = schedule.initialState.invoke()
+
+  while (true) {
+    cancelBoundary()
+    try {
+      return Either.Right(fa.invoke())
+    } catch (e: Throwable) {
+      dec = schedule.update(e, state)
+      state = dec.state
+
+      if (dec.cont) sleep(dec.delay)
+      else return Either.Left(orElse(e.nonFatalOrThrow(), dec.finish.value()))
+    }
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Semaphore.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Semaphore.kt
@@ -1,0 +1,353 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+
+/**
+ * A counting [Semaphore]  has a non-negative number of permits available.
+ * Acquiring permits decreases the available permits, and releasing increases the available permits
+ *
+ * Acquiring permits when there aren't enough available will suspend the acquire call
+ * until the requested become available. Note that acquires are satisfied in strict FIFO order.
+ *
+ * The blocking acquire calls are cancellable, and will release any already acquired permits.
+ */
+interface Semaphore {
+
+  /**
+   * Get a snapshot of the currently available permits, always non negative.
+   *
+   * May be out of data instantly, use [tryAcquire] or [tryAcquireN]
+   * for acquires that immediately return if failed.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val semaphore = Semaphore(5)
+   *   val available = semaphore.available()
+   *   //sampleEnd
+   *   println("available: $available")
+   * }
+   **/
+  suspend fun available(): Long
+
+  /**
+   * Get a snapshot of the number of permits callers are waiting for when there are no permits available.
+   *
+   * The count is current available permits minus the outstanding acquires.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val semaphore = Semaphore(5)
+   *   val count = semaphore.count()
+   *   //sampleEnd
+   *   println("$count: count")
+   * }
+   **/
+  suspend fun count(): Long
+
+  /**
+   * Acquire [n] permits, suspends until the required permits are available.
+   * When it gets cancelled while suspending it will release its already acquired permits.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val semaphore = Semaphore(5)
+   *
+   *   timeOutOrNull(2.seconds) {
+   *     semaphore.acquireN(10) // count: -5
+   *   }.also { println("I timed out with: $it") }
+   *
+   *   semaphore.acquireN(5)
+   *   val available = semaphore.available()
+   *   //sampleEnd
+   *   println(available)
+   * }
+   * ```
+   *
+   * @param n number of permits to acquire - must be >= 0
+   */
+  suspend fun acquireN(n: Long): Unit
+
+  /**
+   * Acquire 1 permit, suspends until the requested permit is available.
+   *
+   * @see acquireN
+   */
+  suspend fun acquire(): Unit = acquireN(1)
+
+  /**
+   * Acquires [n] permits and signals success with a [Boolean] immediately.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val semaphore = Semaphore(5)
+   *   val failed = semaphore.tryAcquireN(6)
+   *   val succeed = semaphore.tryAcquireN(5)
+   *   //sampleEnd
+   *   println("failed: $failed, succeed: $succeed")
+   * }
+   * ```
+   *
+   * @param n number of permits to acquire - must be >= 0
+   */
+  suspend fun tryAcquireN(n: Long): Boolean
+
+  /**
+   * Acquire 1 permit and signals success with a [Boolean] immediately.
+   *
+   * @see acquireN
+   */
+  suspend fun tryAcquire(): Boolean = tryAcquireN(1)
+
+  /**
+   * Releases [n] permits, potentially unblocking outstanding acquires.
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val semaphore = Semaphore(5)
+   *   semaphore.acquireN(5)
+   *   semaphore.releaseN(3)
+   *   val available = semaphore.available()
+   *   //sampleEnd
+   *   println("available: available")
+   * }
+   * ```
+   *
+   * @param n number of permits to release - must be >= 0
+   */
+  suspend fun releaseN(n: Long): Unit
+
+  /**
+   * Releases 1 permit, potentially unblocking an outstanding acquire for 1 permit.
+   *
+   * @see acquireN
+   */
+  suspend fun release(): Unit = releaseN(1)
+
+  /**
+   * Returns an effect that acquires a permit, runs the supplied effect, and then releases the permit.
+   */
+  /**
+   * Runs the supplied effect with an acquired permit, and releases the permit on [ExitCase].
+   *
+   * ```kotlin:ank:playground
+   * import arrow.fx.coroutines.*
+   *
+   * suspend fun main(): Unit {
+   *   //sampleStart
+   *   val semaphore = Semaphore(5)
+   *   val available = semaphore.withPermitN(4) {
+   *     println("I'll run after I got 4 permits first")
+   *     semaphore.available()
+   *   }
+   *   //sampleEnd
+   *   println("available: $available")
+   * }
+   * ```
+   */
+  suspend fun <A> withPermitN(n: Long, fa: suspend () -> A): A
+
+  suspend fun <A> withPermit(fa: suspend () -> A): A =
+    withPermitN(1, fa)
+
+  companion object {
+
+    /**
+     * Construct a [Semaphore] initialized with [n] available permits.
+     *
+     * ```kotlin:ank:playground
+     * import arrow.fx.coroutines.*
+     *
+     * suspend fun main(): Unit {
+     *   //sampleStart
+     *   val semaphore = Semaphore(5)
+     *   //sampleEnd
+     * }
+     */
+    suspend operator fun invoke(n: Long): Semaphore {
+      assertNonNegative(n)
+      val r = Atomic<SemaphoreState>(Either.Right(n))
+      return SemaphoreDefault(r)
+    }
+  }
+}
+
+/**
+ * A Semaphore `Either` has `acquireN` permits waiting,
+ * or has permits available.
+ */
+internal typealias SemaphoreState = Either<AcquiredPermits, Long>
+internal typealias AcquiredPermits = IQueue<Pair<Long, Promise<Unit>>>
+
+internal suspend fun assertNonNegative(n: Long): Unit =
+  if (n < 0) throw IllegalArgumentException("n must be nonnegative, was: $n")
+  else Unit
+
+private class SemaphoreDefault(private val state: Atomic<SemaphoreState>) : Semaphore {
+
+  suspend fun mkGate(): Promise<Unit> = Promise()
+
+  private suspend fun open(gate: Promise<Unit>): Unit {
+    gate.complete(Unit)
+  }
+
+  override suspend fun count(): Long =
+    when (val curr = state.get()) {
+      is Either.Left -> -curr.a.map(Pair<Long, Promise<Unit>>::first).sum()
+      is Either.Right -> curr.b
+    }
+
+  override suspend fun acquireN(n: Long): Unit =
+    bracketCase(
+      acquire = { acquireNInternal(n) },
+      use = { (g, _) -> g.invoke() },
+      release = { (_, c), ex ->
+        when (ex) {
+          ExitCase.Cancelled -> c.invoke()
+          else -> Unit
+        }
+      }
+    )
+
+  suspend fun acquireNInternal(n: Long): Pair<suspend () -> Unit, suspend () -> Unit> {
+    assertNonNegative(n)
+    return if (n == 0L) Pair(suspend { Unit }, suspend { Unit })
+    else {
+      val p = mkGate()
+      val newState = state.updateAndGet { old ->
+        val update = when (old) {
+          is Either.Left -> Either.Left(old.a.enqueue(Pair(n, p)))
+          is Either.Right -> {
+            if (n <= old.b) Either.Right(old.b - n)
+            else Either.Left(IQueue(Pair(n - old.b, p)))
+          }
+        }
+        update
+      }
+
+      when (newState) {
+        is Either.Left -> {
+          val cleanup: suspend () -> Unit = suspend {
+            state.modify { s ->
+              val update = when (s) {
+                is Either.Left -> {
+                  val permitsToRelease = s.a.find { it.second == p }?.first
+                  permitsToRelease?.let { m ->
+                    Pair(Either.Left(s.a.filterNot { it.second == p }), suspend { releaseN(n - m) })
+                  } ?: Pair(Either.Left(s.a), suspend { releaseN(n) })
+                }
+                is Either.Right -> Pair(Either.Right(s.b + n), suspend { Unit })
+              }
+
+              update
+            }.invoke()
+          }
+
+          val entry = newState.a.lastOrNull()
+            ?: throw IllegalStateException("Semaphore has empty waiting queue rather than 0 count")
+
+          Pair(entry.second::get, cleanup)
+        }
+
+        is Either.Right -> Pair(suspend { Unit }, suspend { releaseN(n) })
+      }
+    }
+  }
+
+  override suspend fun tryAcquireN(n: Long): Boolean {
+    assertNonNegative(n)
+    return if (n == 0L) true
+    else {
+      val (previous, now) = state.modify { old ->
+        val update = when {
+          old is Either.Right && old.b >= n -> Either.Right(old.b - n)
+          else -> old
+        }
+
+        Pair(update, Pair(old, update))
+      }
+      cancelBoundary()
+      when (now) {
+        is Either.Left -> false
+        is Either.Right -> when (previous) {
+          is Either.Left -> false
+          is Either.Right -> now.b != previous.b
+        }
+      }
+    }
+  }
+
+  // Calculate new state when to hand out permits.
+  private tailrec fun calculateNewState(m: Long, permits: AcquiredPermits): SemaphoreState =
+    if (permits.isNotEmpty() && m > 0) {
+      val (k, gate) = permits.first()
+      if (k > m) calculateNewState(0, Pair(k - m, gate) prependTo permits.drop(1))
+      else calculateNewState(m - k, permits.drop(1))
+    } else {
+      if (permits.isNotEmpty()) Either.Left(permits)
+      else Either.Right(m)
+    }
+
+  override suspend fun releaseN(n: Long): Unit {
+    assertNonNegative(n)
+    return if (n == 0L) Unit
+    else {
+      val (prev, new) = state.modify { old ->
+        val update = old.fold({ waiting ->
+          calculateNewState(n, waiting)
+        }, { m -> // Nobody waiting for permits
+          Either.Right(m + n)
+        })
+
+        Pair(update, Pair(old, update))
+      }
+
+      when (prev) {
+        is Either.Left -> {
+          val waiting = prev.a
+
+          val newSize = when (new) {
+            is Either.Left -> new.a.length()
+            is Either.Right -> 0
+          }
+
+          val released = waiting.length() - newSize
+          waiting.take(released).foldRight(Unit) { (_, gate), _ ->
+            open(gate)
+          }
+        }
+        is Either.Right -> Unit
+      }
+    }
+  }
+
+  override suspend fun available(): Long =
+    when (val curr = state.get()) {
+      is Either.Left -> 0
+      is Either.Right -> curr.b
+    }
+
+  override suspend fun <A> withPermitN(n: Long, fa: suspend () -> A): A =
+    bracketCase(
+      acquire = { acquireNInternal(n) },
+      use = { (g, _) ->
+        g.invoke()
+        fa.invoke()
+      },
+      release = { (_, c), _ -> c.invoke() }
+    )
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/SuspendConnection.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/SuspendConnection.kt
@@ -1,0 +1,117 @@
+package arrow.fx.coroutines
+
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Inline marker to mark a [CancelToken],
+ * This allows for clearer APIs in functions that expect a [CancelToken] to be returned.
+ */
+@Suppress("EXPERIMENTAL_FEATURE_WARNING")
+inline class CancelToken(val cancel: suspend () -> Unit) {
+
+  suspend fun invoke(): Unit = cancel.invoke()
+
+  companion object {
+    val unit = CancelToken { Unit }
+  }
+}
+
+typealias Disposable = () -> Unit
+
+internal fun CoroutineContext.connection(): SuspendConnection =
+  this[SuspendConnection] ?: SuspendConnection.uncancellable
+
+/**
+ * SuspendConnection is a state-machine inside [CoroutineContext] that manages cancellation.
+ * This could in the future also serve as a mechanism to collect debug information on running connections.
+ */
+@PublishedApi
+internal sealed class SuspendConnection : AbstractCoroutineContextElement(SuspendConnection) {
+
+  abstract suspend fun cancel(): Unit
+  fun cancelToken(): CancelToken = CancelToken { cancel() }
+
+  abstract fun isCancelled(): Boolean
+  abstract fun push(tokens: List<CancelToken>): Unit
+  fun isNotCancelled(): Boolean = !isCancelled()
+
+  abstract fun push(token: CancelToken): Unit
+
+  fun pushPair(lh: SuspendConnection, rh: SuspendConnection): Unit =
+    pushPair(lh.cancelToken(), rh.cancelToken())
+
+  fun pushPair(lh: CancelToken, rh: CancelToken): Unit =
+    push(listOf(lh, rh))
+
+  abstract fun pop(): CancelToken
+  abstract fun tryReactivate(): Boolean
+
+  fun toDisposable(): Disposable = {
+    Platform.unsafeRunSync { cancel() }
+  }
+
+  companion object Key : CoroutineContext.Key<SuspendConnection> {
+    val uncancellable: SuspendConnection = Uncancellable
+    operator fun invoke(): SuspendConnection = DefaultConnection()
+  }
+
+  object Uncancellable : SuspendConnection() {
+    override suspend fun cancel() = Unit
+    override fun isCancelled(): Boolean = false
+    override fun push(tokens: List<CancelToken>) = Unit
+    override fun push(token: CancelToken) = Unit
+    override fun pop(): CancelToken = CancelToken.unit
+    override fun tryReactivate(): Boolean = true
+    override fun toString(): String = "UncancellableConnection"
+  }
+
+  class DefaultConnection : SuspendConnection() {
+    private val state: AtomicRef<List<CancelToken>?> = atomic(emptyList())
+
+    override suspend fun cancel(): Unit =
+      state.getAndSet(null).let { stack ->
+        when {
+          stack == null || stack.isEmpty() -> CancelToken.unit
+          else -> stack.cancelAll()
+        }
+      }
+
+    override fun isCancelled(): Boolean = state.value == null
+
+    override tailrec fun push(token: CancelToken): Unit = when (val list = state.value) {
+      // If connection is already cancelled cancel token immediately.
+      null -> Platform.unsafeRunSync { token.invoke() }
+      else ->
+        if (state.compareAndSet(list, listOf(token) + list)) Unit
+        else push(token)
+    }
+
+    override fun push(tokens: List<CancelToken>) =
+      push(tokens.asSingleToken())
+
+    override tailrec fun pop(): CancelToken {
+      val state = state.value
+      return when {
+        state == null || state.isEmpty() -> CancelToken.unit
+        else ->
+          if (this.state.compareAndSet(state, state.drop(1))) state.first()
+          else pop()
+      }
+    }
+
+    override fun tryReactivate(): Boolean =
+      state.compareAndSet(null, emptyList())
+
+    private suspend fun List<CancelToken>.cancelAll(): Unit =
+      forEach { it.invoke() }
+
+    private fun List<CancelToken>.asSingleToken(): CancelToken =
+      CancelToken { cancelAll() }
+
+    override fun toString(): String =
+      "SuspendConnection(isCancelled = ${isCancelled()}, size= ${state.value?.size ?: 0})"
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/UnsafePromise.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/UnsafePromise.kt
@@ -1,0 +1,63 @@
+package arrow.fx.coroutines
+
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+
+/**
+ * An eager Promise implementation to bridge results across processes internally.
+ * @see ForkAndForget
+ */
+internal class UnsafePromise<A> {
+
+  private sealed class State<out A> {
+    object Empty : State<Nothing>()
+    data class Waiting<A>(val joiners: List<(Result<A>) -> Unit>) : State<A>()
+
+    @Suppress("RESULT_CLASS_IN_RETURN_TYPE")
+    data class Full<A>(val a: Result<A>) : State<A>()
+  }
+
+  private val state: AtomicRef<State<A>> = atomic(State.Empty)
+
+  @Suppress("RESULT_CLASS_IN_RETURN_TYPE")
+  fun tryGet(): Result<A>? =
+    when (val curr = state.value) {
+      is State.Full -> curr.a
+      else -> null
+    }
+
+  fun get(cb: (Result<A>) -> Unit) {
+    tailrec fun go(): Unit = when (val oldState = state.value) {
+      State.Empty -> if (state.compareAndSet(oldState, State.Waiting(listOf(cb)))) Unit else go()
+      is State.Waiting -> if (state.compareAndSet(oldState, State.Waiting(oldState.joiners + cb))) Unit else go()
+      is State.Full -> cb(oldState.a)
+    }
+
+    go()
+  }
+
+  suspend fun join(): A =
+    cancellable { cb ->
+      get(cb)
+      CancelToken { remove(cb) }
+    }
+
+  fun complete(value: Result<A>) {
+    tailrec fun go(): Unit = when (val oldState = state.value) {
+      State.Empty -> if (state.compareAndSet(oldState, State.Full(value))) Unit else go()
+      is State.Waiting -> {
+        if (state.compareAndSet(oldState, State.Full(value))) oldState.joiners.forEach { it(value) }
+        else go()
+      }
+      is State.Full -> throw ArrowInternalException()
+    }
+
+    go()
+  }
+
+  fun remove(cb: (Result<A>) -> Unit) = when (val oldState = state.value) {
+    State.Empty -> Unit
+    is State.Waiting -> state.value = State.Waiting(oldState.joiners - cb)
+    is State.Full -> Unit
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/builders.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/builders.kt
@@ -1,0 +1,79 @@
+package arrow.fx.coroutines
+
+import kotlin.coroutines.suspendCoroutine
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+
+suspend fun <A> cancellable(cb: ((Result<A>) -> Unit) -> CancelToken): A =
+  suspendCoroutine { cont ->
+    val conn = cont.context.connection()
+    val cbb2 = Platform.onceOnly(conn, cont::resumeWith)
+
+    val cancellable = ForwardCancellable()
+    conn.push(cancellable.cancel())
+
+    if (conn.isNotCancelled()) {
+      cancellable.complete(
+        try {
+          cb(cbb2)
+        } catch (throwable: Throwable) {
+          cbb2(Result.failure(throwable.nonFatalOrThrow()))
+          CancelToken.unit
+        }
+      )
+    } else cancellable.complete(CancelToken.unit)
+  }
+
+suspend fun <A> cancellableF(k: suspend ((Result<A>) -> Unit) -> CancelToken): A =
+  suspendCoroutine { cont ->
+    val conn = cont.context.connection()
+
+    val state = AtomicRefW<((Result<Unit>) -> Unit)?>(null)
+    val cb1 = { a: Result<A> ->
+      try {
+        cont.resumeWith(a)
+      } finally {
+        // compareAndSet can only succeed in case the operation is already finished
+        // and no cancellation token was installed yet
+        if (!state.compareAndSet(null, { Unit })) {
+          val cb2 = state.value
+          state.lazySet(null)
+          cb2?.invoke(Result.success(Unit))
+        }
+      }
+    }
+
+    val conn2 = SuspendConnection()
+    conn.push(conn2.cancelToken())
+
+    suspend {
+      // Until we've got a cancellation token, the task needs to be evaluated
+      // uninterruptedly, otherwise risking a leak, hence the bracket
+      // TODO CREATE KotlinTracker issue using CancelToken here breaks something in compilation
+      bracketCase<suspend () -> Unit, Unit>(
+        acquire = { k(cb1).cancel },
+        use = { waitUntilCallbackInvoked(state) },
+        release = { token, ex ->
+          when (ex) {
+            ExitCase.Cancelled -> token.invoke()
+            else -> Unit
+          }
+        }
+      )
+    }.startCoroutineCancellable(CancellableContinuation(cont.context, conn2) {
+      // TODO send CancelToken exception to Enviroment
+      it.fold(::identity, Throwable::printStackTrace)
+    })
+  }
+
+private suspend fun waitUntilCallbackInvoked(state: AtomicRefW<((Result<Unit>) -> Unit)?>) =
+  suspendCoroutineUninterceptedOrReturn<Unit> { cont ->
+    // compareAndSet succeeds if CancelToken returned & callback not invoked, suspend
+    if (state.compareAndSet(null, cont::resumeWith)) COROUTINE_SUSPENDED
+    else Unit // k invoked before token returned, finish immediately
+  }
+
+suspend fun <A> never(): A =
+  suspendCoroutine<Nothing> {}
+
+suspend fun unit(): Unit = Unit

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/cancelBoundary.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/cancelBoundary.kt
@@ -1,0 +1,14 @@
+package arrow.fx.coroutines
+
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+
+/**
+ * Checks for cancellation,
+ * when cancellation occurs this coroutine will suspend indefinitely and never continue.
+ */
+suspend fun cancelBoundary(): Unit =
+  suspendCoroutineUninterceptedOrReturn { cont ->
+    if (cont.context.connection().isCancelled()) COROUTINE_SUSPENDED
+    else Unit
+  }

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/dispatchers.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/dispatchers.kt
@@ -1,0 +1,56 @@
+package arrow.fx.coroutines
+
+import kotlinx.atomicfu.atomic
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ForkJoinPool
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+
+fun fromExecutor(f: suspend () -> ExecutorService): Resource<CoroutineContext> =
+  Resource(f) { s -> s.shutdown() }.map(ExecutorService::asCoroutineContext)
+
+fun singleThreadContext(name: String): Resource<CoroutineContext> =
+  fromExecutor {
+    Executors.newSingleThreadExecutor { r ->
+      Thread(r, name).apply {
+        isDaemon = true
+      }
+    }
+  }
+
+val ComputationPool: CoroutineContext = ForkJoinPool().asCoroutineContext()
+
+private object IOCounter {
+  private val ref = atomic(0)
+  fun getAndIncrement(): Int = ref.getAndIncrement()
+}
+
+val IOPool = Executors.newCachedThreadPool { r ->
+  Thread(r).apply {
+    name = "io-arrow-kt-worker-${IOCounter.getAndIncrement()}"
+    isDaemon = true
+  }
+}.asCoroutineContext()
+
+private fun ExecutorService.asCoroutineContext(): CoroutineContext =
+  ExecutorServiceContext(this)
+
+private class ExecutorServiceContext(val pool: ExecutorService) :
+  AbstractCoroutineContextElement(ContinuationInterceptor), ContinuationInterceptor {
+  override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> =
+    ExecutorServiceContinuation(pool, continuation.context.fold(continuation) { cont, element ->
+      if (element != this@ExecutorServiceContext && element is ContinuationInterceptor)
+        element.interceptContinuation(cont) else cont
+    })
+}
+
+private class ExecutorServiceContinuation<T>(val pool: ExecutorService, val cont: Continuation<T>) : Continuation<T> {
+  override val context: CoroutineContext = cont.context
+
+  override fun resumeWith(result: Result<T>) {
+    pool.execute { cont.resumeWith(result) }
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/evalOn.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/evalOn.kt
@@ -1,0 +1,118 @@
+package arrow.fx.coroutines
+
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.loop
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.createCoroutineUnintercepted
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.resume
+
+suspend fun <T> (suspend () -> T).evalOn(ctx: CoroutineContext): T =
+  evalOn(ctx, this)
+
+/**
+ * Executes a task on [context] and comes back to the original [CoroutineContext].
+ *
+ * State of [context] and previous [CoroutineContext] is merged
+ */
+suspend fun <T> evalOn(
+  context: CoroutineContext,
+  block: suspend () -> T
+): T = suspendCoroutineUninterceptedOrReturn sc@{ uCont ->
+
+  if (uCont.context.connection().isCancelled()) return@sc COROUTINE_SUSPENDED
+
+  val oldContext = uCont.context
+  val newContext = oldContext + context
+
+  // FAST PATH #1 -- new context is the same as the old one
+  // FAST PATH #2 -- same ContinuationInterceptor, something else changed
+  // There are changes in the context, so this thread needs to be updated
+  if (newContext === oldContext || newContext[ContinuationInterceptor] === oldContext[ContinuationInterceptor]) {
+    val coroutine = NonDispatchableCoroutine(newContext, uCont)
+
+    val x = block.startCoroutineUninterceptedOrReturn(coroutine)
+    return@sc (if (x != COROUTINE_SUSPENDED) x else coroutine.getResult())
+  }
+
+  val coroutine = DispatchableCoroutine(newContext, uCont)
+  block.createCoroutineUnintercepted(coroutine).intercepted().resume(Unit)
+  return@sc coroutine.getResult()
+}
+
+internal interface SafeCoroutine {
+  fun getResult(): Any?
+}
+
+internal const val UNDECIDED = 0
+internal const val SUSPENDED = 1
+
+private class NonDispatchableCoroutine<in T>(
+  ctx: CoroutineContext,
+  private val uCont: Continuation<T>
+) : Continuation<T>, CoroutineStackFrame, SafeCoroutine {
+
+  override val context: CoroutineContext = ctx
+
+  private val _decision = atomic<Any?>(UNDECIDED)
+
+  override fun resumeWith(result: Result<T>) {
+    _decision.loop { decision ->
+      when (decision) {
+        UNDECIDED -> {
+          val r: Any? = result.fold({ it }) { t -> uCont.resumeWithException(t) }
+          if (this._decision.compareAndSet(UNDECIDED, r)) return
+        }
+        else -> { // If not `UNDECIDED` then we need to pass result to `uCont`
+          uCont.resumeWith(result)
+          return
+        }
+      }
+    }
+  }
+
+  override fun getResult(): Any? =
+    _decision.loop { decision ->
+      when (decision) {
+        UNDECIDED -> if (this._decision.compareAndSet(UNDECIDED, SUSPENDED)) return COROUTINE_SUSPENDED
+        else -> return decision
+      }
+    }
+
+  override val callerFrame: CoroutineStackFrame?
+    get() = this
+
+  override fun getStackTraceElement(): StackTraceElement? =
+    null
+}
+
+private class DispatchableCoroutine<in T>(
+  ctx: CoroutineContext,
+  private val uCont: Continuation<T>
+) : Continuation<T>, CoroutineStackFrame, SafeCoroutine {
+
+  override val context: CoroutineContext = ctx
+
+  override fun resumeWith(result: Result<T>) {
+    uCont.intercepted().resumeWith(result)
+  }
+
+  override fun getResult(): Any? = COROUTINE_SUSPENDED
+
+  override val callerFrame: CoroutineStackFrame?
+    get() = this
+
+  override fun getStackTraceElement(): StackTraceElement? =
+    null
+}
+
+internal interface CoroutineStackFrame : kotlin.coroutines.jvm.internal.CoroutineStackFrame {
+  override val callerFrame: CoroutineStackFrame?
+  override fun getStackTraceElement(): StackTraceElement?
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/predef.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/predef.kt
@@ -1,0 +1,29 @@
+package arrow.fx.coroutines
+
+fun <A> identity(a: A): A = a
+
+inline infix fun <A, B, C> ((A) -> B).andThen(crossinline f: (B) -> C): (A) -> C =
+  { a -> f(this(a)) }
+
+infix fun <A> A.prependTo(fa: List<A>): List<A> =
+  listOf(this) + fa
+
+fun <A> List<A>.deleteFirst(f: (A) -> Boolean): Pair<A, List<A>>? {
+  tailrec fun go(rem: List<A>, acc: List<A>): Pair<A, List<A>>? =
+    when {
+      rem.isEmpty() -> null
+      else -> {
+        val a = rem.first()
+        val tail = rem.drop(1)
+        if (!f(a)) go(tail, acc + a)
+        else Pair(a, acc + tail)
+      }
+    }
+
+  return go(this, emptyList())
+}
+
+/** Represents a unique identifier using object equality. */
+internal class Token {
+  override fun toString(): String = "Token(${Integer.toHexString(hashCode())})"
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/startCoroutineCancellable.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/startCoroutineCancellable.kt
@@ -1,0 +1,49 @@
+package arrow.fx.coroutines
+
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.createCoroutineUnintercepted
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.resume
+
+/**
+ * Type to constraint [startCoroutineCancellable] to the [CancellableContinuation] constructor.
+ */
+interface CancellableContinuation<A> : Continuation<A>
+
+/** Constructor for [CancellableContinuation] */
+@Suppress("FunctionName")
+inline fun <A> CancellableContinuation(
+  ctx: CoroutineContext = ComputationPool,
+  crossinline resumeWith: (Result<A>) -> Unit
+): CancellableContinuation<A> = CancellableContinuation(ctx, SuspendConnection(), resumeWith)
+
+/**
+ * Starts a coroutine without a receiver and with result type [A].
+ * This function creates and starts a new, fresh instance of suspendable cancellable computation every time it is invoked.
+ * The [completion] continuation is invoked when the coroutine completes with a result or an exception.
+ *
+ * @returns Disposable handler to cancel the started suspendable cancellable computation.
+ */
+fun <A> (suspend () -> A).startCoroutineCancellable(completion: CancellableContinuation<A>): Disposable {
+  val conn = completion.context.connection()
+  createCoroutineUnintercepted(completion).intercepted().resume(Unit)
+  return conn.toDisposable()
+}
+
+/**
+ *
+ * Constructor that allows us to launch a [CancellableContinuation] on an existing [SuspendConnection].
+ */
+@PublishedApi
+@Suppress("FunctionName")
+internal inline fun <A> CancellableContinuation(
+  ctx: CoroutineContext = ComputationPool,
+  conn: SuspendConnection,
+  crossinline resumeWith: (Result<A>) -> Unit
+): CancellableContinuation<A> = object : CancellableContinuation<A> {
+  override val context: CoroutineContext = conn + ctx // Faster in case ctx is EmptyCoroutineContext
+  override fun resumeWith(result: Result<A>) {
+    if (conn.isNotCancelled()) resumeWith(result)
+  }
+}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/timer.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/timer.kt
@@ -1,0 +1,103 @@
+package arrow.fx.coroutines
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * [scheduler] is **only** for internal use for the [sleep] implementation.
+ * This way we can guarantee nothing besides sleeping ever occurs here.
+ */
+internal val scheduler: ScheduledExecutorService by lazy {
+  Executors.newScheduledThreadPool(2) { r ->
+    Thread(r).apply {
+      name = "arrow-effect-scheduler-$id"
+      isDaemon = true
+    }
+  }
+}
+
+/**
+ * Sleeps for a given [duration] without blocking a thread.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   sleep(5.seconds)
+ *   println("Message after sleeping")
+ * }
+ * ```
+ **/
+suspend fun sleep(duration: Duration): Unit =
+  if (duration.amount <= 0) Unit
+  else cancellable { resumeWith ->
+    val cancelRef = scheduler.schedule(
+      { resumeWith(Result.success(Unit)) },
+      duration.amount,
+      duration.timeUnit
+    )
+
+    CancelToken { cancelRef.cancel(false); Unit }
+  }
+
+/**
+ * Returns the result of [fa] within the specified [duration] or returns null.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   timeOutOrNull(2.seconds) {
+ *     sleep(5.seconds)
+ *     "Message from lazy task"
+ *   }.also(::println)
+ *
+ *   timeOutOrNull(2.seconds) {
+ *     "Message from fast task"
+ *   }.also(::println)
+ * }
+ * ```
+ **/
+suspend fun <A> timeOutOrNull(duration: Duration, fa: suspend () -> A): A? =
+  if (duration.amount <= 0L) null
+  else suspendCoroutineUninterceptedOrReturn sc@{ uCont: Continuation<A?> ->
+    val conn = uCont.context.connection()
+    val isActive = AtomicRefW(true) // keep track if already resumed
+
+    // Create connections for fa and timer
+    val faConn = SuspendConnection()
+    val timerConn = SuspendConnection()
+
+    // Register our new tokens to our parents connection
+    conn.push(listOf(timerConn.cancelToken(), faConn.cancelToken()))
+
+    suspend { sleep(duration) }.startCoroutineCancellable(
+      CancellableContinuation(
+        EmptyCoroutineContext,
+        timerConn
+      ) { timeOut ->
+        timeOut.fold({
+          if (isActive.compareAndSet(true, false)) {
+            faConn.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) {
+              it.fold({ uCont.resume(null) }, uCont::resumeWithException)
+            })
+          }
+        }, uCont::resumeWithException)
+      })
+
+    // Start unintercepted with timeOut connection attached to parents CoroutineContext
+    val x = fa.startCoroutineUninterceptedOrReturn(Continuation(uCont.context + faConn) {
+      if (isActive.compareAndSet(true, false)) uCont.resumeWith(it)
+    })
+
+    if (x != COROUTINE_SUSPENDED && isActive.compareAndSet(true, false)) x
+    else COROUTINE_SUSPENDED
+  }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/AtomicTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/AtomicTest.kt
@@ -1,0 +1,123 @@
+package arrow.fx.coroutines
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+
+class AtomicTest : StringSpec({
+
+  "set get - successful" {
+    checkAll(Arb.int(), Arb.int()) { x, y ->
+      val r = Atomic(x)
+      r.set(y)
+      r.get() shouldBe y
+    }
+  }
+
+  "getAndSet - successful" {
+    checkAll(Arb.int(), Arb.int()) { x, y ->
+      val ref = Atomic(x)
+      ref.getAndSet(y) shouldBe x
+      ref.get() shouldBe y
+    }
+  }
+
+  "access - successful" {
+    checkAll(Arb.int(), Arb.int()) { x, y ->
+      val ref = Atomic(x)
+      val (_, setter) = ref.access()
+      setter(y) shouldBe true
+      ref.get() shouldBe y
+    }
+  }
+
+  "access - setter should fail if value is modified before setter is called" {
+    checkAll(Arb.int(), Arb.int(), Arb.int()) { x, y, z ->
+      val ref = Atomic(x)
+      val (_, setter) = ref.access()
+      ref.set(y)
+      setter(z) shouldBe false
+      ref.get() shouldBe y
+    }
+  }
+
+  "access - setter should fail if called twice" {
+    checkAll(Arb.int(), Arb.int(), Arb.int(), Arb.int()) { w, x, y, z ->
+      val ref = Atomic(w)
+      val (_, setter) = ref.access()
+      setter(x) shouldBe true
+      ref.set(y)
+      setter(z) shouldBe false
+      ref.get() shouldBe y
+    }
+  }
+
+  "tryUpdate - modification occurs successfully" {
+    checkAll(Arb.int()) { x ->
+      val ref = Atomic(x)
+      ref.tryUpdate { it + 1 }
+      ref.get() shouldBe x + 1
+    }
+  }
+
+  "tryUpdate - should fail to update if modification has occurred" {
+    checkAll(Arb.int()) { x ->
+      val ref = Atomic(x)
+      ref.tryUpdate {
+        Platform.unsafeRunSync { ref.update(Int::inc) }
+        it + 1
+      } shouldBe false
+    }
+  }
+
+  "consistent set update" {
+    checkAll(Arb.int(), Arb.int()) { x, y ->
+      val set = suspend {
+        val r = Atomic(x)
+        r.set(y)
+        r.get()
+      }
+
+      val update = suspend {
+        val r = Atomic(x)
+        r.update { y }
+        r.get()
+      }
+
+      set() shouldBe update()
+    }
+  }
+
+  "access id" {
+    checkAll(Arb.int()) { x ->
+      val r = Atomic(x)
+      val (a, _) = r.access()
+      r.get() shouldBe a
+    }
+  }
+
+  "consistent access tryUpdate" {
+    checkAll(Arb.int()) { x ->
+      val acccessMap = suspend {
+        val r = Atomic(x)
+        val (a, setter) = r.access()
+        setter(a + 1)
+      }
+      val tryUpdate = suspend {
+        val r = Atomic(x)
+        r.tryUpdate { it + 1 }
+      }
+
+      acccessMap() shouldBe tryUpdate()
+    }
+  }
+
+  "concurrent modifications" {
+    val finalValue = 50_000
+    val r = Atomic(0)
+    (0 until finalValue).parTraverse { r.update { it + 1 } }
+    r.get() shouldBe finalValue
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/BracketCaseTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/BracketCaseTest.kt
@@ -1,0 +1,301 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.long
+import io.kotest.property.checkAll
+
+class BracketCaseTest : StringSpec({
+
+  "Uncancellable back pressures timeoutOrNull" {
+    checkAll(10, Arb.long(10, 20), Arb.long(50, 100)) { a, b ->
+      val start = System.currentTimeMillis()
+
+      val n = timeOutOrNull(a.milliseconds) {
+        uncancellable { sleep(b.milliseconds) }
+      }
+
+      val end = System.currentTimeMillis()
+
+      n shouldBe null // timed-out so should be null
+      require((end - start) >= b) {
+        "Should've taken longer than $b milliseconds, but took ${start - end}ms"
+      }
+    }
+  }
+
+  "Immediate acquire bracketCase finishes successfully" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      bracketCase(
+        acquire = { a },
+        use = { aa -> Pair(aa, b) },
+        release = { _, _ -> CancelToken.unit }
+      ) shouldBe Pair(a, b)
+    }
+  }
+
+  "Suspended acquire bracketCase finishes successfully" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      bracketCase(
+        acquire = { a.suspend() },
+        use = { aa -> Pair(aa, b) },
+        release = { _, _ -> CancelToken.unit }
+      ) shouldBe Pair(a, b)
+    }
+  }
+
+  "Immediate error in acquire stays the same error" {
+    checkAll(Arb.throwable()) { e ->
+      Either.catch {
+        bracketCase<Unit, Int>(
+          acquire = { throw e },
+          use = { 5 },
+          release = { _, _ -> CancelToken.unit }
+        )
+      } shouldBe Either.Left(e)
+    }
+  }
+
+  "Suspend error in acquire stays the same error" {
+    checkAll(Arb.throwable()) { e ->
+      Either.catch {
+        bracketCase<Unit, Int>(
+          acquire = { e.suspend() },
+          use = { 5 },
+          release = { _, _ -> CancelToken.unit }
+        )
+      } shouldBe Either.Left(e)
+    }
+  }
+
+  "Immediate use bracketCase finishes successfully" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      bracketCase(
+        acquire = { a },
+        use = { aa -> Pair(aa, b).suspend() },
+        release = { _, _ -> CancelToken.unit }
+      ) shouldBe Pair(a, b)
+    }
+  }
+
+  "Suspended use bracketCase finishes successfully" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      bracketCase(
+        acquire = { a },
+        use = { aa -> Pair(aa, b).suspend() },
+        release = { _, _ -> CancelToken.unit }
+      ) shouldBe Pair(a, b)
+    }
+  }
+
+  "bracketCase must run release task on use immediate error" {
+    checkAll(Arb.int(), Arb.throwable()) { i, e ->
+      val promise = Promise<ExitCase>()
+
+      Either.catch {
+        bracketCase<Int, Int>(
+          acquire = { i },
+          use = { throw e },
+          release = { _, ex -> promise.complete(ex) }
+        )
+      }
+
+      promise.get() shouldBe ExitCase.Failure(e)
+    }
+  }
+
+  "bracketCase must run release task on use suspended error" {
+    checkAll(Arb.int(), Arb.throwable()) { x, e ->
+      val promise = Promise<Pair<Int, ExitCase>>()
+
+      Either.catch {
+        bracketCase<Int, Int>(
+          acquire = { x },
+          use = { e.suspend() },
+          release = { xx, ex -> promise.complete(Pair(xx, ex)) }
+        )
+      }
+
+      promise.get() shouldBe Pair(x, ExitCase.Failure(e))
+    }
+  }
+
+  "bracketCase must always run immediate release" {
+    checkAll(Arb.int()) { x ->
+      val promise = Promise<Pair<Int, ExitCase>>()
+
+      Either.catch {
+        bracketCase(
+          acquire = { x },
+          use = { it },
+          release = { xx, ex -> promise.complete(Pair(xx, ex)) }
+        )
+      }
+
+      promise.get() shouldBe Pair(x, ExitCase.Completed)
+    }
+  }
+
+  "bracketCase must always run suspended release" {
+    checkAll(Arb.int()) { x ->
+      val promise = Promise<Pair<Int, ExitCase>>()
+
+      Either.catch {
+        bracketCase(
+          acquire = { x },
+          use = { it },
+          release = { xx, ex -> promise.complete(Pair(xx, ex)).suspend() }
+        )
+      }
+
+      promise.get() shouldBe Pair(x, ExitCase.Completed)
+    }
+  }
+
+  "bracketCase must always run immediate release error" {
+    checkAll(Arb.int(), Arb.throwable()) { n, e ->
+      Either.catch {
+        bracketCase(
+          acquire = { n },
+          use = { it },
+          release = { _, _ -> throw e }
+        )
+      } shouldBe Either.Left(e)
+    }
+  }
+
+  "bracketCase must always run suspended release error" {
+    checkAll(Arb.int(), Arb.throwable()) { n, e ->
+      Either.catch {
+        bracketCase(
+          acquire = { n },
+          use = { it },
+          release = { _, _ -> e.suspend() }
+        )
+      } shouldBe Either.Left(e)
+    }
+  }
+
+  "bracketCase must compose immediate use & immediate release error" {
+    checkAll(Arb.int(), Arb.throwable(), Arb.throwable()) { n, e, e2 ->
+      Either.catch {
+        bracketCase<Int, Unit>(
+          acquire = { n },
+          use = { throw e },
+          release = { _, _ -> throw e2 }
+        )
+      } shouldBe Either.Left(Platform.composeErrors(e, e2))
+    }
+  }
+
+  "bracketCase must compose suspend use & immediate release error" {
+    checkAll(Arb.int(), Arb.throwable(), Arb.throwable()) { n, e, e2 ->
+      Either.catch {
+        bracketCase<Int, Unit>(
+          acquire = { n },
+          use = { e.suspend() },
+          release = { _, _ -> throw e2 }
+        )
+      } shouldBe Either.Left(Platform.composeErrors(e, e2))
+    }
+  }
+
+  "bracketCase must compose immediate use & suspend release error" {
+    checkAll(Arb.int(), Arb.throwable(), Arb.throwable()) { n, e, e2 ->
+      Either.catch {
+        bracketCase<Int, Unit>(
+          acquire = { n },
+          use = { throw e },
+          release = { _, _ -> e2.suspend() }
+        )
+      } shouldBe Either.Left(Platform.composeErrors(e, e2))
+    }
+  }
+
+  "bracketCase must compose suspend use & suspend release error" {
+    checkAll(Arb.int(), Arb.throwable(), Arb.throwable()) { n, e, e2 ->
+      Either.catch {
+        bracketCase<Int, Unit>(
+          acquire = { n },
+          use = { e.suspend() },
+          release = { _, _ -> e2.suspend() }
+        )
+      } shouldBe Either.Left(Platform.composeErrors(e, e2))
+    }
+  }
+
+  "cancel on bracketCase releases" {
+    val start = Promise<Unit>()
+    val exit = Promise<ExitCase>()
+
+    val f = ForkAndForget {
+      bracketCase(
+        acquire = { Unit },
+        use = {
+          // Signal that fiber is running
+          start.complete(Unit)
+          never<Unit>()
+        },
+        release = { _, exitCase ->
+          exit.complete(exitCase)
+        }
+      )
+    }
+
+    // Wait until the fiber is started before cancelling
+    start.get()
+    f.cancel()
+    exit.get() shouldBe ExitCase.Cancelled
+  }
+
+  "acquire on bracketCase is not cancellable" {
+    checkAll(Arb.int(), Arb.int()) { x, y ->
+      val mVar = ConcurrentVar(x)
+      val latch = Promise<Unit>()
+      val p = Promise<ExitCase>()
+
+      val fiber = ForkAndForget {
+        bracketCase(
+          acquire = {
+            latch.complete(Unit)
+            mVar.put(y)
+          },
+          use = { never<Unit>() },
+          release = { _, exitCase -> p.complete(exitCase) }
+        )
+      }
+
+      // Wait until acquire started
+      latch.get()
+      ForkAndForget { fiber.cancel() }
+
+      mVar.take() shouldBe x
+      mVar.take() shouldBe y
+      p.get() shouldBe ExitCase.Cancelled
+    }
+  }
+
+  "release on bracketCase is not cancellable" {
+    checkAll(Arb.int(), Arb.int()) { x, y ->
+      val mVar = ConcurrentVar(x)
+      val latch = Promise<Unit>()
+
+      val fiber = ForkAndForget {
+        bracketCase(
+          acquire = { latch.complete(Unit) },
+          use = { never<Unit>() },
+          release = { _, _ -> mVar.put(y) }
+        )
+      }
+
+      latch.get()
+      ForkAndForget { fiber.cancel() }
+
+      mVar.take() shouldBe x
+      mVar.take() shouldBe y
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
@@ -1,0 +1,115 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+
+class CancellableF : StringSpec({
+
+  "cancelable works for immediate values" {
+    checkAll(Arb.result(Arb.int())) { res ->
+      Either.catch {
+        cancellable<Int> { cb ->
+          cb(res)
+          CancelToken.unit
+        }
+      } shouldBe res.toEither()
+    }
+  }
+
+  "cancelable gets canceled" {
+    val cancelled = Promise<Boolean>()
+    val latch = UnsafePromise<Unit>()
+
+    val c = suspend {
+      cancellable<Unit> {
+        latch.complete(Result.success(Unit))
+        CancelToken { cancelled.complete(true) }
+      }
+    }.startCoroutineCancellable(CancellableContinuation { })
+
+    latch.join()
+    c.invoke()
+
+    cancelled.get() shouldBe true
+  }
+
+  "cancelableF works for immediate values" {
+    checkAll(Arb.result(Arb.int())) { res ->
+      Either.catch {
+        cancellableF<Int> { cb ->
+          cb(res)
+          CancelToken.unit
+        }
+      } shouldBe res.toEither()
+    }
+  }
+
+  "cancelableF works for async values" {
+    checkAll(Arb.result(Arb.int())) { res ->
+      Either.catch {
+        cancellableF<Int> { cb ->
+          Unit.suspend()
+          cb(res)
+          CancelToken.unit
+        }
+      } shouldBe res.toEither()
+    }
+  }
+
+  "cancelableF can yield cancelable tasks" {
+    checkAll(Arb.int()) { i ->
+      val d = ConcurrentVar.empty<Int>()
+      val latch = Promise<Unit>()
+      val fiber = ForkConnected {
+        cancellableF<Unit> { _ ->
+          latch.complete(Unit)
+          CancelToken { d.put(i) }
+        }
+      }
+
+      latch.get()
+      d.tryTake() shouldBe null
+      fiber.cancel()
+      d.take() shouldBe i
+    }
+  }
+
+  "cancelableF executes generated task uninterruptedly" {
+    checkAll(Arb.int()) { i ->
+      val latch = Promise<Unit>()
+      val start = Promise<Unit>()
+      val done = Promise<Int>()
+
+      val task = suspend {
+        cancellableF<Unit> { cb ->
+          latch.complete(Unit)
+          start.get()
+          cancelBoundary()
+          cb(Result.success(Unit))
+          done.complete(i)
+          CancelToken.unit
+        }
+      }
+
+      val p = UnsafePromise<Unit>()
+
+      val cancel = task.startCoroutineCancellable(CancellableContinuation { r -> p.complete(r) })
+
+      latch.get()
+
+      ForkConnected { cancel.invoke() }
+
+      // Let cancel schedule
+      sleep(10.milliseconds)
+
+      start.complete(Unit) // Continue cancellableF
+
+      done.get() shouldBe i
+      p.tryGet() shouldBe null
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
@@ -1,0 +1,277 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.assertions.fail
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.lang.RuntimeException
+
+class CircuitBreakerTest : StringSpec({
+
+  val dummy = RuntimeException("dummy")
+  val maxFailures = 5
+  val exponentialBackoffFactor = 2.0
+  val resetTimeout = 200.milliseconds
+  val maxTimeout = 600.milliseconds
+
+  "should work for successful async tasks" {
+    val cb = CircuitBreaker.of(maxFailures = maxFailures, resetTimeout = resetTimeout)!!
+    var effect = 0
+    repeat(Schedule.recurs(10_000)) {
+      cb.protect { evalOn(ComputationPool) { effect += 1 } }
+    }
+    effect shouldBe 10_001
+  }
+
+  "should work for successful immediate tasks" {
+    val cb = CircuitBreaker.of(maxFailures = maxFailures, resetTimeout = resetTimeout)!!
+    var effect = 0
+    repeat(Schedule.recurs(10_000)) {
+      cb.protect { effect += 1 }
+    }
+    effect shouldBe 10_001
+  }
+
+  "Circuit breaker stays closed after less than maxFailures" {
+    val cb = CircuitBreaker.of(maxFailures = maxFailures, resetTimeout = resetTimeout)!!
+
+    repeat(recurAndCollect(3)) {
+      Either.catch { cb.protect { throw dummy } }
+    } shouldBe (0..3).map { Either.Left(dummy) }
+
+    cb.state() shouldBe CircuitBreaker.State.Closed(4)
+  }
+
+  "Closed circuit breaker resets failure count after success" {
+    val cb = CircuitBreaker.of(maxFailures = maxFailures, resetTimeout = resetTimeout)!!
+
+    repeat(recurAndCollect(3)) {
+      Either.catch { cb.protect { throw dummy } }
+    } shouldBe (0..3).map { Either.Left(dummy) }
+
+    cb.state() shouldBe CircuitBreaker.State.Closed(4)
+
+    cb.protect { 1 } shouldBe 1
+
+    cb.state() shouldBe CircuitBreaker.State.Closed(0)
+  }
+
+  "Circuit breaker opens after max failures" {
+    val cb = CircuitBreaker.of(maxFailures = maxFailures, resetTimeout = resetTimeout)!!
+
+    repeat(recurAndCollect(3)) {
+      Either.catch { cb.protect { throw dummy } }
+    } shouldBe (0..3).map { Either.Left(dummy) }
+
+    cb.state() shouldBe CircuitBreaker.State.Closed(4)
+
+    Either.catch { cb.protect { throw dummy } } shouldBe Either.Left(dummy)
+
+    when (val s = cb.state()) {
+      is CircuitBreaker.State.Open -> {
+        s.resetTimeout shouldBe resetTimeout
+      }
+      else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
+    }
+  }
+
+  "Circuit breaker can be closed again after waiting resetTimeOut" {
+    var openedCount = 0
+    var closedCount = 0
+    var halfOpenCount = 0
+    var rejectedCount = 0
+
+    val cb = CircuitBreaker.of(
+      maxFailures = maxFailures,
+      resetTimeout = resetTimeout,
+      exponentialBackoffFactor = exponentialBackoffFactor,
+      maxResetTimeout = maxTimeout
+    )!!.doOnOpen { openedCount += 1 }
+      .doOnClosed { closedCount += 1 }
+      .doOnHalfOpen { halfOpenCount += 1 }
+      .doOnRejectedTask { rejectedCount += 1 }
+
+    // CircuitBreaker opens after 4 failures
+    repeat(recurAndCollect(4)) { Either.catch { cb.protect { throw dummy } } }
+
+    when (val s = cb.state()) {
+      is CircuitBreaker.State.Open -> {
+        s.resetTimeout shouldBe resetTimeout
+      }
+      else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
+    }
+
+    // If CircuitBreaker is Open our tasks our rejected
+    shouldThrow<CircuitBreaker.ExecutionRejected> {
+      cb.protect { throw dummy }
+    }
+
+    // After resetTimeout passes, CB should still be Open, and we should be able to reset to Closed.
+    sleep(resetTimeout + 10.milliseconds)
+
+    when (val s = cb.state()) {
+      is CircuitBreaker.State.Open -> {
+        s.resetTimeout shouldBe resetTimeout
+      }
+      else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
+    }
+
+    val checkHalfOpen = Promise<Unit>()
+    val delayProtectLatch = Promise<Unit>()
+    val stateAssertionLatch = Promise<Unit>()
+
+    ForkAndForget { // Successful tasks puts circuit breaker back in HalfOpen
+      cb.protect {
+        checkHalfOpen.complete(Unit)
+        delayProtectLatch.get()
+      } // Delay protect, to inspect HalfOpen state.
+      stateAssertionLatch.complete(Unit)
+    }
+
+    checkHalfOpen.get()
+
+    when (val s = cb.state()) {
+      is CircuitBreaker.State.HalfOpen -> {
+        s.resetTimeout shouldBe resetTimeout
+      }
+      else -> fail("Invalid state: Expect CircuitBreaker.State.HalfOpen but found $s")
+    }
+
+    // Rejects all other tasks in HalfOpen
+    shouldThrow<CircuitBreaker.ExecutionRejected> { cb.protect { throw dummy } }
+    shouldThrow<CircuitBreaker.ExecutionRejected> { cb.protect { throw dummy } }
+
+    // Once we complete `protect`, the circuitbreaker will go back to closer state
+    delayProtectLatch.complete(Unit)
+    stateAssertionLatch.get()
+
+    // Circuit breaker should be reset after successful task.
+    cb.state() shouldBe CircuitBreaker.State.Closed(0)
+
+    rejectedCount shouldBe 3 // 3 tasks were rejected in total
+    openedCount shouldBe 1 // Circuit breaker opened once
+    halfOpenCount shouldBe 1 // Circuit breaker went into halfOpen once
+    closedCount shouldBe 1 // Circuit breaker closed once after it opened
+  }
+
+  "Circuit breaker stays open with failure after resetTimeOut" {
+    var openedCount = 0
+    var closedCount = 0
+    var halfOpenCount = 0
+    var rejectedCount = 0
+
+    val cb = CircuitBreaker.of(
+      maxFailures = maxFailures,
+      resetTimeout = resetTimeout,
+      exponentialBackoffFactor = 2.0,
+      maxResetTimeout = maxTimeout
+    )!!.doOnOpen { openedCount += 1 }
+      .doOnClosed { closedCount += 1 }
+      .doOnHalfOpen { halfOpenCount += 1 }
+      .doOnRejectedTask { rejectedCount += 1 }
+
+    // CircuitBreaker opens after 4 failures
+    repeat(recurAndCollect(4)) { Either.catch { cb.protect { throw dummy } } }
+
+    when (val s = cb.state()) {
+      is CircuitBreaker.State.Open -> {
+        s.resetTimeout shouldBe resetTimeout
+      }
+      else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
+    }
+
+    // If CircuitBreaker is Open our tasks our rejected
+    shouldThrow<CircuitBreaker.ExecutionRejected> {
+      cb.protect { throw dummy }
+    }
+
+    // After resetTimeout passes, CB should still be Open, and we should be able to reset to Closed.
+    sleep(resetTimeout + 10.milliseconds)
+
+    when (val s = cb.state()) {
+      is CircuitBreaker.State.Open -> {
+        s.resetTimeout shouldBe resetTimeout
+      }
+      else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
+    }
+
+    val checkHalfOpen = Promise<Unit>()
+    val delayProtectLatch = Promise<Unit>()
+    val stateAssertionLatch = Promise<Unit>()
+
+    ForkAndForget { // Successful tasks puts circuit breaker back in HalfOpen
+      // Delay protect, to inspect HalfOpen state.
+      Either.catch {
+        cb.protect {
+          checkHalfOpen.complete(Unit)
+          delayProtectLatch.get(); throw dummy
+        }
+      }
+      stateAssertionLatch.complete(Unit)
+    }
+
+    checkHalfOpen.get()
+
+    when (val s = cb.state()) {
+      is CircuitBreaker.State.HalfOpen -> {
+        s.resetTimeout shouldBe resetTimeout
+      }
+      else -> fail("Invalid state: Expect CircuitBreaker.State.HalfOpen but found $s")
+    }
+
+    // Rejects all other tasks in HalfOpen
+    shouldThrow<CircuitBreaker.ExecutionRejected> { cb.protect { throw dummy } }
+    shouldThrow<CircuitBreaker.ExecutionRejected> { cb.protect { throw dummy } }
+
+    // Once we complete `protect`, the circuitbreaker will go back to closer state
+    delayProtectLatch.complete(Unit)
+    stateAssertionLatch.get()
+
+    // Circuit breaker should've stayed open on failure after timeOutReset
+    // resetTimeout should've applied
+    when (val s = cb.state()) {
+      is CircuitBreaker.State.Open -> {
+        s.resetTimeout shouldBe (resetTimeout * exponentialBackoffFactor.toInt())
+      }
+      else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
+    }
+
+    rejectedCount shouldBe 3 // 3 tasks were rejected in total
+    openedCount shouldBe 2 // Circuit breaker opened once
+    halfOpenCount shouldBe 1 // Circuit breaker went into halfOpen once
+    closedCount shouldBe 0 // Circuit breaker closed once after it opened
+  }
+
+  "should be stack safe for successful async tasks" {
+    stackSafeSuspend(
+      CircuitBreaker.of(maxFailures = 5, resetTimeout = 1.minutes)!!,
+      20_000, 0
+    ) shouldBe 20_000
+  }
+
+  "should be stack safe for successful immediate tasks" {
+    stackSafeImmediate(
+      CircuitBreaker.of(maxFailures = 5, resetTimeout = 1.minutes)!!,
+      20_000, 0
+    ) shouldBe 20_000
+  }
+})
+
+/**
+ * Recurs the effect [n] times, and collects the output along the way for easy asserting.
+ */
+fun <A> recurAndCollect(n: Int): Schedule<A, List<A>> =
+  Schedule.recurs<A>(n).zipRight(Schedule.identity<A>().collect())
+
+tailrec suspend fun stackSafeSuspend(cb: CircuitBreaker, n: Int, acc: Int): Int =
+  if (n > 0) {
+    val s = cb.protect { evalOn(ComputationPool) { acc + 1 } }
+    stackSafeSuspend(cb, n - 1, s)
+  } else acc
+
+tailrec suspend fun stackSafeImmediate(cb: CircuitBreaker, n: Int, acc: Int): Int =
+  if (n > 0) {
+    val s = cb.protect { acc + 1 }
+    stackSafeImmediate(cb, n - 1, s)
+  } else acc

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ConcurrentVarTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ConcurrentVarTest.kt
@@ -1,0 +1,280 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.ExperimentalTime
+import io.kotest.property.forAll
+
+@ExperimentalTime
+class ConcurrentVarTest : StringSpec({
+
+  "empty; put; isNotEmpty; take; put; take" {
+    val mvar = ConcurrentVar.empty<Int>()
+    mvar.isEmpty() shouldBe true
+    mvar.put(1)
+    mvar.isNotEmpty() shouldBe true
+    mvar.take() shouldBe 1
+    mvar.put(2)
+    mvar.take() shouldBe 2
+  }
+
+  "empty; tryPut; tryPut; isNotEmpty; tryTake; tryTake; put; take" {
+    val av = ConcurrentVar.empty<Int>()
+    av.isEmpty() shouldBe true
+    av.tryPut(1) shouldBe true
+    av.tryPut(2) shouldBe false
+    av.isNotEmpty() shouldBe true
+    av.tryTake() shouldBe 1
+    av.tryTake() shouldBe null
+    av.put(3)
+    av.take() shouldBe 3
+  }
+
+  "empty; take; put; take; put" {
+    val mvar = ConcurrentVar.empty<Int>()
+
+    val f1 = mvar::take.forkAndForget()
+    mvar.put(10)
+
+    val f2 = mvar::take.forkAndForget()
+    mvar.put(20)
+
+    val aa = f1.join()
+    val bb = f2.join()
+    setOf(aa, bb) shouldBe setOf(10, 20)
+  }
+
+  "empty; put; put; put; take; take; take" {
+    val av = ConcurrentVar.empty<Int>()
+
+    val f1 = ForkAndForget { av.put(10) }
+    val f2 = ForkAndForget { av.put(20) }
+    val f3 = ForkAndForget { av.put(30) }
+
+    val aa = av.take()
+    val bb = av.take()
+    val cc = av.take()
+
+    f1.join()
+    f2.join()
+    f3.join()
+
+    setOf(aa, bb, cc) shouldBe setOf(10, 20, 30)
+  }
+
+  "empty; take; take; take; put; put; put" {
+    val av = ConcurrentVar.empty<Int>()
+
+    val f1 = av::take.forkAndForget()
+    val f2 = av::take.forkAndForget()
+    val f3 = av::take.forkAndForget()
+
+    av.put(10)
+    av.put(20)
+    av.put(30)
+
+    val aa = f1.join()
+    val bb = f2.join()
+    val cc = f3.join()
+
+    setOf(aa, bb, cc) shouldBe setOf(10, 20, 30)
+  }
+
+  "initial; isNotEmpty; take; put; take" {
+    val av = ConcurrentVar(1)
+    av.isNotEmpty() shouldBe true
+    av.take() shouldBe 1
+    av.put(2)
+    av.take() shouldBe 2
+  }
+
+  "initial; take; put; take" {
+    val av = ConcurrentVar(1)
+    av.isEmpty() shouldBe false
+    av.take() shouldBe 1
+    av.put(2)
+    av.take() shouldBe 2
+  }
+
+  "initial; read; take" {
+    val av = ConcurrentVar(1)
+    av.read() shouldBe 1
+    av.take() shouldBe 1
+  }
+
+  "empty; read; put" {
+    val mvar = ConcurrentVar.empty<Int>()
+    val read = mvar::read.forkAndForget()
+    mvar.put(10)
+    read.join() shouldBe 10
+  }
+
+  "put(null) works" {
+    val mvar = ConcurrentVar.empty<String?>()
+    mvar.put(null)
+    mvar.read() shouldBe null
+  }
+
+  // Seems to hang
+  "take/put test is stack safe" {
+    val count = 10000
+    val mvar = ConcurrentVar(1)
+    takePutTestIsStacksafe(count, 0, mvar) shouldBe count
+  }
+
+  "stack overflow test" {
+    val count = 10_000L
+
+    suspend fun exec(channel: Channel<Long>): Long {
+      val f1 = ForkAndForget {
+        (0 until count).parTraverse { i -> channel.put(i) }
+        channel.put(null)
+      }
+
+      val f2 = ForkAndForget { consumerParallel(channel, 0L) }
+      f1.join()
+      return f2.join()
+    }
+
+    val mvar = ConcurrentVar<Long?>(0L)
+    exec(mvar) shouldBe count * (count - 1) / 2
+  }
+
+  "producer-consumer parallel loop" {
+    val count = 10000L
+    forAll(10) { _: Int ->
+      val channel = ConcurrentVar<Long?>(0L)
+      val producerFiber = ForkAndForget { producerParallel(channel, (0L until count).toList()) }
+      val consumerFiber = ForkAndForget { consumerParallel(channel, 0L) }
+
+      producerFiber.join() shouldBe Unit
+      consumerFiber.join() shouldBe count * (count - 1) / 2
+      true
+    }
+  }
+
+  "put is stack safe when repeated sequentially" {
+    val channel = ConcurrentVar.empty<Int>()
+    val (count, reads, writes) = testStackSequential(channel)
+    writes.forkAndForget()
+    reads.invoke() shouldBe count
+  }
+
+  "take is stack safe when repeated sequentially" {
+    val channel = ConcurrentVar.empty<Int>()
+    val (count, reads, writes) = testStackSequential(channel)
+    val fr = reads.forkAndForget()
+    writes.invoke()
+    fr.join() shouldBe count
+  }
+
+  "concurrent take and put" {
+    val count = 1_000
+    val mVar = ConcurrentVar.empty<Int>()
+    val ref = Atomic(0)
+    val takes = ForkAndForget {
+      (0 until count)
+        .parTraverse {
+          val x = mVar.read() + mVar.take()
+          ref.update { it + x }
+        }
+    }
+
+    val puts = ForkAndForget { (0 until count).parTraverse { mVar.put(1) } }
+
+    takes.join()
+    puts.join()
+    ref.get() shouldBe count * 2
+  }
+
+  "put is cancellable" {
+    val mVar = ConcurrentVar(0)
+    ForkAndForget { mVar.put(1) }
+    val p2 = ForkAndForget { mVar.put(2) }
+    ForkAndForget { mVar.put(3) }
+    sleep(10.milliseconds) // Give put callbacks a chance to register
+    p2.cancel()
+    mVar.take()
+    val r1 = mVar.take()
+    val r3 = mVar.take()
+    setOf(r1, r3) shouldBe setOf(1, 3)
+  }
+
+  "take is cancellable" {
+    val mVar = ConcurrentVar.empty<Int>()
+    val t1 = ForkAndForget { mVar.take() }
+    val t2 = ForkAndForget { mVar.take() }
+    val t3 = ForkAndForget { mVar.take() }
+    sleep(10.milliseconds) // Give take callbacks a chance to register
+    t2.cancel()
+    mVar.put(1)
+    mVar.put(3)
+    val r1 = t1.join()
+    val r3 = t3.join()
+    setOf(r1, r3) shouldBe setOf(1, 3)
+  }
+
+  "read is cancellable" {
+    val mVar = ConcurrentVar.empty<Int>()
+    val finished = Promise<Int>()
+    val fiber = ForkAndForget {
+      mVar.read()
+      finished.complete(1)
+    }
+    sleep(100.milliseconds) // Give read callback a chance to register
+    fiber.cancel()
+    mVar.put(10)
+    val fallback = suspend { sleep(200.milliseconds); 0 }
+    raceN(finished::get, fallback) shouldBe Either.Right(0)
+  }
+})
+
+// Signaling using null, because we need to detect completion
+private typealias Channel<A> = ConcurrentVar<A?>
+
+private tailrec suspend fun takePutTestIsStacksafe(n: Int, acc: Int, ch: ConcurrentVar<Int>): Int =
+  if (n <= 0) acc
+  else {
+    val x = ch.take()
+    ch.put(1)
+    takePutTestIsStacksafe(n = n - 1, acc = acc + x, ch = ch)
+  }
+
+suspend fun producerParallel(ch: Channel<Long>, list: List<Long>): Unit {
+  list.map { ch.put(it) }
+  ch.put(null) // we are done!
+}
+
+tailrec suspend fun consumerParallel(ch: Channel<Long>, sum: Long): Long {
+  val x = ch.take()
+  return if (x != null) consumerParallel(ch, sum + x) // next please
+  else sum
+}
+
+//  java.lang.UnsupportedOperationException: This class is an internal synthetic class generated by
+//  the Kotlin compiler, such as an anonymous class for a lambda, a SAM wrapper, a callable reference, etc.
+//  It's not a Kotlin class or interface, so the reflection library has no idea what declarations does it have.
+//  Please use Java reflection to inspect this class: class arrow.fx.coroutines.MVarTest$1$14$1
+// TODO CREATE TICKET KOTLIN BUG TRACKER. HAVING THIS IN THE CLASS BLEW UP WITH THIS @ RUNTIME
+fun testStackSequential(channel: ConcurrentVar<Int>): Triple<Int, suspend () -> Int, suspend () -> Unit> {
+  val count = 10000
+  return Triple(
+    count,
+    suspend { readLoop(count, 0, channel) },
+    suspend { writeLoop(count, channel) }
+  )
+}
+
+tailrec suspend fun readLoop(n: Int, acc: Int, channel: ConcurrentVar<Int>): Int =
+  if (n > 0) {
+    channel.read()
+    channel.take()
+    readLoop(n - 1, acc + 1, channel)
+  } else acc
+
+tailrec suspend fun writeLoop(n: Int, channel: ConcurrentVar<Int>): Unit =
+  if (n > 0) {
+    channel.put(1)
+    writeLoop(n - 1, channel)
+  } else Unit

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/EvalOnTests.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/EvalOnTests.kt
@@ -1,0 +1,232 @@
+package arrow.fx.coroutines
+
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+import io.kotest.property.forAll
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineName
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+class EvalOnTests : StringSpec({
+
+  "immediate value" {
+    checkAll(Arb.int()) { i ->
+      evalOn(ComputationPool) {
+        i
+      } shouldBe i
+    }
+  }
+
+  "suspend value" {
+    checkAll(Arb.int()) { i ->
+      evalOn(ComputationPool) {
+        i.suspend()
+      } shouldBe i
+    }
+  }
+
+  "evalOn on the same context doesn't dispatch" {
+    suspend fun onSameContext(): String =
+      evalOn(ComputationPool) {
+        Thread.currentThread().name
+      }
+
+    forAll { _: Int ->
+      Platform.unsafeRunSync(ComputationPool) {
+        val startOn = Thread.currentThread().name
+        onSameContext() shouldBe startOn
+        Thread.currentThread().name == startOn
+      }
+    }
+  }
+
+  "evalOn on the same context doesn't intercept" {
+    suspend fun onComputation(ctx: CoroutineContext): String =
+      evalOn(ctx) {
+        Thread.currentThread().name
+      }
+
+    forAll { _: Int ->
+      val interceptor = TestableContinuationInterceptor()
+
+      Platform.unsafeRunSync(interceptor) {
+        val startOn = Thread.currentThread().name
+        onComputation(interceptor) shouldBe startOn
+        Thread.currentThread().name shouldBe startOn
+        interceptor.timesIntercepted() shouldBe 0
+        true
+      }
+    }
+  }
+
+  "evalOn on a different context with the same ContinuationInterceptor doesn't intercept" {
+    suspend fun onComputation(ctx: CoroutineContext): String =
+      evalOn(ctx + CoroutineName("Different coroutine")) {
+        Thread.currentThread().name
+      }
+
+    forAll { _: Int ->
+      val interceptor = TestableContinuationInterceptor()
+
+      Platform.unsafeRunSync(interceptor) {
+        val startOn = Thread.currentThread().name
+        onComputation(interceptor) shouldBe startOn
+        Thread.currentThread().name shouldBe startOn
+        interceptor.timesIntercepted() shouldBe 0
+        true
+      }
+    }
+  }
+
+  "evalOn on a different context with a different ContinuationInterceptor does intercept" {
+    suspend fun onComputation(): String =
+      evalOn(IOPool) {
+        Thread.currentThread().name
+      }
+
+    forAll { _: Int -> // Run this test on single thread context to guarantee name
+      single.use { ctx ->
+        Platform.unsafeRunSync(ctx) {
+          val startOn = Thread.currentThread().name
+          onComputation() shouldNotBe startOn
+          Thread.currentThread().name shouldBe startOn
+          true
+        }
+      }
+    }
+  }
+
+  "immediate exception on KotlinX Dispatchers" {
+    checkAll(Arb.int(), Arb.throwable()) { i, e ->
+      val r = try {
+        evalOn<Int>(coroutineContext) {
+          throw e
+        }
+        fail("Should never reach this point")
+      } catch (throwable: Throwable) {
+        throwable shouldBe e
+        i
+      }
+
+      r shouldBe i
+    }
+  }
+
+  "suspend exception on KotlinX Dispatchers" {
+    checkAll(Arb.int(), Arb.throwable()) { i, e ->
+      val r = try {
+        evalOn<Int>(coroutineContext) {
+          e.suspend()
+        }
+        fail("Should never reach this point")
+      } catch (throwable: Throwable) {
+        throwable shouldBe e
+        i
+      }
+
+      r shouldBe i
+    }
+  }
+
+  "immediate exception from wrapped KotlinX Dispatcher" {
+    checkAll(Arb.int(), Arb.throwable()) { i, e ->
+      val r = try {
+        evalOn<Int>(wrapperKotlinXDispatcher(coroutineContext)) {
+          throw e
+        }
+        fail("Should never reach this point")
+      } catch (throwable: Throwable) {
+        throwable shouldBe e
+        i
+      }
+
+      r shouldBe i
+    }
+  }
+
+  "suspend exception from wrapped KotlinX Dispatcher" {
+    checkAll(Arb.int(), Arb.throwable()) { i, e ->
+      val r = try {
+        evalOn<Int>(wrapperKotlinXDispatcher(coroutineContext)) {
+          e.suspend()
+        }
+        fail("Should never reach this point")
+      } catch (throwable: Throwable) {
+        throwable shouldBe e
+        i
+      }
+
+      r shouldBe i
+    }
+  }
+
+  "immediate exception from Arrow Fx Pool" {
+    checkAll(Arb.int(), Arb.throwable()) { i, e ->
+      val r = try {
+        evalOn<Int>(IOPool) {
+          throw e
+        }
+        fail("Should never reach this point")
+      } catch (throwable: Throwable) {
+        throwable shouldBe e
+        i
+      }
+
+      r shouldBe i
+    }
+  }
+
+  "suspend exception from Arrow Fx Pool" {
+    checkAll(Arb.int(), Arb.throwable()) { i, e ->
+      val r = try {
+        evalOn<Int>(IOPool) {
+          e.suspend()
+        }
+        fail("Should never reach this point")
+      } catch (throwable: Throwable) {
+        throwable shouldBe e
+        i
+      }
+
+      r shouldBe i
+    }
+  }
+})
+
+private class TestableContinuationInterceptor : AbstractCoroutineContextElement(ContinuationInterceptor),
+  ContinuationInterceptor {
+
+  // Starting to run test always starts with an initial intercepted, so start count on -1.
+  private val invocations = atomic(-1)
+
+  companion object Key : CoroutineContext.Key<ContinuationInterceptor>
+
+  override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> {
+    invocations.incrementAndGet()
+    return continuation
+  }
+
+  fun timesIntercepted(): Int = invocations.value
+}
+
+private fun wrapperKotlinXDispatcher(context: CoroutineContext): CoroutineContext {
+  val dispatcher = context[ContinuationInterceptor] as CoroutineDispatcher
+  return object : CoroutineDispatcher() {
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean =
+      dispatcher.isDispatchNeeded(context)
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) =
+      dispatcher.dispatch(context, block)
+  }
+}

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/FiberTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/FiberTest.kt
@@ -1,0 +1,205 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+
+class FiberTest : StringSpec({
+
+  "ForkConnected get cancelled by its parent" {
+    val start = Promise<Unit>()
+    val p = Promise<ExitCase>()
+
+    val parent = ForkAndForget {
+      ForkConnected { // Child fiber
+        guaranteeCase({
+          start.complete(Unit)
+          never<Unit>()
+        }, { p.complete(it) })
+      }
+    }
+
+    start.get()
+    parent.cancel()
+    p.get() shouldBe ExitCase.Cancelled
+  }
+
+  "ForkConnected doesn't cancel its parent" {
+    checkAll(Arb.int()) { i ->
+      val cancelled = Promise<Unit>()
+
+      val parent = ForkAndForget {
+        val f = ForkConnected { never<Unit>() }
+        parTupledN({ cancelled.get() }, { f.cancel(); cancelled.complete(Unit) })
+        cancelBoundary()
+        i
+      }
+
+      parent.join() shouldBe i
+    }
+  }
+
+  "ForkConnected runs on the expected dispatcher" {
+    suspend fun threadName(): String =
+      Thread.currentThread().name
+
+    single.use { ctx ->
+      val fiber = ::threadName.forkConnected(ctx)
+
+      // Join fiber before closing ctx resource
+      fiber.join() shouldBe "single"
+    }
+  }
+
+  "ForkConnected.join is idempotent" {
+    checkAll(Arb.int()) { i ->
+      val ref = Atomic(0)
+
+      val f = suspend { ref.update { it + i } }
+        .forkConnected()
+
+      f.join()
+
+      f.join()
+
+      ref.get() shouldBe i
+    }
+  }
+
+  "ForkConnected error join is identity" {
+    checkAll(Arb.throwable()) { e ->
+      val f = suspend { throw e }.forkConnected()
+      Either.catch { f.join() } shouldBe Either.Left(e)
+    }
+  }
+
+  "ForkConnected error cancel is unit" {
+    checkAll(Arb.throwable()) { e ->
+      val f = suspend { throw e }.forkConnected()
+      f.cancel() shouldBe Unit
+    }
+  }
+
+  "ForkConnected value cancel is unit" {
+    checkAll(Arb.int()) { i ->
+      val f = suspend { i }.forkConnected()
+      f.cancel() shouldBe Unit
+    }
+  }
+
+  "ForkScoped get cancelled by interrupt token" {
+    val start = Promise<Unit>()
+    val p = Promise<ExitCase>()
+    val interrupt = Promise<Unit>()
+
+    ForkScoped(interruptWhen = interrupt::get) { // Child fiber
+      guaranteeCase({
+        start.complete(Unit)
+        never<Unit>()
+      }, { p.complete(it) })
+    }
+
+    start.get()
+    interrupt.complete(Unit)
+    p.get() shouldBe ExitCase.Cancelled
+  }
+
+  "ForkScoped runs on the expected dispatcher" {
+    suspend fun threadName(): String =
+      Thread.currentThread().name
+
+    single.use { ctx ->
+      val fiber = ::threadName.forkScoped(ctx) { never<Unit>() }
+
+      // Join fiber before closing ctx resource
+      fiber.join() shouldBe "single"
+    }
+  }
+
+  "ForkScoped.join is idempotent" {
+    checkAll(Arb.int()) { i ->
+      val ref = Atomic(0)
+
+      val f = suspend { ref.update { it + i } }
+        .forkScoped { never<Unit>() }
+
+      f.join()
+
+      f.join()
+
+      ref.get() shouldBe i
+    }
+  }
+
+  "ForkScoped error join is identity" {
+    checkAll(Arb.throwable()) { e ->
+      val f = suspend { throw e }.forkScoped { never<Unit>() }
+      Either.catch { f.join() } shouldBe Either.Left(e)
+    }
+  }
+
+  "ForkScoped error cancel is unit" {
+    checkAll(Arb.throwable()) { e ->
+      val f = suspend { throw e }.forkScoped { never<Unit>() }
+      f.cancel() shouldBe Unit
+    }
+  }
+
+  "ForkScoped value cancel is unit" {
+    checkAll(Arb.int()) { i ->
+      val f = suspend { i }.forkScoped { never<Unit>() }
+      f.cancel() shouldBe Unit
+    }
+  }
+
+  "ForkAndForget runs on the expected dispatcher" {
+    suspend fun threadName(): String =
+      Thread.currentThread().name
+
+    single.use { ctx ->
+      val fiber = ::threadName.forkAndForget(ctx)
+
+      // Join fiber before closing ctx resource
+      fiber.join() shouldBe "single"
+    }
+  }
+
+  "ForkAndForget.join is idempotent" {
+    checkAll(Arb.int()) { i ->
+      val ref = Atomic(0)
+
+      val f = suspend { ref.update { it + i } }
+        .forkAndForget()
+
+      f.join()
+
+      f.join()
+
+      ref.get() shouldBe i
+    }
+  }
+
+  "ForkAndForget error join is identity" {
+    checkAll(Arb.throwable()) { e ->
+      val f = suspend { throw e }.forkAndForget()
+      Either.catch { f.join() } shouldBe Either.Left(e)
+    }
+  }
+
+  "ForkAndForget error cancel is unit" {
+    checkAll(Arb.throwable()) { e ->
+      val f = suspend { throw e }.forkAndForget()
+      f.cancel() shouldBe Unit
+    }
+  }
+
+  "ForkAndForget value cancel is unit" {
+    checkAll(Arb.int()) { i ->
+      val f = suspend { i }.forkAndForget()
+      f.cancel() shouldBe Unit
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ForwardCancelableTests.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ForwardCancelableTests.kt
@@ -1,0 +1,58 @@
+package arrow.fx.coroutines
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.lang.IllegalStateException
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+
+class ForwardCancelableTests : StringSpec({
+  "cancel() after complete" {
+    var effect = 0
+
+    val ref = ForwardCancellable()
+    ref.complete(CancelToken { effect += 1 })
+    effect shouldBe 0
+
+    Platform.unsafeRunSync(ref.cancel().cancel)
+    effect shouldBe 1
+
+    // Weak idempotency guarantees (not thread-safe)
+    Platform.unsafeRunSync(ref.cancel().cancel)
+    effect shouldBe 1
+  }
+
+  "cancel() before complete" {
+    var effect = 0
+
+    val ref = ForwardCancellable()
+    ref.cancel().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { })
+    effect shouldBe 0
+
+    ref.complete(CancelToken { effect += 1 })
+    effect shouldBe 1
+
+    shouldThrow<IllegalStateException> { ref.complete(CancelToken { effect += 2 }) }
+    // completed task was canceled before error was thrown
+    effect shouldBe 3
+
+    Platform.unsafeRunSync(ref.cancel().cancel)
+    effect shouldBe 3
+  }
+
+  "complete twice before cancel" {
+    var effect = 0
+
+    val ref = ForwardCancellable()
+    ref.complete(CancelToken { effect += 1 })
+    effect shouldBe 0
+
+    shouldThrow<IllegalStateException> { ref.complete(CancelToken { effect += 2 }) }
+    effect shouldBe 2
+
+    Platform.unsafeRunSync(ref.cancel().cancel)
+    effect shouldBe 3
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/GuaranteeCaseTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/GuaranteeCaseTest.kt
@@ -1,0 +1,59 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+
+class GuaranteeCaseTest : StringSpec({
+
+  "release for success was invoked" {
+    checkAll(Arb.int()) { i ->
+      val p = Promise<ExitCase>()
+
+      val res = guaranteeCase(
+        fa = { i },
+        release = { ex -> p.complete(ex) }
+      )
+
+      p.get() shouldBe ExitCase.Completed
+      res shouldBe i
+    }
+  }
+
+  "release for error was invoked" {
+    checkAll(Arb.throwable()) { e ->
+      val p = Promise<ExitCase>()
+      val attempted = Either.catch {
+        guaranteeCase<Int>(
+          fa = { throw e },
+          release = { ex -> p.complete(ex) }
+        )
+      }
+
+      p.get() shouldBe ExitCase.Failure(e)
+      attempted shouldBe Either.Left(e)
+    }
+  }
+
+  "release for never was invoked" {
+    val p = Promise<ExitCase>()
+    val start = Promise<Unit>()
+
+    val fiber = ForkAndForget {
+      guaranteeCase(
+        fa = {
+          start.complete(Unit)
+          never<Unit>()
+        },
+        release = { ex -> p.complete(ex) }
+      )
+    }
+
+    start.get()
+    fiber.cancel()
+    p.get() shouldBe ExitCase.Cancelled
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTraverseTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTraverseTest.kt
@@ -1,0 +1,167 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+class ParTraverseTest : StringSpec({
+
+  "parTraverse can traverse effect full computations" {
+    val ref = Atomic(0)
+    (0 until 100).parTraverse {
+      ref.update { it + 1 }
+    }
+    ref.get() shouldBe 100
+  }
+
+  "parTraverse runs in parallel" {
+    val promiseA = Promise<Unit>()
+    val promiseB = Promise<Unit>()
+    val promiseC = Promise<Unit>()
+
+    listOf(
+      suspend {
+        promiseA.get()
+        promiseC.complete(Unit)
+      },
+      suspend {
+        promiseB.get()
+        promiseA.complete(Unit)
+      },
+      suspend {
+        promiseB.complete(Unit)
+        promiseC.get()
+      }
+    ).parSequence()
+  }
+
+  "parTraverse results in the correct error" {
+    checkAll(
+      10,
+      Arb.int(min = 10, max = 20),
+      Arb.int(min = 1, max = 9),
+      Arb.throwable()
+    ) { n, killOn, e ->
+      Either.catch {
+        (0 until n).parTraverse(IOPool) { i ->
+          if (i == killOn) throw e else unit()
+        }
+      } shouldBe Either.Left(e)
+    }
+  }
+
+  "parTraverse identity is identity" {
+    checkAll(Arb.list(Arb.int())) { l ->
+      l.parTraverse { it } shouldBe l
+    }
+  }
+
+  "parTraverse stack-safe" {
+    val count = 20_000
+    val l = (0 until count).parTraverse { it }
+    l shouldBe (0 until count).toList()
+  }
+
+  "parTraverse finishes on single thread " { // 100 is same default length as Arb.list
+    checkAll(Arb.int(min = Int.MIN_VALUE, max = 100)) { i ->
+      single.use { ctx ->
+        (0 until i).parTraverse(ctx) { Thread.currentThread().name }
+      } shouldBe (0 until i).map { "single" }
+    }
+  }
+
+  "parTraverseN can traverse effect full computations" {
+    val ref = Atomic(0)
+    (0 until 100).parTraverseN(5) {
+      ref.update { it + 1 }
+    }
+    ref.get() shouldBe 100
+  }
+
+  "parTraverseN finishes on single thread" {
+    checkAll(Arb.int(min = Int.MIN_VALUE, max = 100)) { i ->
+      single.use { ctx ->
+        (0 until i).parTraverseN(ctx, 3) {
+          Thread.currentThread().name
+        }
+      } shouldBe (0 until i).map { "single" }
+    }
+  }
+
+  "parTraverseN(3) runs in (3) parallel" {
+    val promiseA = Promise<Unit>()
+    val promiseB = Promise<Unit>()
+    val promiseC = Promise<Unit>()
+
+    listOf(
+      suspend {
+        promiseA.get()
+        promiseC.complete(Unit)
+      },
+      suspend {
+        promiseB.get()
+        promiseA.complete(Unit)
+      },
+      suspend {
+        promiseB.complete(Unit)
+        promiseC.get()
+      }
+    ).parSequenceN(3)
+  }
+
+  "parTraverseN(1) times out running 3 tasks" {
+    val promiseA = Promise<Unit>()
+    val promiseB = Promise<Unit>()
+    val promiseC = Promise<Unit>()
+
+    timeOutOrNull(10.milliseconds) {
+      listOf(
+        suspend {
+          promiseA.get()
+          promiseC.complete(Unit)
+        },
+        suspend {
+          promiseB.get()
+          promiseA.complete(Unit)
+        },
+        suspend {
+          promiseB.complete(Unit)
+          promiseC.get()
+        }
+      ).parSequenceN(1)
+    } shouldBe null
+  }
+
+  "parTraverseN identity is identity" {
+    checkAll(Arb.list(Arb.int())) { l ->
+      l.parTraverseN(5) { it } shouldBe l
+    }
+  }
+
+  "parTraverseN results in the correct error" {
+    checkAll(
+      10,
+      Arb.int(min = 10, max = 20),
+      Arb.int(min = 1, max = 9),
+      Arb.throwable()
+    ) { n, killOn, e ->
+      Either.catch {
+        (0 until n).parTraverseN(IOPool, 3) { i ->
+          if (i == killOn) throw e else unit()
+        }
+      } shouldBe Either.Left(e)
+    }
+  }
+
+  "parTraverseN stack-safe" {
+    val count = 20_000
+    val l = (0 until count).parTraverseN(20) { it }
+    l shouldBe (0 until count).toList()
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTupledNTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTupledNTest.kt
@@ -1,0 +1,166 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bool
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+
+class ParTupledNTest : StringSpec({
+
+  "ParTupledN 2 runs in parallel" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      val r = Atomic("")
+      val modifyGate = Promise<Int>()
+
+      parTupledN(
+        {
+          modifyGate.get()
+          r.update { i -> "$i$a" }
+        },
+        {
+          r.set("$b")
+          modifyGate.complete(0)
+        }
+      )
+
+      r.get() shouldBe "$b$a"
+    }
+  }
+
+  "ParTupledN 2 finishes on single thread" {
+    checkAll(Arb.string()) { name ->
+      single.use { ctx ->
+        parTupledN(ctx, threadName, threadName)
+      } shouldBe Pair("single", "single")
+    }
+  }
+
+  "Cancelling ParTupledN 2 cancels all participants" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+      val pb = Promise<Pair<Int, ExitCase>>()
+
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+      val loserB = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+
+      val f = ForkAndForget { parTupledN(loserA, loserB) }
+
+      s.acquireN(2) // Suspend until all racers started
+      f.cancel()
+
+      pa.get() shouldBe Pair(a, ExitCase.Cancelled)
+      pb.get() shouldBe Pair(b, ExitCase.Cancelled)
+    }
+  }
+
+  "ParTupledN 2 cancels losers if a failure occurs in one of the tasks" {
+    checkAll(
+      Arb.throwable(),
+      Arb.bool(),
+      Arb.int()
+    ) { e, leftWinner, a ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+
+      val winner = suspend { s.acquire(); throw e }
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+
+      val r = Either.catch {
+        if (leftWinner) parTupledN(winner, loserA)
+        else parTupledN(loserA, winner)
+      }
+
+      pa.get() shouldBe Pair(a, ExitCase.Cancelled)
+      r shouldBe Either.Left(e)
+    }
+  }
+
+  "ParTupledN 3 runs in parallel" {
+    checkAll(Arb.int(), Arb.int(), Arb.int()) { a, b, c ->
+      val r = Atomic("")
+      val modifyGate1 = Promise<Unit>()
+      val modifyGate2 = Promise<Unit>()
+
+      parTupledN(
+        {
+          modifyGate2.get()
+          r.update { i -> "$i$a" }
+        },
+        {
+          modifyGate1.get()
+          r.update { i -> "$i$b" }
+          modifyGate2.complete(Unit)
+        },
+        {
+          r.set("$c")
+          modifyGate1.complete(Unit)
+        }
+      )
+
+      r.get() shouldBe "$c$b$a"
+    }
+  }
+
+  "ParTupledN 3 finishes on single thread" {
+      single.use { ctx ->
+        parTupledN(ctx, threadName, threadName, threadName)
+      } shouldBe Triple("single", "single", "single")
+  }
+
+  "Cancelling ParTupledN 3 cancels all participants" {
+    checkAll(Arb.int(), Arb.int(), Arb.int()) { a, b, c ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+      val pb = Promise<Pair<Int, ExitCase>>()
+      val pc = Promise<Pair<Int, ExitCase>>()
+
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+      val loserB = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+      val loserC = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pc.complete(Pair(c, ex)) } }
+
+      val f = ForkAndForget { parTupledN(loserA, loserB, loserC) }
+
+      s.acquireN(3) // Suspend until all racers started
+      f.cancel()
+
+      pa.get() shouldBe Pair(a, ExitCase.Cancelled)
+      pb.get() shouldBe Pair(b, ExitCase.Cancelled)
+      pc.get() shouldBe Pair(c, ExitCase.Cancelled)
+    }
+  }
+
+  "ParTupledN 3 cancels losers if a failure occurs in one of the tasks" {
+    checkAll(
+      Arb.throwable(),
+      Arb.element(listOf(1, 2, 3)),
+      Arb.int(),
+      Arb.int()
+    ) { e, leftWinner, a, b ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+      val pb = Promise<Pair<Int, ExitCase>>()
+
+      val winner = suspend { s.acquireN(2); throw e }
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+      val loserB = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+
+      val res = Either.catch {
+        when (leftWinner) {
+          1 -> raceN(winner, loserA, loserB)
+          2 -> raceN(loserA, winner, loserB)
+          else -> raceN(loserA, loserB, winner)
+        }
+      }
+
+      pa.get() shouldBe Pair(a, ExitCase.Cancelled)
+      pb.get() shouldBe Pair(b, ExitCase.Cancelled)
+      res shouldBe Either.Left(e)
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/PredefTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/PredefTest.kt
@@ -1,0 +1,46 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+
+class PredefTest : StringSpec({
+
+  "suspended always suspends" {
+    checkAll(Arb.int()) { i ->
+      val promise = UnsafePromise<Int>()
+
+      val x = i.suspended()
+        .startCoroutineUninterceptedOrReturn(Continuation(EmptyCoroutineContext) {
+          promise.complete(it)
+        })
+
+      x shouldBe COROUTINE_SUSPENDED
+      promise.join() shouldBe i
+    }
+  }
+
+  "either.suspended always suspends" {
+    checkAll(Arb.either(Arb.throwable(), Arb.int())) { ea ->
+      val promise = UnsafePromise<Int>()
+
+      val x = ea.suspended()
+        .startCoroutineUninterceptedOrReturn(Continuation(EmptyCoroutineContext) {
+          promise.complete(it)
+        })
+
+      x shouldBe COROUTINE_SUSPENDED
+
+      Either.catch {
+        promise.join()
+      } shouldBe ea
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/PromiseTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/PromiseTest.kt
@@ -1,0 +1,55 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class PromiseTest : StringSpec({
+
+  class MyException : Exception()
+
+  val exception = MyException()
+
+  "complete" {
+    val p = Promise<Int>()
+    p.complete(1) shouldBe Either.Right(Unit)
+    p.get() shouldBe 1
+  }
+
+  "complete twice should result in Promise.AlreadyFulfilled" {
+    val p = Promise<Int>()
+    p.complete(1) shouldBe Either.Right(Unit)
+    p.complete(2) shouldBe Either.Left(Promise.AlreadyFulfilled)
+    p.get() shouldBe 1
+  }
+
+  "get blocks until set" {
+    val r = Atomic(0)
+    val modifyGate = Promise<Int>()
+    val readGate = Promise<Int>()
+
+    ForkAndForget {
+      modifyGate.get()
+      r.update { i -> i * 2 }
+      readGate.complete(0)
+    }
+
+    ForkAndForget {
+      r.set(1)
+      modifyGate.complete(0)
+    }
+
+    readGate.get()
+    r.get() shouldBe 2
+  }
+
+  "tryGet returns None for empty Promise" {
+    Promise<Int>().tryGet() shouldBe null
+  }
+
+  "tryGet returns Some for completed promise" {
+    val p = Promise<Int>()
+    p.complete(1)
+    p.tryGet() shouldBe 1
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RaceNTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RaceNTest.kt
@@ -1,0 +1,145 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bool
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+
+class RaceNTest : StringSpec({
+
+  "race2 can join first" {
+    checkAll(Arb.int()) { i ->
+      raceN({ i }, { never<Unit>() }) shouldBe Either.Left(i)
+    }
+  }
+
+  "race2 can join second" {
+    checkAll(Arb.int()) { i ->
+      raceN({ never<Unit>() }, { i }) shouldBe Either.Right(i)
+    }
+  }
+
+  "first racer out of 2 always wins on a single thread" {
+      single.use { ctx ->
+        raceN(ctx, threadName, threadName)
+      } shouldBe Either.Left("single")
+  }
+
+  "Cancelling race 2 cancels all participants" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+      val pb = Promise<Pair<Int, ExitCase>>()
+
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+      val loserB = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+
+      val f = ForkAndForget { raceN(loserA, loserB) }
+
+      s.acquireN(2) // Suspend until all racers started
+      f.cancel()
+
+      pa.get() shouldBe Pair(a, ExitCase.Cancelled)
+      pb.get() shouldBe Pair(b, ExitCase.Cancelled)
+    }
+  }
+
+  "race 2 cancels losers with first success or failure determining winner" {
+    checkAll(
+      Arb.either(Arb.throwable(), Arb.int()),
+      Arb.bool(),
+      Arb.int()
+    ) { eith, leftWinner, a ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+
+      val winner = suspend { s.acquire(); eith.rethrow() }
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+
+      Either.catch {
+        if (leftWinner) raceN(winner, loserA)
+        else raceN(loserA, winner)
+      }
+
+      pa.get() shouldBe Pair(a, ExitCase.Cancelled)
+    }
+  }
+
+  "race3 can join first" {
+    checkAll(Arb.int()) { i ->
+      raceN({ i }, { never<Unit>() }, { never<Unit>() }) shouldBe Race3.First(i)
+    }
+  }
+
+  "race3 can join second" {
+    checkAll(Arb.int()) { i ->
+      raceN({ never<Unit>() }, { i }, { never<Unit>() }) shouldBe Race3.Second(i)
+    }
+  }
+
+  "race3 can join third" {
+    checkAll(Arb.int()) { i ->
+      raceN({ never<Unit>() }, { never<Unit>() }, { i }) shouldBe Race3.Third(i)
+    }
+  }
+
+  "first racer out of 3 always wins on a single thread" {
+      single.use { ctx ->
+        raceN(ctx, threadName, threadName, threadName)
+      } shouldBe Race3.First("single")
+  }
+
+  "Cancelling race 3 cancels all participants" {
+    checkAll(Arb.int(), Arb.int(), Arb.int()) { a, b, c ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+      val pb = Promise<Pair<Int, ExitCase>>()
+      val pc = Promise<Pair<Int, ExitCase>>()
+
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+      val loserB = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+      val loserC = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pc.complete(Pair(c, ex)) } }
+
+      val f = ForkAndForget { raceN(loserA, loserB, loserC) }
+
+      s.acquireN(3) // Suspend until all racers started
+      f.cancel()
+
+      pa.get() shouldBe Pair(a, ExitCase.Cancelled)
+      pb.get() shouldBe Pair(b, ExitCase.Cancelled)
+      pc.get() shouldBe Pair(c, ExitCase.Cancelled)
+    }
+  }
+
+  "race 3 cancels losers with first success or failure determining winner" {
+    checkAll(
+      Arb.either(Arb.throwable(), Arb.int()),
+      Arb.element(listOf(1, 2, 3)),
+      Arb.int(),
+      Arb.int()
+    ) { eith, leftWinner, a, b ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+      val pb = Promise<Pair<Int, ExitCase>>()
+
+      val winner = suspend { s.acquireN(2); eith.rethrow() }
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+      val loserB = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+
+      Either.catch {
+        when (leftWinner) {
+          1 -> raceN(winner, loserA, loserB)
+          2 -> raceN(loserA, winner, loserB)
+          else -> raceN(loserA, loserB, winner)
+        }
+      }
+
+      pa.get() shouldBe Pair(a, ExitCase.Cancelled)
+      pb.get() shouldBe Pair(b, ExitCase.Cancelled)
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RacePairTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RacePairTest.kt
@@ -1,0 +1,98 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bool
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+
+class RacePairTest : StringSpec({
+
+  "race pair mirrors left winner" {
+    checkAll(Arb.either(Arb.throwable(), Arb.int())) { fa ->
+
+      Either.catch {
+        racePair({ fa.rethrow() }, { never<Unit>() })
+          .fold(Pair<Int, Fiber<Unit>>::first) { fail("never can not win race") }
+      } shouldBe fa
+    }
+  }
+
+  "race pair mirrors right winner" {
+    checkAll(Arb.either(Arb.throwable(), Arb.int())) { fa ->
+
+      Either.catch {
+        racePair({ never<Unit>() }, { fa.rethrow() })
+          .fold({ fail("never can not win race") }, Pair<Fiber<Unit>, Int>::second)
+      } shouldBe fa
+    }
+  }
+
+  "race pair can cancel loser" {
+    checkAll(
+      Arb.either(Arb.throwable(), Arb.int()),
+      Arb.bool(),
+      Arb.int()
+    ) { fa, leftWinner, i ->
+      val s = Semaphore(0)
+      val p = Promise<Int>()
+      val winner = suspend { s.acquire(); fa.rethrow() }
+      val loser = suspend { bracket(acquire = { s.release() }, use = { never<String>() }, release = { p.complete(i) }) }
+
+      Either.catch {
+        if (leftWinner) racePair(winner, loser)
+        else racePair(loser, winner)
+      }.fold({ p.get() }, {
+        it.fold(
+          { (_, fiberB) -> ForkConnected { fiberB.cancel() }; p.get() },
+          { (fiberA, _) -> ForkConnected { fiberA.cancel() }; p.get() }
+        )
+      }) shouldBe i
+    }
+  }
+
+  "race pair can join left" {
+    checkAll(Arb.int()) { i ->
+      val p = Promise<Int>()
+      racePair({ p.get() }, { Unit })
+        .fold(
+          { fail("promise.get cannot win race") },
+          { (fiber, _) -> p.complete(i); fiber.join() }
+        ) shouldBe i
+    }
+  }
+
+  "race pair can join right" {
+    checkAll(Arb.int()) { i ->
+      val p = Promise<Int>()
+      racePair({ Unit }, { p.get() })
+        .fold(
+          { (_, fiber) -> p.complete(i); fiber.join() },
+          { fail("promise.get cannot win race") }
+        ) shouldBe i
+    }
+  }
+
+  "cancelling race pair cancels both" {
+    checkAll(Arb.int(), Arb.int()) { a, b ->
+      val s = Semaphore(0)
+      val pa = Promise<Int>()
+      val pb = Promise<Int>()
+
+      val loserA = suspend { bracket({ s.release() }, use = { never<Int>() }, release = { pa.complete(a) }) }
+      val loserB = suspend { bracket({ s.release() }, use = { never<Int>() }, release = { pb.complete(b) }) }
+
+      val fiber = ForkAndForget { racePair(loserA, loserB) }
+
+      s.acquireN(2) // Wait until both racers started
+
+      fiber.cancel()
+
+      pa.get() shouldBe a
+      pb.get() shouldBe b
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RaceTripleTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RaceTripleTest.kt
@@ -1,0 +1,147 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.assertions.fail
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+
+class RaceTripleTest : StringSpec({
+
+  "race triple mirrors left winner" {
+    checkAll(Arb.either(Arb.throwable(), Arb.int())) { fa ->
+
+      Either.catch {
+        raceTriple({ fa.rethrow() }, { never<Unit>() }, { never<Unit>() })
+          .fold(
+            { a, _, _ -> a },
+            { _, _, _ -> fail("never can not win race") },
+            { _, _, _ -> fail("never can not win race") }
+          )
+      } shouldBe fa
+    }
+  }
+
+  "race triple mirrors middle winner" {
+    checkAll(Arb.either(Arb.throwable(), Arb.int())) { fa ->
+
+      Either.catch {
+        raceTriple({ never<Unit>() }, { fa.rethrow() }, { never<Unit>() })
+          .fold(
+            { _, _, _ -> fail("never can not win race") },
+            { _, b, _ -> b },
+            { _, _, _ -> fail("never can not win race") }
+          )
+      } shouldBe fa
+    }
+  }
+
+  "race triple mirrors right winner" {
+    checkAll(Arb.either(Arb.throwable(), Arb.int())) { fa ->
+
+      Either.catch {
+        raceTriple({ never<Unit>() }, { never<Unit>() }, { fa.rethrow() })
+          .fold(
+            { _, _, _ -> fail("never can not win race") },
+            { _, _, _ -> fail("never can not win race") },
+            { _, _, b -> b }
+          )
+      } shouldBe fa
+    }
+  }
+
+  "race triple can cancel loser" {
+    checkAll(
+      Arb.either(Arb.throwable(), Arb.int()),
+      Arb.int(0, 2),
+      Arb.int(),
+      Arb.int()
+    ) { fa, decision, a, b ->
+      val s = Semaphore(0)
+      val pa = Promise<Int>()
+      val pb = Promise<Int>()
+
+      val winner = suspend { s.acquireN(2); fa.rethrow() }
+      val loserA =
+        suspend { bracket(acquire = { s.release() }, use = { never<String>() }, release = { pa.complete(a) }) }
+      val loserB =
+        suspend { bracket(acquire = { s.release() }, use = { never<String>() }, release = { pb.complete(b) }) }
+
+      Either.catch {
+        when (decision) {
+          0 -> raceTriple(winner, loserA, loserB)
+          1 -> raceTriple(loserA, winner, loserB)
+          else -> raceTriple(loserA, loserB, winner)
+        }
+      }.fold(
+        { Pair(pa.get(), pb.get()) },
+        {
+          it.fold(
+            { _, fiberB, fiberC -> ForkAndForget { fiberB.cancel(); fiberC.cancel() }; Pair(pa.get(), pb.get()) },
+            { fiberA, _, fiberC -> ForkAndForget { fiberA.cancel(); fiberC.cancel() }; Pair(pa.get(), pb.get()) },
+            { fiberA, fiberB, _ -> ForkAndForget { fiberA.cancel(); fiberB.cancel() }; Pair(pa.get(), pb.get()) }
+          )
+        }) shouldBe Pair(a, b)
+    }
+  }
+
+  "race triple can join left" {
+    checkAll(Arb.int()) { i ->
+      val p = Promise<Int>()
+      raceTriple({ p.get() }, { Unit }, { Unit })
+        .fold(
+          { _, _, _ -> fail("promise.get cannot win race") },
+          { fiber, _, _ -> p.complete(i); fiber.join() },
+          { fiber, _, _ -> p.complete(i); fiber.join() }
+        ) shouldBe i
+    }
+  }
+
+  "race triple can join middle" {
+    checkAll(Arb.int()) { i ->
+      val p = Promise<Int>()
+      raceTriple({ Unit }, { p.get() }, { Unit })
+        .fold(
+          { _, fiber, _ -> p.complete(i); fiber.join() },
+          { _, _, _ -> fail("promise.get cannot win race") },
+          { _, fiber, _ -> p.complete(i); fiber.join() }
+        ) shouldBe i
+    }
+  }
+
+  "race triple can join right" {
+    checkAll(Arb.int()) { i ->
+      val p = Promise<Int>()
+      raceTriple({ Unit }, { Unit }, { p.get() })
+        .fold(
+          { _, _, fiber -> p.complete(i); fiber.join() },
+          { _, _, fiber -> p.complete(i); fiber.join() },
+          { _, _, _ -> fail("promise.get cannot win race") }
+        ) shouldBe i
+    }
+  }
+
+  "Cancelling race triple cancels both" {
+    checkAll(Arb.int(), Arb.int(), Arb.int()) { a, b, c ->
+      val s = Semaphore(0)
+      val pa = Promise<Int>()
+      val pb = Promise<Int>()
+      val pc = Promise<Int>()
+
+      val loserA = suspend { bracket({ s.release() }, use = { never<Int>() }, release = { pa.complete(a) }) }
+      val loserB = suspend { bracket({ s.release() }, use = { never<Int>() }, release = { pb.complete(b) }) }
+      val loserC = suspend { bracket({ s.release() }, use = { never<Int>() }, release = { pc.complete(c) }) }
+
+      val fiber = ForkAndForget { raceTriple(loserA, loserB, loserC) }
+
+      s.acquireN(3) // Wait until both racers started
+
+      fiber.cancel()
+      pa.get() shouldBe a
+      pb.get() shouldBe b
+      pc.get() shouldBe c
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ResourceTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ResourceTest.kt
@@ -1,0 +1,59 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+
+class ResourceTest : StringSpec({
+
+  "Can consume resource" {
+    checkAll(Arb.int()) { n ->
+      val r = Resource({ n }, { _ -> Unit })
+
+      r.use { it + 1 } shouldBe n + 1
+    }
+  }
+
+  "value resource is released with Complete" {
+    checkAll(Arb.int()) { n ->
+      val p = Promise<ExitCase>()
+      Resource({ n }, { _, ex -> p.complete(ex) })
+        .use { Unit }
+
+      p.get() shouldBe ExitCase.Completed
+    }
+  }
+
+  "error resource finishes with error" {
+    checkAll(Arb.throwable()) { e ->
+      val p = Promise<ExitCase>()
+      val r = Resource<Int>({ throw e }, { _, ex -> p.complete(ex) })
+
+      Either.catch {
+        r.use { it + 1 }
+      } shouldBe Either.Left(e)
+    }
+  }
+
+  "never use can be cancelled with ExitCase.Completed" {
+    checkAll(Arb.int()) { n ->
+      val p = Promise<ExitCase>()
+      val start = Promise<Unit>()
+      val r = Resource({ n }, { _, ex -> p.complete(ex) })
+
+      val f = ForkAndForget {
+        r.use {
+          start.complete(Unit)
+          never<Int>()
+        }
+      }
+
+      start.get()
+      f.cancel()
+      p.get() shouldBe ExitCase.Cancelled
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ScheduleTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ScheduleTest.kt
@@ -1,0 +1,250 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import arrow.core.Eval
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.math.pow
+
+class ScheduleTest : StringSpec({
+
+  class MyException : Exception()
+
+  val exception = MyException()
+
+  "Schedule.identity()" {
+    val dec = Schedule.identity<Int>().calculateSchedule1(1)
+    val expected = Schedule.Decision<Any?, Int>(true, 0.nanoseconds, Unit, Eval.now(1))
+
+    dec eqv expected
+  }
+
+  "Schedule.unfold()" {
+    val dec = Schedule.unfold<Any?, Int>(0) { it + 1 }.calculateSchedule1(0)
+    val expected = Schedule.Decision<Any?, Int>(true, 0.nanoseconds, 1, Eval.now(1))
+
+    dec eqv expected
+  }
+
+  "Schedule.forever() == Schedule.unfold(0) { it + 1 }" {
+    val foreverDesc = Schedule.forever<Any?>().calculateSchedule1(0)
+    val unfoldDesc = Schedule.unfold<Any?, Int>(0) { it + 1 }.calculateSchedule1(0)
+
+    foreverDesc eqv unfoldDesc
+  }
+
+  "Schedule.recurs(negative number)" {
+    checkRepeat(Schedule.recurs(-500), expected = 0)
+  }
+
+  "Schedule.recurs(0)" {
+    checkRepeat(Schedule.recurs(0), expected = 0)
+  }
+
+  "Schedule.recurs(1)" {
+    checkRepeat(Schedule.recurs(1), expected = 1)
+  }
+
+  "Schedule.recurs(n: Int)" {
+    val n = 500
+    val res = Schedule.recurs<Int>(n).calculateSchedule(0, n + 1)
+
+    res.dropLast(1).map { it.delay.nanoseconds } shouldBe res.dropLast(1).map { 0L }
+    res.dropLast(1).map { it.cont } shouldBe res.dropLast(1).map { true }
+
+    res.last() eqv Schedule.Decision(false, 0.nanoseconds, n + 1, Eval.now(n + 1))
+  }
+
+  "Schedule.once() repeats 1 additional time" {
+    var count = 0
+    repeat(Schedule.once()) {
+      count++
+    }
+    count shouldBe 2
+  }
+
+  "Schedule.doWhile repeats while condition holds and returns itself" {
+    checkRepeat(Schedule.doWhile { it < 10 }, expected = 10)
+    checkRepeat(Schedule.doWhile { it > 10 }, expected = 1)
+    checkRepeat(Schedule.doWhile { it == 1 }, expected = 2)
+  }
+
+  "Schedule.doUntil repeats until the cond is satisfied" {
+    checkRepeat(Schedule.doUntil { it < 10 }, expected = 1)
+    checkRepeat(Schedule.doUntil { it > 10 }, expected = 11)
+    checkRepeat(Schedule.doUntil { it == 1 }, expected = 1)
+  }
+
+  "Schedule.doWhile.collect() collects all inputs into a list" {
+    checkRepeat(Schedule
+      .doWhile<Int> { it < 10 }
+      .collect(), expected = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9))
+  }
+
+  "Schedule.doUntil.collect() collects all inputs into a list" {
+    checkRepeat(Schedule
+      .doUntil<Int> { it > 10 }
+      .collect(), expected = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+  }
+
+  "Repeat a scheduled repeat repeats the whole number" {
+    val n = 42
+    var count = 0
+    repeat(Schedule.recurs(1)) {
+      repeat(Schedule.recurs(n)) {
+        count++
+      }
+    }
+
+    count shouldBe ((n + 1) * 2)
+  }
+
+  "Schedule.never() times out" {
+    timeOutOrNull(10.milliseconds) {
+      val a: Nothing = repeat(Schedule.never()) {
+        1
+      }
+    } shouldBe null
+  }
+
+  "Schedule.spaced()" {
+    val duration = 5.seconds
+    val res = Schedule.spaced<Any>(duration).calculateSchedule(0, 500)
+
+    res.map { it.cont } shouldBe res.map { true }
+    res.map { it.delay.nanoseconds } shouldBe res.map { duration.nanoseconds }
+  }
+
+  "Schedule.fibonacci()" {
+    val i = 10L
+    val n = 10
+    val res = Schedule.fibonacci<Any?>(i.seconds).calculateSchedule(0, n)
+
+    val sum = res.fold(0L) { acc, v ->
+      acc + v.delay.inSeconds
+    }
+    val fib = fibs(i).drop(1).take(n)
+
+    res.all { it.cont } shouldBe true
+    sum shouldBe fib.sum()
+  }
+
+  "Schedule.linear()" {
+    val i = 10L
+    val n = 10
+    val res = Schedule.linear<Any?>(i.seconds).calculateSchedule(0, n)
+
+    val sum = res.fold(0L) { acc, v -> acc + v.delay.inSeconds }
+    val exp = linear(i).drop(1).take(n)
+
+    res.all { it.cont } shouldBe true
+    sum shouldBe exp.sum()
+  }
+
+  "Schedule.exponential()" {
+    val i = 10L
+    val n = 10
+    val res = Schedule.exponential<Any?>(i.seconds).calculateSchedule(0, n)
+
+    val sum = res.fold(0L) { acc, v -> acc + v.delay.inSeconds }
+    val expSum = exp(i).drop(1).take(n).sum()
+
+    res.all { it.cont } shouldBe true
+    sum shouldBe expSum
+  }
+
+  "repeat is stack-safe" {
+    checkRepeat(Schedule.recurs(20_000), expected = 20_000)
+  }
+
+  "repeat" {
+    val stop = RuntimeException("WOOO")
+    val dec = Schedule.Decision(true, 10.nanoseconds, 0, Eval.now("state"))
+    val n = 100
+    val schedule = Schedule({ 0 }) { _: Unit, _ -> dec }
+
+    val eff = SideEffect()
+
+    val l = Either.catch {
+      repeat(schedule) {
+        if (eff.counter >= n) throw stop
+        else eff.increment()
+      }
+    }
+
+    eff.counter shouldBe 100
+    l shouldBe Either.Left(stop)
+  }
+
+  "retry is stack-safe" {
+    val count = Atomic(0)
+    val l = Either.catch {
+      val n: Nothing = retry(Schedule.recurs(20_000)) {
+        count.updateAndGet { it + 1 }
+        throw exception
+      }
+    }
+
+    l shouldBe Either.Left(exception)
+    count.get() shouldBe 20_001
+  }
+})
+
+private fun fibs(one: Long): Sequence<Long> = generateSequence(Pair(0L, one)) { (a, b) ->
+  Pair(b, (a + b))
+}.map { it.first }
+
+private fun exp(base: Long): Sequence<Long> = generateSequence(Pair(base, 1.0)) { (_, n) ->
+  Pair((base * 2.0.pow(n)).toLong(), n + 1)
+}.map { it.first }
+
+private fun linear(base: Long): Sequence<Long> = generateSequence(Pair(base, 1L)) { (_, n) ->
+  Pair((base * n), (n + 1))
+}.map { it.first }
+
+private suspend fun <I, A> Schedule<I, A>.calculateSchedule1(input: I): Schedule.Decision<Any?, A> =
+  calculateSchedule(input, 1).first()
+
+/**
+ * Calculates the schedule for [input] I, and [n] iterations
+ * This allows to calculate the resulting [Schedule.Decision] state and make assertions.
+ */
+@Suppress("UNCHECKED_CAST")
+private suspend fun <I, A> Schedule<I, A>.calculateSchedule(input: I, n: Int): List<Schedule.Decision<Any?, A>> {
+  (this as Schedule.ScheduleImpl<Any?, I, A>)
+  val state = initialState.invoke()
+  return go(this, input, state, n, emptyList())
+}
+
+private tailrec suspend fun <I, A> go(
+  schedule: Schedule.ScheduleImpl<Any?, I, A>,
+  input: I,
+  s: Any?,
+  rem: Int,
+  acc: List<Schedule.Decision<Any?, A>>
+): List<Schedule.Decision<Any?, A>> =
+  if (rem <= 0) acc
+  else {
+    val res = schedule.update(input, s) // Calculate new decision
+    go(schedule, input, res.state, rem - 1, acc + listOf(res))
+  }
+
+private suspend fun <B> checkRepeat(schedule: Schedule<Int, B>, expected: B): Unit {
+  val count = Atomic(0)
+  repeat(schedule) {
+    count.updateAndGet { it + 1 }
+  } shouldBe expected
+}
+
+private infix fun <A> Schedule.Decision<Any?, A>.eqv(other: Schedule.Decision<Any?, A>): Unit {
+  require(cont == other.cont) { "Decision#cont: ${this.cont} shouldBe ${other.cont}" }
+  require(delay.nanoseconds == other.delay.nanoseconds) { "Decision#delay.nanoseconds: ${this.delay.nanoseconds} shouldBe ${other.delay.nanoseconds}" }
+  if (cont) {
+    val lh = finish.value()
+    val rh = other.finish.value()
+    require(lh == rh) { "Decision#cont: $lh shouldBe $rh" }
+  }
+}
+
+private val Duration.inSeconds: Long
+  get() = timeUnit.toSeconds(amount)

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/SemaphoreTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/SemaphoreTest.kt
@@ -1,0 +1,233 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.positiveInts
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+
+class SemaphoreTest : StringSpec({
+
+  "acquire n times synchronously" {
+    checkAll(Arb.positiveInts(max = 20).map(Int::toLong)) { n ->
+      val s = Semaphore(n)
+
+      repeat(n.toInt()) {
+        s.acquire()
+      }
+
+      s.available() shouldBe 0
+    }
+  }
+
+  "acquireN synchronously" {
+    checkAll(Arb.positiveInts().map(Int::toLong)) { n ->
+      val s = Semaphore(n)
+      s.acquireN(n)
+      s.available() shouldBe 0
+    }
+  }
+
+  "releaseN can add permits" {
+    checkAll(Arb.positiveInts().map(Int::toLong)) { n ->
+      val s = Semaphore(n)
+      s.releaseN(n)
+      s.available() shouldBe n * 2
+    }
+  }
+
+  "releaseN hands out outstanding permits to waiting acquireN" {
+    checkAll(Arb.positiveInts().map(Int::toLong), Arb.string()) { n, x ->
+      val s = Semaphore(n / 2)
+      val start = Promise<Unit>()
+      val f = ForkAndForget {
+        start.complete(Unit)
+        s.acquireN(n)
+        x
+      }
+      start.get()
+      s.releaseN(n)
+      f.join() shouldBe x
+    }
+  }
+
+  "tryAcquire with available permits" {
+    checkAll(Arb.positiveInts().map(Int::toLong)) { n ->
+      val s = Semaphore(n)
+      s.acquireN(n - 1)
+      s.tryAcquire() shouldBe true
+    }
+  }
+
+  "tryAcquire with no available permits" {
+    checkAll(Arb.positiveInts().map(Int::toLong)) { n ->
+      val s = Semaphore(n)
+      s.acquireN(n)
+      s.tryAcquire() shouldBe false
+    }
+  }
+
+  "available with available permits" {
+    val minPermits = 10
+    checkAll(
+      Arb.int(minPermits, Int.MAX_VALUE).map(Int::toLong),
+      Arb.int(1, minPermits).map(Int::toLong)
+    ) { n, x ->
+      val s = Semaphore(n)
+      s.acquireN(n - x)
+      s.available() shouldBe x
+    }
+  }
+
+  "available with no available permits" {
+    checkAll(Arb.positiveInts().map(Int::toLong)) { n ->
+      val s = Semaphore(n)
+      s.acquireN(n)
+      s.available() shouldBe 0
+    }
+  }
+
+  "tryAcquireN with no available permits" {
+    checkAll(Arb.positiveInts().map(Int::toLong)) { n ->
+      val s = Semaphore(n)
+      s.acquireN(n)
+      s.tryAcquireN(1) shouldBe false
+    }
+  }
+
+  "count with available permits" {
+    val minPermits = 10
+    checkAll(
+      Arb.int(minPermits, Int.MAX_VALUE).map(Int::toLong),
+      Arb.int(1, minPermits)
+    ) { n, x ->
+      val s = Semaphore(n)
+      repeat(x) { s.acquire() }
+      s.available() shouldBe s.count()
+    }
+  }
+
+  "count with no available permits" {
+    checkAll(Arb.positiveInts().map(Int::toLong)) { n ->
+      val s = Semaphore(n)
+      s.acquireN(n)
+      s.count() shouldBe 0
+    }
+  }
+
+  suspend fun testOffsettingReleasesAcquires(
+    acquires: suspend (Semaphore, List<Long>) -> Unit,
+    releases: suspend (Semaphore, List<Long>) -> Unit
+  ): Unit {
+    val permits = listOf(1L, 0, 20, 4, 0, 5, 2, 1, 1, 3)
+    val s = Semaphore(0)
+
+    parTupledN(
+      { acquires(s, permits) },
+      { releases(s, permits) }
+    )
+
+    s.count() shouldBe 0
+  }
+
+  "offsetting acquires/releases - acquires parallel with releases" {
+    testOffsettingReleasesAcquires(
+      { s, p -> p.forEach { s.acquireN(it) } },
+      { s, p -> p.reversed().forEach { s.releaseN(it) } }
+    )
+  }
+
+  "offsetting acquires/releases - individual acquires/increment in parallel" {
+    testOffsettingReleasesAcquires(
+      { s, p -> p.parTraverse { s.acquireN(it) } },
+      { s, p -> p.reversed().parTraverse { s.releaseN(it) } }
+    )
+  }
+
+  "Failure in withPermitN results in correct error & releases permits" {
+    checkAll(Arb.positiveInts().map(Int::toLong), Arb.throwable()) { n, e ->
+      val s = Semaphore(n)
+      val p = Promise<Long>()
+      val r = Either.catch {
+        s.withPermitN(n) {
+          p.complete(s.available())
+          throw e
+        }
+      }
+
+      r shouldBe Either.Left(e)
+      p.get() shouldBe 0
+      s.available() shouldBe n
+    }
+  }
+
+  "withPermitN does not leak fibers or permits upon failure" {
+    checkAll(Arb.positiveInts().map(Int::toLong), Arb.throwable()) { n, e ->
+      val s = Semaphore(n)
+
+      val r = Either.catch {
+        parTupledN({
+          s.withPermitN(n + 1) { // Requests a n + 1 permits, puts count to -1
+            s.release() // Never runs due to async exception
+          }
+        }, { throw e }) // Cancels other parallel op
+      }
+
+      r shouldBe Either.Left(e) // Proof parallel op failed
+      s.count() shouldBe n // Proof that withPermitN released on cancel
+    }
+  }
+
+  "withPermitN does not leak fibers or permits upon cancellation" {
+    checkAll(100, Arb.positiveInts().map(Int::toLong)) { n -> // 100 iterations takes 1 second
+      val s = Semaphore(n)
+
+      val r = timeOutOrNull(10.milliseconds) {
+        s.withPermitN(n + 1) { // Requests a n + 1 permits, puts count to -1
+          s.release() // Timeouts out due to no permit
+        } // cancel should put count back to 0
+      }
+
+      r shouldBe null // proof of timeout
+
+      // proof of permit cancel, if release ran it would be 1L
+      s.count() shouldBe n
+    }
+  }
+
+  "acquireN does not leak fibers or permits upon failure" {
+    checkAll(Arb.positiveInts().map(Int::toLong), Arb.throwable()) { n, e ->
+      val s = Semaphore(n)
+
+      val r = Either.catch {
+        parTupledN({
+          s.acquireN(n + 1) // Puts count to -1, and gets cancelled by async exception
+        }, { throw e })
+      }
+
+      r shouldBe Either.Left(e) // Proof parallel op failed
+      s.count() shouldBe n // Proof that acquireN released on cancel
+    }
+  }
+
+  "acquireN does not leak permits upon cancellation" {
+    checkAll(100, Arb.positiveInts().map(Int::toLong)) { n -> // 100 iterations takes 1 second
+      val s = Semaphore(n)
+
+      val x = timeOutOrNull(10.milliseconds) {
+        // Puts count to -1, and times out before acquired so should out count back to 1
+        s.acquireN(n + 1)
+        s.release() // Never runs
+      }
+
+      x shouldBe null // proof of timeout
+
+      // proof of cancel, if release ran then would be 2L
+      s.count() shouldBe n
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/SuspendConnectionTests.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/SuspendConnectionTests.kt
@@ -1,0 +1,234 @@
+package arrow.fx.coroutines
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineName
+import kotlin.coroutines.EmptyCoroutineContext
+
+class SuspendConnectionTests : StringSpec({
+
+  "Left identity" {
+    val ref = SuspendConnection()
+    (ref + EmptyCoroutineContext) == ref
+  }
+
+  "Right identity" {
+    val ref = SuspendConnection()
+    (EmptyCoroutineContext + ref) == ref
+  }
+
+  "Making connection uncancelable" {
+    val test = CoroutineName("test")
+    val ref = SuspendConnection() + test
+    (ref + SuspendConnection.uncancellable) shouldBe (test + SuspendConnection.uncancellable)
+  }
+
+  "Restoring cancellation" {
+    val test = CoroutineName("test")
+    val ref = SuspendConnection()
+    val original = ref + test
+    val uncancelable = original + SuspendConnection.uncancellable
+    (uncancelable + original) shouldBe (test + original)
+  }
+
+  "cancellation is only executed once" {
+    var effect = 0
+    val initial = CancelToken { effect += 1 }
+    val c = SuspendConnection()
+    c.push(initial)
+
+    c.cancel()
+    effect shouldBe 1
+
+    c.cancel()
+    effect shouldBe 1
+  }
+
+  "Disposable is only executed once" {
+    var effect = 0
+    val initial = CancelToken { effect += 1 }
+    val c = SuspendConnection()
+    c.push(initial)
+
+    c.toDisposable().invoke()
+    effect shouldBe 1
+
+    c.toDisposable().invoke()
+    effect shouldBe 1
+  }
+
+  "CancelToken delays cancel effect until invoked" {
+    var effect = 0
+    val initial = CancelToken { effect += 1 }
+    val c = SuspendConnection()
+    c.push(initial)
+
+    val token = c.cancelToken()
+    effect shouldBe 0
+
+    token.invoke()
+    effect shouldBe 1
+  }
+
+  "empty; isCancelled" {
+    val c = SuspendConnection()
+    c.isCancelled() shouldBe false
+  }
+
+  "empty; isNotCancelled" {
+    val c = SuspendConnection()
+    c.isNotCancelled() shouldBe true
+  }
+
+  "empty; push; cancel; isCancelled" {
+    val c = SuspendConnection()
+    c.push(CancelToken {})
+    c.cancel()
+    c.isCancelled() shouldBe true
+  }
+
+  "cancel immediately if already cancelled" {
+    var effect = 0
+    val initial = CancelToken { effect += 1 }
+    val c = SuspendConnection()
+    c.push(initial)
+
+    c.cancel()
+    effect shouldBe 1
+
+    c.push(initial)
+    effect shouldBe 2
+  }
+
+  "push two, pop one" {
+    var effect = 0
+    val initial1 = CancelToken { effect += 1 }
+    val initial2 = CancelToken { effect += 2 }
+
+    val c = SuspendConnection()
+    c.push(initial1)
+    c.push(initial2)
+    c.pop()
+
+    c.cancel()
+    effect shouldBe 1
+  }
+
+  "push two, pop two" {
+    var effect = 0
+    val initial1 = CancelToken { effect += 1 }
+    val initial2 = CancelToken { effect += 2 }
+
+    val c = SuspendConnection()
+    c.push(initial1)
+    c.push(initial2)
+    c.pop()
+    c.pop()
+    c.cancel()
+
+    effect shouldBe 0
+  }
+
+  "pop removes tokens in LIFO order" {
+    var effect = 0
+    val initial1 = CancelToken { effect += 1 }
+    val initial2 = CancelToken { effect += 2 }
+    val initial3 = CancelToken { effect += 3 }
+
+    val c = SuspendConnection()
+    c.push(initial1)
+    c.push(initial2)
+    c.push(initial3)
+    c.pop() shouldBe initial3
+    c.pop() shouldBe initial2
+    c.pop() shouldBe initial1
+  }
+
+  "push list tokens" {
+    var effect = 0
+    val initial = CancelToken { effect += 1 }
+
+    val c = SuspendConnection()
+    c.push(listOf(initial, initial, initial))
+    c.cancel()
+
+    effect shouldBe 3
+  }
+
+  "pushPair token" {
+    var effect = 0
+    val initial1 = CancelToken { effect += 1 }
+    val initial2 = CancelToken { effect += 2 }
+
+    val c = SuspendConnection()
+    c.pushPair(initial1, initial2)
+    c.cancel()
+
+    effect shouldBe 3
+  }
+
+  "pushPair connections" {
+    var effect = 0
+    val ref1 = SuspendConnection().apply {
+      push(CancelToken { effect += 1 })
+    }
+    val ref2 = SuspendConnection().apply {
+      push(CancelToken { effect += 2 })
+    }
+
+    val c = SuspendConnection()
+    c.pushPair(ref1, ref2)
+    c.cancel()
+
+    effect shouldBe 3
+  }
+
+  "Cannot reactivate when not cancelled" {
+    val ref = SuspendConnection()
+    ref.tryReactivate() shouldBe false
+  }
+
+  "Cannot reactivate when cancelled" {
+    val ref = SuspendConnection()
+    ref.cancel()
+    ref.tryReactivate() shouldBe true
+  }
+
+  "uncancellable returns same reference" {
+    val ref1 = SuspendConnection.uncancellable
+    val ref2 = SuspendConnection.uncancellable
+    ref1 shouldBe ref2
+  }
+
+  "uncancellable reference cannot be cancelled" {
+    val ref = SuspendConnection.uncancellable
+    ref.isCancelled() shouldBe false
+
+    ref.cancel()
+    ref.isCancelled() shouldBe false
+  }
+
+  "uncancellable.pop" {
+    val ref = SuspendConnection.uncancellable
+    ref.pop() should unsafeEquals(CancelToken.unit)
+
+    ref.push(CancelToken.unit)
+    ref.pop() should unsafeEquals(CancelToken.unit)
+  }
+
+  "uncancellable.push never cancels the given cancellable" {
+    val ref = SuspendConnection.uncancellable
+    ref.cancel()
+
+    var effect = 0
+    val c = CancelToken { effect += 1 }
+    ref.push(c)
+    effect shouldBe 0
+  }
+
+  "uncancellable can always reactivate" {
+    val ref = SuspendConnection.uncancellable
+    ref.tryReactivate() shouldBe true
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/SuspendRunners.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/SuspendRunners.kt
@@ -1,0 +1,141 @@
+package arrow.fx.coroutines
+
+import io.kotest.assertions.fail
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.checkAll
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+
+class SuspendRunners : StringSpec({
+
+  "should defer evaluation until run" {
+    var run = false
+    val fa = suspend { run = true }
+    run shouldBe false
+    Platform.unsafeRunSync(fa)
+    run shouldBe true
+  }
+
+  "invoke is called on every run call" {
+    val sideEffect = SideEffect()
+    val fa = suspend { sideEffect.increment(); 1 }
+
+    Platform.unsafeRunSync(fa)
+    Platform.unsafeRunSync(fa)
+
+    sideEffect.counter shouldBe 2
+  }
+
+  "should catch exceptions within main block" {
+    checkAll(Arb.throwable()) { e ->
+      val task = suspend { throw e }
+      shouldThrow<Throwable> {
+        Platform.unsafeRunSync { task.invoke() }
+      } shouldBe e
+    }
+  }
+
+  "should yield immediate successful invoke value" {
+    checkAll(Arb.int()) { i ->
+      val task = suspend { i }
+      val run = Platform.unsafeRunSync { task.invoke() }
+      run shouldBe i
+    }
+  }
+
+  "should return a null value from unsafeRunSync" {
+    val run = Platform.unsafeRunSync { suspend { null }() }
+    run shouldBe null
+  }
+
+  "suspend with unsafeRunSync" {
+    checkAll(Arb.int().map { suspend { it } }) { i ->
+      val map = suspend { i() + 1 }
+      Platform.unsafeRunSync(map) shouldBe (i.invoke() + 1)
+    }
+  }
+
+  "should complete when running a pure value with unsafeRunAsync" {
+    checkAll(Arb.int()) { i ->
+      val task = suspend { i }
+
+      task.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+        res.getOrThrow() shouldBe i
+      })
+    }
+  }
+
+  "should return an error when running an exception with unsafeRunAsync" {
+    checkAll(Arb.throwable()) { e ->
+      val task = suspend { throw e }
+      task.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+        res.fold({ fail("Expected $e but found with $it") }, {
+          it shouldBe e
+        })
+      })
+    }
+  }
+
+  "should rethrow exceptions within run block with unsafeRunAsync" {
+    checkAll(Arb.throwable()) { e ->
+      val task = suspend { throw e }
+      try {
+        task.startCoroutine(Continuation(EmptyCoroutineContext) { res ->
+          res.fold({ fail("Expected $e but found with $it") }, { throw e })
+        })
+        fail("Should rethrow the exception")
+      } catch (t: Throwable) {
+        t shouldBe e
+      }
+    }
+  }
+
+  "should complete when running a pure value with startCoroutineCancellable" {
+    checkAll(Arb.int()) { i ->
+      val task = suspend { i }
+      task.startCoroutineCancellable(CancellableContinuation(EmptyCoroutineContext) { res ->
+        res.getOrThrow() shouldBe i
+      })
+    }
+  }
+
+  "should return exceptions within main block with startCoroutineCancellable" {
+    checkAll(Arb.throwable()) { e ->
+      val task = suspend { throw e }
+      task.startCoroutineCancellable(CancellableContinuation(EmptyCoroutineContext) { res ->
+        res.fold({ fail("Expected $e but found with $it") }, { it shouldBe e })
+      })
+    }
+  }
+
+  "should rethrow exceptions within run block with startCoroutineCancellable" {
+    checkAll(Arb.throwable()) { e ->
+      val task = suspend { throw e }
+      try {
+        task.startCoroutineCancellable(CancellableContinuation(EmptyCoroutineContext) { res ->
+          res.fold({ fail("Expected $e but found with $it") }, { throw it })
+        })
+        fail("Should rethrow the exception")
+      } catch (t: Throwable) {
+        t shouldBe e
+      }
+    }
+  }
+
+  "Effect-full stack-safe map" {
+    val max = 10000
+
+    suspend fun addOne(n: Int): Int = n + 1 // Equivalent of `map` for `IO`.
+
+    suspend fun fa(): Int =
+      (0 until (max * 10000)).fold(0) { acc, _ -> addOne(acc) }
+
+    Platform.unsafeRunSync { fa() } shouldBe (max * 10000)
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
@@ -1,0 +1,68 @@
+package arrow.fx.coroutines
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.positiveInts
+import io.kotest.property.checkAll
+
+class TimerTest : StringSpec({
+
+  suspend fun timeNano(): Long =
+    System.nanoTime()
+
+  suspend fun timeMilis(): Long =
+    System.currentTimeMillis()
+
+  "sleep should last specified time" {
+    checkAll(Arb.positiveInts(max = 50)) { i ->
+      val length = i.toLong()
+      val start = timeNano()
+      sleep(length.milliseconds)
+      val end = timeNano()
+      require((end - start) >= length) { "Expected (end - start) >= length but found ($end - $start) <= $length" }
+    }
+  }
+
+  "negative sleep should be immediate" {
+    checkAll(Arb.int(Int.MIN_VALUE, -1)) { i ->
+      val start = timeNano()
+      sleep(i.nanoseconds)
+      val end = timeNano()
+      require((start - end) <= 0L) { "Expected (end - start) <= 0L but found (${start - end}) <= 0L" }
+    }
+  }
+
+  "sleep can be cancelled" {
+    checkAll(15, Arb.int(100, 500)) { d ->
+      assertCancellable { sleep(d.milliseconds) }
+    }
+  }
+
+  "timeout can lose" {
+    checkAll(Arb.int()) { i ->
+      timeOutOrNull(1.milliseconds) {
+        sleep(100.milliseconds)
+        i
+      } shouldBe null
+    }
+  }
+
+  "timeout wins non suspend" {
+    checkAll(Arb.int()) { i ->
+      timeOutOrNull(10.milliseconds) {
+        i
+      } shouldBe i
+    }
+  }
+
+  "timeout wins suspend" {
+    checkAll(Arb.int()) { i ->
+      timeOutOrNull(100.milliseconds) {
+        sleep(1.milliseconds)
+        i
+      } shouldBe i
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
@@ -1,0 +1,162 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.choice
+import io.kotest.property.arbitrary.flatMap
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.string
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.startCoroutine
+import kotlin.math.max
+import kotlin.math.min
+
+data class SideEffect(var counter: Int = 0) {
+  fun increment() {
+    counter++
+  }
+}
+
+val single = singleThreadContext("single")
+
+val threadName: suspend () -> String =
+  { Thread.currentThread().name }
+
+fun unsafeEquals(other: CancelToken): Matcher<CancelToken> = object : Matcher<CancelToken> {
+  override fun test(value: CancelToken): MatcherResult {
+    val r1 = Platform.unsafeRunSync { value.cancel.invoke() }
+    val r2 = Platform.unsafeRunSync { other.cancel.invoke() }
+    return MatcherResult(r1 == r2, "Expected: $r2 but found: $r1", "$r2 and $r1 should be equal")
+  }
+}
+
+suspend fun assertCancellable(f: suspend () -> Unit): Unit {
+  val p = Promise<ExitCase>()
+  val start = Promise<Unit>()
+
+  val fiber = ForkAndForget {
+    guaranteeCase(
+      fa = {
+        start.complete(Unit)
+        f()
+      },
+      release = { ex -> p.complete(ex) }
+    )
+  }
+
+  start.get()
+  fiber.cancel()
+  p.get() shouldBe ExitCase.Cancelled
+}
+
+/**
+ * Catches `System.err` output, for testing purposes.
+ */
+fun catchSystemErr(thunk: () -> Unit): String {
+  val outStream = ByteArrayOutputStream()
+  catchSystemErrInto(outStream, thunk)
+  return String(outStream.toByteArray(), StandardCharsets.UTF_8)
+}
+
+/**
+ * Catches `System.err` output into `outStream`, for testing purposes.
+ */
+@Synchronized
+fun <A> catchSystemErrInto(outStream: OutputStream, thunk: () -> A): A {
+  val oldErr = System.err
+  val fakeErr = PrintStream(outStream)
+  System.setErr(fakeErr)
+  return try {
+    thunk()
+  } finally {
+    System.setErr(oldErr)
+    fakeErr.close()
+  }
+}
+
+fun Arb.Companion.throwable(): Arb<Throwable> =
+  Arb.string().map(::RuntimeException)
+
+fun <A> Arb.Companion.result(right: Arb<A>): Arb<Result<A>> {
+  val failure: Arb<Result<A>> = Arb.throwable().map { e -> Result.failure<A>(e) }
+  val success: Arb<Result<A>> = right.map { a -> Result.success(a) }
+  return Arb.choice(failure, success)
+}
+
+fun <L, R> Arb.Companion.either(left: Arb<L>, right: Arb<R>): Arb<Either<L, R>> {
+  val failure: Arb<Either<L, R>> = left.map { l -> l.left() }
+  val success: Arb<Either<L, R>> = right.map { r -> r.right() }
+  return Arb.choice(failure, success)
+}
+
+fun Arb.Companion.intRange(min: Int = 0, max: Int = 1000): Arb<IntRange> =
+  Arb.int(min, max).flatMap { a ->
+    Arb.int(min, max).map { b ->
+      val first = min(a, b)
+      val last = max(a, b)
+      first..last
+    }
+  }
+
+/** Useful for testing success & error scenarios with an `Either` generator **/
+internal suspend fun <A> Either<Throwable, A>.rethrow(): A =
+  fold({ throw it }, ::identity)
+
+internal fun <A> Result<A>.toEither(): Either<Throwable, A> =
+  fold({ a -> Either.Right(a) }, { e -> Either.Left(e) })
+
+internal suspend fun Throwable.suspend(): Nothing =
+  suspendCoroutineUninterceptedOrReturn { cont ->
+    suspend { throw this }.startCoroutine(Continuation(ComputationPool) {
+      cont.intercepted().resumeWith(it)
+    })
+
+    COROUTINE_SUSPENDED
+  }
+
+internal suspend fun <A> A.suspend(): A =
+  suspendCoroutineUninterceptedOrReturn { cont ->
+    suspend { this }.startCoroutine(Continuation(ComputationPool) {
+      cont.intercepted().resumeWith(it)
+    })
+
+    COROUTINE_SUSPENDED
+  }
+
+internal fun <A> A.suspended(): suspend () -> A =
+  suspend { suspend() }
+
+internal suspend fun <A> Either<Throwable, A>.suspend(): A =
+  suspendCoroutineUninterceptedOrReturn { cont ->
+    suspend { this }.startCoroutine(Continuation(ComputationPool) {
+      it.fold(
+        {
+          it.fold(
+            { e -> cont.intercepted().resumeWithException(e) },
+            { a -> cont.intercepted().resume(a) }
+          )
+        },
+        { e -> cont.intercepted().resumeWithException(e) }
+      )
+    })
+
+    COROUTINE_SUSPENDED
+  }
+
+internal fun <A> Either<Throwable, A>.suspended(): suspend () -> A =
+  suspend { suspend() }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ configure(subprojects
 {
     apply plugin: 'ru.vyarus.animalsniffer'
     apply plugin: 'java'
+
+    animalsniffer { // Ingore tests
+        sourceSets = [sourceSets.main]
+    }
+
     dependencies {
         signature 'net.sf.androidscents.signature:android-api-level-21:5.0.1_r2@signature'
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'arrow-fx-lib'
 
 include 'arrow-fx'
+include 'arrow-fx-coroutines'
 include 'arrow-streams'
 include 'arrow-fx-reactor'
 include 'arrow-fx-rx2'


### PR DESCRIPTION
I've been working on this in secret for a while, and I am happy to finally announce the new Arrow Fx Coroutines library that will shape the future for functional effectful programming in Kotlin!

# Arrow Fx Coroutines

Arrow Fx Coroutines offers a suspend DSL with the same semantics and API you find in Arrow Fx's IO, this allows for writing programs using suspend fun directly instead of wrapping in IO.
It's a functional implementation of Kotlin's coroutine system while providing support for cancellation, error handling, resource handling and all goodies you might be familiar with from other functional effect systems.

Arrow Fx aims to be a battery included functional effects framework, below you can find a small overview of the library.
A full coverage of all data types and functions can be found [here](LINK DOCS).

### IO<A> vs suspend () -> A

Let's look at two simple concurrent examples that switch context and print the `Thread.currentThread().name`.

```kotlin:ank
suspend fun getThreadName(): String =
  Thread.currentThread().name
suspend fun main(): Unit = IO.fx {
  val t1 = !effect { getThreadName() }.evalOn(Computation) 
  val t2 = !effect { getThreadName() }.evalOn(BlockingIO)
  val t3 = !effect { getThreadName() }.evalOn(UI)
  !effect { println("$t1 ~> $t2 ~> $t3") }
}.suspended()
```

becomes

```kotlin:ank
suspend fun getThreadName(): String =
  Thread.currentThread().name
suspend fun main(): Unit {
  val t1 = evalOn(Computation) { getThreadName() }
  val t2 = evalOn(BlockingIO) { getThreadName() }
  val t3 = evalOn(UI) { getThreadName() }
  println("$t1 ~> $t2 ~> $t3")
}
```

As you can see we can directly apply `evalOn` to our `suspend fun`, this eliminates the need to wrap explicitly in `IO`.
Both programs are equivalent in semantics and guarantees, the later will however perform better since it eliminates the wrapping `IO` requires.
This is possible without losing cancellation support, as explained in the detail here [anchor cancellation].

### IO<Either<E, A>> vs suspend () -> Either<E, A>

When writing functional code style we often want to express our domain errors as clearly as possible, a popular pattern is to return `Either<DomainError, SuccessValue>`.
Let's assume following domain, and compare two snippets one using `IO<Either<E, A>>` and another `suspend () -> Either<E, A>`.

```kotlin:ank
inline class Id(val id: Long)
object PersistenceError
data class User(val email: String, val name: String)
data class ProcessedUser(val id: Id, val email: String, val name: String)
suspend fun fetchUser(): Either<PersistenceError, User> =
    Right(User("simon@arrow-kt.io", "Simon"))
suspend fun User.process(): Either<PersistenceError, ProcessedUser> =
    if (email.contains(Regex("^(.+)@(.+)$"))) Right(ProcessedUser(UUID.V4.squuid(), email, name))
    else Left(PersistenceError)
```

#### IO<Either<E, A>>

 ```kotlin:ank
fun ioProgram(): IO<Either<PersistenceError, ProcessedUser>> =
  IO.fx {
    val res = !IO.effect { fetchUser() }
    !res.fold({ error ->
      IO.just(Either.Left(error))
    }, { user ->
      IO.effect { user.process() }
    })
  }
// Or unwrapped in `suspend`
suspend suspendedIOProgram(): Either<PersistenceError, ProcessedUser> =
  ioProgram().suspended()
 ```

#### suspend () -> Either<E, A>

```kotlin:ank
suspend fun either(): Either<PersistenceError, ProcessedUser> =
  Either.fx {
    val user = !fetchUser()
    val processed = !user.process()
    processed
  }
```

#### suspend R.() -> A

We can use extension functions to do functional dependency injection with similar semantics as `Reader` or `Kleisli`.
They allow us to elegantly define `syntax` for a certain type. Let's see a simple example.

Let's reuse our previous domain of`User`, `ProcessedUser`, but let's introduce `Repo` and `Persistence` layers to mimick what could be a small app with a couple layers.

```kotlin:ank:playground
interface Repo {
    suspend fun fetchUsers(): List<User>
}
interface Persistence {
    suspend fun User.process(): Either<ProcessingError, ProcessedUser>
    suspend fun List<User>.process(): Either<ProcessingError, List<ProcessedUser>> =
        Either.fx { map { !it.process() } }
}
```

Given the above defined layers we can easily compose them by creating a product which implements the dependencies by delegation.
This can easily be done manually or with the help of a framework like Dagger to do this wiring automatically.

```kotlin:ank
class DataModule(
    persistence: Persistence,
    repo: Repo
) : Persistence by persistence, Repo by repo
```

We can also define top-level functions based on constraints on the receiver.
Here we define `getProcessUsers` which can only be called where `R` is both `Repo` and `Persistence`.

```kotlin:ank
/**
 * Generic top-level function based on syntax enabled by [Persistence] & [Repo] constraint
 */
suspend fun <R> R.getProcessUsers(): Either<ProcessingError, List<ProcessedUser>>
        where R : Repo,
              R : Persistence = fetchUsers().process()
```

## Cancellation

The cancellation system exists out of a few simple building blocks.

All operators found in Arrow Fx check for cancellation. In the small example of an infinite sleeping loop below `sleep` checks for cancellation and thus this function also check for cancellation before/and while sleeping.

```kotlin:ank
tailrec suspend fun sleeper(): Unit {
  println("I am sleepy. I'm going to nap")
  sleep(1.seconds)                                     // <-- cancellation check-point
  println("1 second nap.. Going to sleep some more")
  sleeper()
}
```

#### cancelBoundary()

Calling `suspend fun cancelBoundary()` will check for cancellation, and will gracefully exit in case the effect was cancelled. An example.

```
suspend fun loop(): Unit {
  while(true) { 
	 cancelBoundary() // cancellable computation loop
    println("I am getting dizzy...")
  }
}
```

This `while` will `loop` until the cancel signal is triggered. Once the cancellation is trigger, this task will gracefully exit through `cancelBoundary()`.

In case you don't want to check for cancellation so often, you can also only install a `cancelBoundary` every n batches.
The example below defines `repeat` which checks cancellation every `10` repetition.

```kotlin:ank
tailrec suspend fun repeat(n: Int): Unit {
  if (n % 10 == 0) cancelBoundary()
  if (n == 0) Unit
  else repeat(n - 1)
}
```

#### Parallel operations cancellation

All parallel `suspend` operators in Arrow Fx behave in the following way.

1. When one of the parallel task fails, the others are also cancelled since a result cannot be determined. This will allow the other parallel operations to gracefully exit and close their resources before returning.

2. When the resulting `suspend` operation is cancelled than all running fibers inside will also be cancelled so that all paralell running task can gracefully exit and close their resources before returning.

For more documentation on parallel operations see below.

#### Uncancellable

So how can you execute of `suspend fun` with guarantee that it cannot be cancelled. You simply `wrap` it in the `uncancelable` builder and the function will guarantee not to be cancelled. If the progam is already cancelled before, this block will not run and if it gets cancelled during the execution of this block it will exit immediately after.

```kotlin:ank
suspend fun uncancellableSleep(duration: Duration): Unit =
  uncancellable { sleep(duration) }
```

If we now re-implement our previous `sleeper`, than it will behave a little different from before. The cancellation check before and after `uncancellableSleep` but note that the `sleep` istelf will not be cancelled.

```kotlin:ank
tailrec suspend fun sleeper(): Unit {
  println("I am sleepy. I'm going to nap")
   // <-- cancellation check-point
  uncancellableSleep(1.seconds)
   // <-- cancellation check-point
  println("1 second nap.. Going to sleep some more")
  sleeper()
}
```

This also means that our new sleep can back-pressure `timeOutOrNull`.

```kotlin:ank
suspend main(): Unit {
  val r = timeOutOrNull(1.seconds) {
    uncancelable { sleep(2.seconds) }
  } // r is null, but took 2 seconds.
}
```

## Resource Safety

To ensure resource safety we need to take care with cancellation since we don't wont our process to be cancelled but our resources to remain open.

There Arrow Fx offers 2 tools `Resource` and `suspend fun bracketCase`. Any `resource` operations exists out of 3 steps.

1. Acquiring the resource
2. Using the resource
3. Releasing the resource with either a result, a `Throwable` or `Cancellation`.

To ensure the resource can be correctly acquired we make the `acquire` & `release` step `uncancelable`.
If the `bracketCase` was cancelled during `acquire` it'll immediately go to `release`, skipping the `use` step.

`bracketCase` is defined below, in the `release` step you can inspect the `ExitCase` of the `acquire`/`use`.

```
sealed ExitCase {
  object Completed: ExitCase()
  object Cancelled: ExitCase()
  data class Error(val error: Throwable): ExitCase()
}
suspend fun <A, B> bracketCase(acquire: suspend () -> A, use: suspend (A) -> B, release: (a, ExitCase) -> B): B
```

`bracket` is an overload of `bracketCase` that ignores the `ExitCase` value, a simple example.
We want to create a function to safely create and consume a `DatabaseConnection` that always needs to be closed no matter what the _ExitCase_.

```kotlin:ank
class DatabaseConnection {
  suspend fun open(): String = println("Database connection opened")
  suspend fun close(): String = println("Database connection closed")
}
suspend fun <A> DatabaseConnection.use(f: suspend (DatabaseConnection) -> A): A =
  bracket(
    acquire = { DatabaseConnection().apply { open() } },
    use = f,
    release = DatabaseConnection::close
  )
```

The difference between `Resource` is that `bracketCase` is simple function, while `Resource` is a data type, both ensure that resources are `acquire`d and `release`d correctly.
It also forms a `Monad` so you can use it to safely compose `Resource`s, map them or safely traverse `Resource`s.

```kotlin:ank
suspend fun service(nThreads: Int, name: String): ExecutorService {
  val threadN = AtomicReference(1)
  return Executors.newScheduledThreadPool(nThreads) { r ->
    Thread(r, if (nThreads == 1) name else "$name-${threadNo.incrementAndGet()}")
    .apply { isDaemon = true}
  }
}
suspend fun shutdown(service: ExecutorService): Unit =
  service.shutdown()
suspend fun singleThreadContext(name: String): Resource<CoroutineContext> =
  Resource({ service(1, name) }, ::shutdown)
    .map(ScheduledExecutorService::asCoroutineContext)
suspend fun main(): Unit {
  singleThreadContext("example-pool").use { ctx ->
     evalOn(ctx) {
        println("Running on example-pool: $Thread.currenThread().name")
     }
  }
}
```

A more advanced `Resource` example that reads 3 `DatabaseConnection`s in parallel

```kotlin:ank
class File(url: String) {
  fun open(): File = this
  suspend fun close(): Unit {}
  override fun toString(): String = "This file contains some interesting content!"
}
suspend fun openFile(uri: String): File = File(uri).open()
val resources: List<Resource<File>> =
 listOf(
   Resource({ openFile("path1") }, File::close),
   Resource({ openFile("path2") }, File::close),
   Resource({ openFile("path3") }, File::close)
 )
val resource: Resource<List<File>> =
  resources.sequence(Resource.applicative())
suspend main(): Unit {
  resource.use { files ->
    files.parTraverse(IODispatchers.IOPool) { file ->
       file.toString()
    }
  }
}
```

### Error Handling

In Kotlin with suspend `try/catch` can safely be used to recover from exceptions.

Simple constructs like `suspend fun Either.catch(f: () -> A): Either<Throwable, A>` are available for nicer syntax when and lifting errors in your domain.

### Retrying and repeating effects

`Schedule` allows you to define and compose powerful yet simple policies, which can be used to either repeat or retry computation. 

A simple example might be to repeat an action `n` times, similar to the `repeat` function in the standard library.

```kotlin:ank
suspend main(): Unit {
  repeat(Schedule.recurs<A>(n)) {
    println("Hello")
  }
}
```

Alternatively we can re-use this `Schedule` to `retry` a `suspend fun` `n` times when it fails.

```kotlin:ank
suspend main(): Unit {
  retry(Schedule.recurs<A>(n)) {
    println("I am going to do nothing but throw a tantrum!")
    throw RuntimeException("Boom!")
  }
}
```

Additionally a `Schedule` can also produce an output, let's compose our simple `recurs` Schedule to `recur` every `10.seconds` in a `spaced` fashion and collect all outputs along the way.

```kotlin:ank
fun <A> schedule(): Schedule<A, List<A>> = Schedule {
  (recurs<A>(10) and spaced(10.seconds)) zipRight collect()
}
suspend main(): Unit {
  var count = Atomic(0)
  val history: List<Int> = repeat(schedule<Int>()) {
    println("Incrementing the ref")
    count.update(Int::inc)
  }
}
```

## Parallel Ops


### ForkConnected

`forkConnected` launches a `suspend () -> A` function in a seperate processes called a `Fiber`, the lifecycle of this process is connected to its parent.
If the parent cancels that this operation will also be cancelled.

A `Fiber` is a data type that represents a `suspend fun join(): A` and `suspend fun cancel(): Unit` handle.

### ForkScoped

`forkScoped` is a similar construct as `ForkConnected` but instead of automatically connecting to its parent it takes a `suspend () -> Unit` op which triggers the cancellation.
This can be used as a lower level construct to signal cancellation on a trigger, and wire cancellation with 3rd party frameworks.

```kotlin:ank
tailrec fun fun sleeper(): Unit {
  sleep(1.seconds)
  return sleeper()
}
class AndroidFragnent {
  val cancelPromise = Promise.unsafe<Unit>()
  
  override fun onCreateView(bundle: SavedBundleInstance): Unit {
     suspend {
       ::sleeper.forkScoped(cancelPromise::get)
     }.startCoroutine(Continuation(EmptyCoroutineContext) { })
  }
  
  override fun onDestroyView(): Unit {
    suspend { cancelPromise.complete(Unit) }
      .startCoroutine(Continuation(EmptyCoroutineContext) { })
  }
}
```

### ParMapN/parTupldN

`parMapN` combines two `suspend` functions given a pure function `(A, B) -> C` in parallel on a given `CoroutineContext`. Both `suspend fun` will guarantee to dispatch on the given `CoroutineContext` before they start running.

It also wires their respective cancellation. That means that cancelling the resulting `suspend fun` will cancel both functions running in parallel inside.
Additionally, the function does not return until both tasks are finished and their results combined by `f: (A, B) -> C`.


### ParTraverse/parSequence

`parTraverse` can be used to traverse any data type that supports `Traverse` such as `List`, `Validated`, `Either`, `Option`, etc.
It is used to map elements of the same type `A` in parallel. Cancelling the caller `suspend fun` will cancel all running `Fiber`s inside `parTraverse` gracefully. 

### RaceN

`raceN` is similar to `parMapN` except for it only returns the winner of the race, and cancels the loser as soon as the first fiber finishes the race.

#### RacePair/RaceTriple/ForkAndForget

There are a couple of low level constructs available, and they should be used with care!

- racePair/raceTriple like `raceN` races 2 operations, but instead of cancelling the loser it returns the `Fiber` of the loser task

- ForkAndForget launches a task `fa` as a `Fiber` but doesn't connect it's cancellation system

Both operators can safely capture the running `Fiber` and _guarantee_ not leaking using `bracketCase`.
An example, writing `raceN` in terms of `racePair`.

```kotlin:ank
suspend fun <A, B> raceN(ctx: CoroutineContext, fa: suspend () -> A, fb: suspend () -> B): Either<A, B> =
  bracket(
    acquire = { racePair(ctx, fa, fb) },
    use = { it.bimap({ (a, _) -> a }, { (_, b) -> b }) },
    release = {
      it.bimap(
        { (_, fiber) -> fiber.cancel() },
        { (fiber, _) -> fiber.cancel() }
      )
    }
  )
```

## Arrow Fx Coroutines, KotlinX Coroutines & Kotlin Standard Library

### Demystify Coroutine 

Kotlin's standard library defines a `Coroutine` as an instance of a suspendable computation.

In other words, a `Coroutine` is a compiled `suspend () -> A` program wired to a `Continuation`.

Which can be created by using [`kotlin.coroutines.intrinsics.createCoroutineUnintercepted`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines.intrinsics/create-coroutine-unintercepted.html).

So let's take a quick look at an example.

```kotlin:ank
import kotlin.coroutines.intrinsics.createCoroutineUnintercepted
suspend fun one(): Int = 1
val cont: Continuation<Unit> = ::one
  .createCoroutineUnintercepted(Continuation(EmptyCoroutineContext, ::println))
cont.resume(Unit)
```

As you can see here above we create a `Coroutine` using `createCoroutineUnintercepted` which returns us `Continuation<Unit>`.
Strange, you might've expected a `Coroutine` type but a `Coroutine` is represented by `Continuation<Unit>`.

This `typealias Coroutine = Contination<Unit>` will start running every time you call `resume(Unit)`, which allows you to run the suspend program N times.

### Arrow Fx Coroutines & KotlinX Coroutines

Both Arrow Fx Coroutines & KotlinX Coroutines independently offer an implementation for Kotlin's coroutine system.

As explained in the document above, Arrow Fx Coroutines offers a battery-included functional IO with cancellation support.
Where KotlinX Coroutines offers an implementation that offers light-weight futures with cancellation support.