### PR TITLE
Configuration: Add cache management

### DIFF
--- a/.github/workflows/build_arrow-fx.yml
+++ b/.github/workflows/build_arrow-fx.yml
@@ -10,11 +10,19 @@ jobs:
       ARROW_LIB: arrow-fx
 
     runs-on: macos-latest
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v1
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
+    - name: Cache management
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}--gradle--${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}--gradle--
     - name: Checkout orchestrator
       run: |
         cd $BASEDIR
@@ -36,3 +44,6 @@ jobs:
     #  run: |
     #    export PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d/ -f3)
     #    ./gradlew :arrow-benchmarks-fx:compareBenchmarksCI
+    - name: Clean SNAPSHOTs
+      run: |
+        find ~/.gradle/caches/ -type d -name "*SNAPSHOT*" -prune -exec rm -rf {} +


### PR DESCRIPTION
I was talking about our current problems with a heavy test process and this is one of the recommendations to improve it. 

How it works:

- `Cache management` step will add the use of the cache if it exists.
- A new final step is added automatically to create the cache.

SNAPSHOT dependencies are being used during development for the rest of Arrow libraries so I remove them before caching all the dependencies.

## Reason of this pull request

We're still having random errors:

```
arrow.fx.QueueTest > UnboundedQueue - queue can be filled at once over capacity with takers FAILED
arrow.fx.internal.TimeoutException: Duration(amount=5, timeUnit=SECONDS)
```

```
arrow.fx.coroutines.BracketCaseTest > Uncancellable back pressures timeoutOrNull STANDARD_ERROR
kotlinx.coroutines.CoroutinesInternalError: Fatal exception in coroutines machinery for DispatchedContinuation[BlockingEventLoop@56dc1a35, Continuation at io.kotest.core.runtime.ExecutorExecutionContext$executeWithTimeoutInterruption$$inlined$suspendCoroutine$lambda$2@1d335513]. Please read KDoc to 'handleFatalException' method and report this incident to maintainers
at kotlinx.coroutines.DispatchedTask.handleFatalException$kotlinx_coroutines_core(DispatchedTask.kt:93)
...
Caused by: java.lang.ClassCastException: kotlin.coroutines.jvm.internal.CompletedContinuation cannot be cast to kotlinx.coroutines.DispatchedContinuation
at kotlinx.coroutines.CoroutineDispatcher.releaseInterceptedContinuation(CoroutineDispatcher.kt:103)
```
```
arrow.fx.coroutines.BracketCaseTest > Uncancellable back pressures timeoutOrNull FAILED
TimeoutException(duration=600s)
at io.kotest.core.runtime.ExecutorExecutionContext$executeWithTimeoutInterruption$$inlined$suspendCoroutine$lambda$1.run(ExecutorExecutionContext.kt:39)
```
```
arrow.fx.coroutines.BracketCaseTest > executionError FAILED
TimeoutException(duration=600s)
at io.kotest.core.runtime.ExecutorExecutionContext$executeWithTimeoutInterruption$$inlined$suspendCoroutine$lambda$1.run(ExecutorExecutionContext.kt:39)
```