### PR TITLE
Tuning configuration

### DIFF
--- a/.github/workflows/build_arrow-fx.yml
+++ b/.github/workflows/build_arrow-fx.yml
@@ -10,11 +10,7 @@ jobs:
       JAVA_OPTS: -Xms512m -Xmx1024m
       ARROW_LIB: arrow-fx
 
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-            os: [ubuntu-16.04, ubuntu-latest, macos-latest]
-        fail-fast: false
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v1

--- a/arrow-benchmarks-fx/arrow-kio-benchmarks/build.gradle
+++ b/arrow-benchmarks-fx/arrow-kio-benchmarks/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
 }

--- a/arrow-benchmarks-fx/arrow-scala-benchmarks/build.gradle
+++ b/arrow-benchmarks-fx/arrow-scala-benchmarks/build.gradle
@@ -2,10 +2,8 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
-    id "ru.vyarus.animalsniffer"
     id "scala"
 }
 

--- a/arrow-benchmarks-fx/build.gradle
+++ b/arrow-benchmarks-fx/build.gradle
@@ -17,10 +17,8 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
-    id "ru.vyarus.animalsniffer"
 
     id "me.champeau.gradle.jmh" version "$JMH_PLUGIN_VERSION"
     id "io.morethan.jmhreport" version "$JMH_REPORT_PLUGIN_VERSION"

--- a/arrow-docs/build.gradle
+++ b/arrow-docs/build.gradle
@@ -11,9 +11,7 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jlleitschuh.gradle.ktlint"
-    id "ru.vyarus.animalsniffer"
 }
 
 apply from: "$SUBPROJECT_CONF"

--- a/arrow-fx-coroutines/build.gradle
+++ b/arrow-fx-coroutines/build.gradle
@@ -2,20 +2,13 @@ plugins {
     id "maven-publish"
     id "base"
     id "org.jetbrains.kotlin.jvm"
-    id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
-    id "ru.vyarus.animalsniffer"
 }
 
 apply from: "$SUBPROJECT_CONF"
 apply from: "$DOC_CONF"
 apply from: "$PUBLISH_CONF"
-
-test {
-    useJUnitPlatform()
-}
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"

--- a/arrow-fx-kotlinx-coroutines/build.gradle
+++ b/arrow-fx-kotlinx-coroutines/build.gradle
@@ -3,10 +3,8 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
-    id "ru.vyarus.animalsniffer"
 }
 
 apply from: "$SUBPROJECT_CONF"

--- a/arrow-fx-reactor/build.gradle
+++ b/arrow-fx-reactor/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
 }

--- a/arrow-fx-rx2/build.gradle
+++ b/arrow-fx-rx2/build.gradle
@@ -3,10 +3,8 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
-    id "ru.vyarus.animalsniffer"
 }
 
 apply from: "$SUBPROJECT_CONF"

--- a/arrow-fx-test/build.gradle
+++ b/arrow-fx-test/build.gradle
@@ -3,9 +3,7 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jlleitschuh.gradle.ktlint"
-    id "ru.vyarus.animalsniffer"
 }
 
 apply from: "$SUBPROJECT_CONF"

--- a/arrow-fx/build.gradle
+++ b/arrow-fx/build.gradle
@@ -3,10 +3,8 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
-    id "ru.vyarus.animalsniffer"
 }
 
 apply from: "$SUBPROJECT_CONF"

--- a/arrow-streams/build.gradle
+++ b/arrow-streams/build.gradle
@@ -3,10 +3,8 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "net.rdrei.android.buildtimetracker"
     id "org.jetbrains.dokka"
     id "org.jlleitschuh.gradle.ktlint"
-    id "ru.vyarus.animalsniffer"
 }
 
 apply from: "$SUBPROJECT_CONF"

--- a/build.gradle
+++ b/build.gradle
@@ -16,30 +16,12 @@ plugins {
     id "base"
     id "org.jetbrains.kotlin.jvm" version "$KOTLIN_VERSION"
     id "org.jetbrains.kotlin.kapt" version "$KOTLIN_VERSION"
-    id "net.rdrei.android.buildtimetracker" version "$BUILD_TIME_TRACKER_VERSION"
     id "org.jetbrains.dokka" version "$DOKKA_VERSION" apply false
     id "org.jlleitschuh.gradle.ktlint" version "$KTLINT_GRADLE_VERSION"
-    id "ru.vyarus.animalsniffer" version "$ANIMALS_SNIFFER_VERSION"
 }
 
 apply from: "$GENERIC_CONF"
 
 subprojects {
     apply plugin: 'kotlinx-atomicfu'
-}
-
-configure(subprojects
-            - project("arrow-fx-reactor") 
-            - project("arrow-benchmarks-fx:arrow-kio-benchmarks")) 
-{
-    apply plugin: 'ru.vyarus.animalsniffer'
-    apply plugin: 'java'
-
-    animalsniffer { // Ingore tests
-        sourceSets = [sourceSets.main]
-    }
-
-    dependencies {
-        signature 'net.sf.androidscents.signature:android-api-level-21:5.0.1_r2@signature'
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ DOC_CONF=https://raw.githubusercontent.com/arrow-kt/arrow/master/doc-conf.gradle
 PUBLISH_CONF=https://raw.githubusercontent.com/arrow-kt/arrow/master/publish-conf.gradle
 # Gradle options
 org.gradle.jvmargs=-Xmx4g
-org.gradle.parallel=false
+org.gradle.parallel=true
 # Kotlin configuration
 kotlin.incremental=true
 # Kotlin Test configuration


### PR DESCRIPTION
## Target

PR on `sv-arrow-fx-coroutines` branch (PR #169 ).

## Changes

- Just one environment.
- Parallel Gradle execution.
- Remove buildtimetracker forever .
- Remove animalsniffer temporarily. It's going to be isolated in a single check.
- useJUnitPlatform is specified in SUBPROJECT_CONF