### PR TITLE
Fixes to Schedule

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Schedule.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Schedule.kt
@@ -617,6 +617,8 @@ sealed class Schedule<Input, Output> {
 
     /**
      * Create a schedule that never retries.
+     *
+     * Note that this will hang a program if used as a repeat/retry schedule unless cancelled.
      */
     fun <A> never(): Schedule<A, Nothing> =
       invoke(suspend { arrow.fx.coroutines.never<Unit>() }) { _, _ ->

--- a/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
@@ -691,13 +691,13 @@ sealed class Schedule<F, Input, Output> : ScheduleOf<F, Input, Output> {
       unfoldM(M, M.just(c)) { M.just(f(it)) }
 
     /**
-     * Create a schedule that continues forever and returns the number of iterations.
+     * Create a schedule that continues forever and returns the number of repetitions.
      */
     fun <F, A> forever(M: Monad<F>): Schedule<F, A, Int> =
       unfold(M, 0) { it + 1 }
 
     /**
-     * Create a schedule that continues n times and returns the number of iterations.
+     * Create a schedule that continues n times and returns the number of repetitions.
      */
     fun <F, A> recurs(M: Monad<F>, n: Int): Schedule<F, A, Int> =
       invoke(M, M.just(0)) { _, acc ->

--- a/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
@@ -714,6 +714,8 @@ sealed class Schedule<F, Input, Output> : ScheduleOf<F, Input, Output> {
 
     /**
      * Create a schedule that never retries.
+     *
+     * Note that this will hang a program if used as a repeat/retry schedule unless cancelled.
      */
     fun <F, A> never(AS: Async<F>): Schedule<F, A, Nothing> =
       invoke(AS, AS.never<A>()) { a, _ ->

--- a/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
@@ -15,6 +15,7 @@ import arrow.core.right
 import arrow.core.some
 import arrow.core.toT
 import arrow.fx.Schedule.Companion.withMonad
+import arrow.fx.typeclasses.Async
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.Duration
 import arrow.fx.typeclasses.MonadDefer
@@ -818,7 +819,8 @@ sealed class Schedule<F, Input, Output> : ScheduleOf<F, Input, Output> {
     interface ScheduleFor<M> {
       fun MM(): Monad<M>
 
-      fun <A> identity(): Schedule<M, A, A> = identity(MM())
+      fun <A> identity(): Schedule<M, A, A> =
+        identity(MM())
 
       fun <A, I> unfoldM(c: Kind<M, A>, f: (A) -> Kind<M, A>): Schedule<M, I, A> =
         unfoldM(MM(), c, f)
@@ -829,12 +831,15 @@ sealed class Schedule<F, Input, Output> : ScheduleOf<F, Input, Output> {
       fun <A> forever(): Schedule<M, A, Int> =
         forever(MM())
 
-      fun <A> unit(): Schedule<M, A, Unit> = unit(MM())
+      fun <A> unit(): Schedule<M, A, Unit> =
+        unit(MM())
 
       fun <A> recurs(n: Int): Schedule<M, A, Int> =
         recurs(MM(), n)
 
-      fun <A> once(): Schedule<M, A, Unit> = once(MM())
+      fun <A> once(): Schedule<M, A, Unit> =
+        once(MM())
+
       fun <S, A> delayed(delaySchedule: Schedule<M, A, Duration>): Schedule<M, A, Duration> =
         delayed(MM(), delaySchedule)
 
@@ -899,7 +904,7 @@ fun <F, E, A, B> Kind<F, A>.repeat(
   ME: MonadError<F, E>,
   T: Timer<F>,
   schedule: Schedule<F, A, B>
-): Kind<F, B> = repeatOrElse(ME, T, schedule) { e, _ -> ME.raiseError(e) }
+): Kind<F, B> = repeatOrElse(ME, T, schedule) { e: E, _ -> ME.raiseError(e) }
 
 /**
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
@@ -909,18 +914,18 @@ fun <F, A, B> Kind<F, A>.repeatOrElse(
   CF: Concurrent<F>,
   schedule: Schedule<F, A, B>,
   orElse: (Throwable, Option<B>) -> Kind<F, B>
-): Kind<F, B> = CF.run { repeatOrElseEither(CF, schedule, orElse).map { it.fold(::identity, ::identity) } }
+): Kind<F, B> = repeatOrElseEither(CF, schedule, orElse).map { it.fold(::identity, ::identity) }
 
 /**
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during repetition.
  */
 fun <F, E, A, B> Kind<F, A>.repeatOrElse(
-  ME: MonadError<F, E>,
+  M: Monad<F>,
   T: Timer<F>,
   schedule: Schedule<F, A, B>,
   orElse: (E, Option<B>) -> Kind<F, B>
-): Kind<F, B> = ME.run { repeatOrElseEither(ME, T, schedule, orElse).map { it.fold(::identity, ::identity) } }
+): Kind<F, B> = repeatOrElseEither(M, T, schedule, orElse).map { it.fold(::identity, ::identity) }
 
 /**
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
@@ -937,11 +942,11 @@ fun <F, A, B, C> Kind<F, A>.repeatOrElseEither(
  * Also offers a function to handle errors if they are encountered during repetition.
  */
 fun <F, E, A, B, C> Kind<F, A>.repeatOrElseEither(
-  ME: MonadError<F, E>,
+  M: Monad<F>,
   T: Timer<F>,
   schedule: Schedule<F, A, B>,
   orElse: (E, Option<B>) -> Kind<F, C>
-): Kind<F, Either<C, B>> = ME.run {
+): Kind<F, Either<C, B>> {
   (schedule as Schedule.ScheduleImpl<F, Any?, A, B>)
 
   fun loop(last: A, state: Any?): Kind<F, Either<C, B>> =
@@ -949,12 +954,12 @@ fun <F, E, A, B, C> Kind<F, A>.repeatOrElseEither(
       .flatMap { desc ->
         if (desc.cont)
           flatMap { a -> T.sleep(desc.delay).flatMap { loop(a, desc.state) } }
-            .handleErrorWith { e -> orElse(e, desc.finish.value().some()).map { Left(it) } }
-        else just(desc.finish.value().right())
+            .handleErrorWith { e -> orElse(e, desc.finish.value().some()).map(::Left) }
+        else M.just(desc.finish.value().right())
       }
 
   return flatMap { a -> schedule.initialState.flatMap { b -> loop(a, b) } }
-    .handleErrorWith { e -> orElse(e, None).map { Left(it) } }
+    .handleErrorWith { e -> orElse(e, None).map(::Left) }
 }
 
 /**
@@ -984,18 +989,18 @@ fun <F, A, B> Kind<F, A>.retryOrElse(
   CF: Concurrent<F>,
   schedule: Schedule<F, Throwable, B>,
   orElse: (Throwable, B) -> Kind<F, A>
-): Kind<F, A> = CF.run { retryOrElseEither(CF, schedule, orElse).map { it.fold(::identity, ::identity) } }
+): Kind<F, A> = retryOrElseEither(CF, schedule, orElse).map { it.fold(::identity, ::identity) }
 
 /**
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during retrial.
  */
 fun <F, E, A, B> Kind<F, A>.retryOrElse(
-  ME: MonadError<F, E>,
+  M: Monad<F>,
   T: Timer<F>,
   schedule: Schedule<F, E, B>,
   orElse: (E, B) -> Kind<F, A>
-): Kind<F, A> = ME.run { retryOrElseEither(ME, T, schedule, orElse).map { it.fold(::identity, ::identity) } }
+): Kind<F, A> = retryOrElseEither(M, T, schedule, orElse).map { it.fold(::identity, ::identity) }
 
 /**
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
@@ -1012,15 +1017,15 @@ fun <F, A, B, C> Kind<F, A>.retryOrElseEither(
  * Also offers a function to handle errors if they are encountered during retrial.
  */
 fun <F, E, A, B, C> Kind<F, A>.retryOrElseEither(
-  ME: MonadError<F, E>,
+  M: Monad<F>,
   T: Timer<F>,
   schedule: Schedule<F, E, B>,
   orElse: (E, B) -> Kind<F, C>
-): Kind<F, Either<C, A>> = ME.run {
+): Kind<F, Either<C, A>> {
   (schedule as Schedule.ScheduleImpl<F, Any?, E, B>)
 
   fun loop(state: Any?): Kind<F, Either<C, A>> =
-    flatMap { just(it.right()) }
+    flatMap { M.just(it.right()) }
       .handleErrorWith { e ->
         schedule.update(e, state)
           .flatMap { dec ->
@@ -1029,5 +1034,5 @@ fun <F, E, A, B, C> Kind<F, A>.retryOrElseEither(
           }
       }
 
-  schedule.initialState.flatMap(::loop)
+  return schedule.initialState.flatMap(::loop)
 }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule.kt
@@ -8,7 +8,6 @@ import arrow.fx.ForSchedule
 import arrow.fx.Schedule
 import arrow.fx.SchedulePartialOf
 import arrow.fx.fix
-import arrow.typeclasses.Alternative
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Apply
 import arrow.typeclasses.Category
@@ -17,7 +16,6 @@ import arrow.typeclasses.Contravariant
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
-import arrow.typeclasses.MonoidK
 import arrow.typeclasses.Profunctor
 import arrow.typeclasses.Semigroup
 import arrow.typeclasses.SemigroupK
@@ -69,25 +67,6 @@ interface ScheduleMonoid<F, Input, Output> : Monoid<Schedule<F, Input, Output>>,
 interface ScheduleSemigroupK<F, Input> : SemigroupK<SchedulePartialOf<F, Input>> {
   override fun <A> Kind<SchedulePartialOf<F, Input>, A>.combineK(y: Kind<SchedulePartialOf<F, Input>, A>): Kind<SchedulePartialOf<F, Input>, A> =
     fix().andThen(y.fix()).map { it.fold(::identity, ::identity) }
-}
-
-@extension
-interface ScheduleMonoidK<F, Input> : MonoidK<SchedulePartialOf<F, Input>>, ScheduleSemigroupK<F, Input> {
-  fun MF(): Monad<F>
-
-  override fun <A> empty(): Kind<SchedulePartialOf<F, Input>, A> =
-    Schedule.never(MF())
-}
-
-@extension
-interface ScheduleAlternative<F, Input> : Alternative<SchedulePartialOf<F, Input>>, ScheduleApplicative<F, Input>, ScheduleMonoidK<F, Input> {
-  override fun MF(): Monad<F>
-
-  override fun <A> Kind<SchedulePartialOf<F, Input>, A>.orElse(b: Kind<SchedulePartialOf<F, Input>, A>): Kind<SchedulePartialOf<F, Input>, A> =
-    fix().andThen(b.fix()).map { it.fold(::identity, ::identity) }
-
-  override fun <A> Kind<SchedulePartialOf<F, Input>, A>.combineK(y: Kind<SchedulePartialOf<F, Input>, A>): Kind<SchedulePartialOf<F, Input>, A> =
-    orElse(y)
 }
 
 @extension

--- a/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
@@ -24,6 +24,7 @@ import arrow.core.test.laws.ProfunctorLaws
 import arrow.core.toT
 import arrow.core.value
 import arrow.fx.extensions.io.applicativeError.attempt
+import arrow.fx.extensions.io.async.async
 import arrow.fx.extensions.io.monad.monad
 import arrow.fx.extensions.io.monadDefer.monadDefer
 import arrow.fx.extensions.io.monadThrow.monadThrow
@@ -177,7 +178,9 @@ class ScheduleTest : UnitSpec() {
 
     "Schedule.never() == Schedule.recurs(0)" {
       scheduleEq.run {
-        Schedule.never<ForId, Any?>(Id.monad()).eqv(Schedule.recurs(Id.monad(), 0)) shouldBe true
+        val res = Schedule.never<ForIO, Any?>(IO.async()).runIdSchedule(0)
+
+//        Schedule.never<ForIO, Any?>(IO.async()).eqv(Schedule.recurs(IO.monad(), 0)) shouldBe true
       }
     }
 

--- a/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
@@ -178,6 +178,7 @@ class ScheduleTest : UnitSpec() {
 
     "Schedule.never() == Schedule.recurs(0)" {
       scheduleEq.run {
+        // WIP
         val res = Schedule.never<ForIO, Any?>(IO.async()).runIdSchedule(0)
 
 //        Schedule.never<ForIO, Any?>(IO.async()).eqv(Schedule.recurs(IO.monad(), 0)) shouldBe true

--- a/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
@@ -178,7 +178,6 @@ class ScheduleTest : UnitSpec() {
 
     "Schedule.never() == Schedule.recurs(0)" {
       scheduleEq.run {
-        // WIP
         val res = Schedule.never<ForIO, Any?>(IO.async()).runIdSchedule(0)
 
 //        Schedule.never<ForIO, Any?>(IO.async()).eqv(Schedule.recurs(IO.monad(), 0)) shouldBe true

--- a/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/ScheduleTest.kt
@@ -5,6 +5,7 @@ import arrow.Kind2
 import arrow.core.Either
 import arrow.core.ForId
 import arrow.core.Id
+import arrow.core.None
 import arrow.core.extensions.eq
 import arrow.core.extensions.id.eqK.eqK
 import arrow.core.extensions.id.monad.monad
@@ -16,7 +17,6 @@ import arrow.core.test.generators.GenK
 import arrow.core.test.generators.GenK2
 import arrow.core.test.generators.applicative
 import arrow.core.test.generators.intSmall
-import arrow.core.test.laws.AlternativeLaws
 import arrow.core.test.laws.ApplicativeLaws
 import arrow.core.test.laws.CategoryLaws
 import arrow.core.test.laws.MonoidLaws
@@ -28,7 +28,6 @@ import arrow.fx.extensions.io.async.async
 import arrow.fx.extensions.io.monad.monad
 import arrow.fx.extensions.io.monadDefer.monadDefer
 import arrow.fx.extensions.io.monadThrow.monadThrow
-import arrow.fx.extensions.schedule.alternative.alternative
 import arrow.fx.extensions.schedule.applicative.applicative
 import arrow.fx.extensions.schedule.category.category
 import arrow.fx.extensions.schedule.monoid.monoid
@@ -37,6 +36,7 @@ import arrow.fx.test.eq.eqK
 import arrow.fx.test.generators.genK
 import arrow.fx.test.laws.forFew
 import arrow.fx.typeclasses.Duration
+import arrow.fx.typeclasses.milliseconds
 import arrow.fx.typeclasses.seconds
 import arrow.typeclasses.Eq
 import arrow.typeclasses.EqK
@@ -117,11 +117,6 @@ class ScheduleTest : UnitSpec() {
         Schedule.genK<ForId, Int>(Id.monad()).genK(Gen.int()).map { it.fix() },
         eqK(Id.eqK(), Id.monad(), 0).liftEq(Int.eq())
       ),
-      AlternativeLaws.laws(
-        Schedule.alternative<ForId, Int>(Id.monad()),
-        Schedule.genK<ForId, Int>(Id.monad()),
-        eqK(Id.eqK(), Id.monad(), 0)
-      ),
       ProfunctorLaws.laws(
         Schedule.profunctor(),
         Schedule.genK2(Id.monad()),
@@ -165,8 +160,21 @@ class ScheduleTest : UnitSpec() {
         val res = Schedule.recurs<ForId, Int>(Id.monad(), i).runIdSchedule(0, i + 1)
 
         if (i < 0) res.isEmpty()
-        else res.dropLast(1).forAll { it.cont && it.delay.amount == 0L } &&
-          res.last().let { it.cont.not() && it.delay.amount == 0L && it.finish.value() == i + 1 && it.state == i + 1 }
+        else {
+          res.dropLast(1).forEach {
+            it.cont shouldBe true
+            it.delay.amount shouldBe 0L
+          }
+
+          res.last().let {
+            it.cont shouldBe false
+            it.delay.amount shouldBe 0L
+            it.finish.value() shouldBe i
+            it.state shouldBe i
+          }
+
+          true
+        }
       }
     }
 
@@ -176,12 +184,12 @@ class ScheduleTest : UnitSpec() {
       }
     }
 
-    "Schedule.never() == Schedule.recurs(0)" {
-      scheduleEq.run {
-        val res = Schedule.never<ForIO, Any?>(IO.async()).runIdSchedule(0)
+    "Schedule.never() should execute once and timeout" {
+      val sideEffect = SideEffect()
+      IO { sideEffect.increment() }.repeat(Schedule.never(IO.async()))
+        .unsafeRunTimed(50.milliseconds) shouldBe None
 
-//        Schedule.never<ForIO, Any?>(IO.async()).eqv(Schedule.recurs(IO.monad(), 0)) shouldBe true
-      }
+      sideEffect.counter shouldBe 1
     }
 
     "Schedule.spaced()" {
@@ -228,7 +236,7 @@ class ScheduleTest : UnitSpec() {
     }
 
     "repeat" {
-      forAll(Schedule.Decision.genK().genK(Gen.int()), Gen.intSmall().filter { it < 100 }.filter { it >= 0 }) { dec, n ->
+      forAll(Schedule.Decision.genK().genK(Gen.int()), Gen.intSmall().filter { it in 0..99 }) { dec, n ->
         val schedule = Schedule(IO.monad(), IO.just(0 as Any?)) { _: Unit, _ -> IO.just(dec.fix()) }
 
         val eff = SideEffect()
@@ -239,12 +247,18 @@ class ScheduleTest : UnitSpec() {
           .attempt()
           .fix().unsafeRunSync()
 
-        if (dec.fix().cont || n == 0) res.isLeft() &&
-          ref.get().fix().unsafeRunSync().nanoseconds == max(n - 1, 0) * dec.fix().delay.nanoseconds &&
-          eff.counter == n
-        else res.isRight() && eff.counter == 1 &&
-          ref.get().fix().unsafeRunSync().nanoseconds == 0L &&
-          (res as Either.Right).b == dec.fix().finish.value()
+        if (dec.fix().cont || n == 0) {
+          res.isLeft() shouldBe true
+          ref.get().fix().unsafeRunSync().nanoseconds shouldBe max(n, 0) * dec.fix().delay.nanoseconds
+          eff.counter shouldBe n
+        } else {
+          res.isRight() shouldBe true
+          eff.counter shouldBe 1
+          ref.get().fix().unsafeRunSync().nanoseconds shouldBe 0L
+          (res as Either.Right).b shouldBe dec.fix().finish.value()
+        }
+
+        true
       }
     }
 
@@ -264,12 +278,17 @@ class ScheduleTest : UnitSpec() {
           .attempt()
           .fix().unsafeRunSync()
 
-        if (dec.fix().cont) res.isRight() &&
-          eff.counter == n + 1 &&
-          ref.get().fix().unsafeRunSync().nanoseconds == (n + 1) * dec.fix().delay.nanoseconds
-        else res.isLeft() &&
-          eff.counter == 1 &&
-          ref.get().fix().unsafeRunSync().nanoseconds == 0L
+        if (dec.fix().cont) {
+          res.isRight() shouldBe true
+          eff.counter shouldBe n + 1
+          ref.get().fix().unsafeRunSync().nanoseconds shouldBe (n + 1) * dec.fix().delay.nanoseconds
+        } else {
+          res.isLeft() shouldBe true
+          eff.counter shouldBe 1
+          ref.get().fix().unsafeRunSync().nanoseconds shouldBe 0L
+        }
+
+        true
       }
     }
   }


### PR DESCRIPTION
* Fix schedule recurs #173 returning the number of total iterations, instead of repetitions
* Fix never #174 that should never repeat and basically hang the program
* Fix repeat not waiting for delay after first emission #172 
* Also removed Alternative and MonoidK instances as it might not have sense to provide Schedule.never() as MonoidK.empty()