### PR TITLE
Fix issue SuspendConnection

### DIFF
--- a/.github/workflows/build_arrow-fx.yml
+++ b/.github/workflows/build_arrow-fx.yml
@@ -16,20 +16,14 @@ jobs:
     - uses: actions/checkout@v1
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
-    - name: Cache management
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}--gradle--${{ hashFiles('**/*.gradle*') }}
-        restore-keys: |
-          ${{ runner.os }}--gradle--
     - name: Checkout orchestrator
       run: |
         cd $BASEDIR
         git clone https://github.com/arrow-kt/arrow.git
     - name: Build with Gradle
       run: |
-        $BASEDIR/arrow/scripts/project-build.sh $ARROW_LIB
+        ./gradlew build
+        #$BASEDIR/arrow/scripts/project-build.sh $ARROW_LIB
     #- name: Run benchmark for master branch
     #  run: |
     #    git checkout master
@@ -44,6 +38,3 @@ jobs:
     #  run: |
     #    export PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d/ -f3)
     #    ./gradlew :arrow-benchmarks-fx:compareBenchmarksCI
-    - name: Clean SNAPSHOTs
-      run: |
-        find ~/.gradle/caches/ -type d -name "*SNAPSHOT*" -prune -exec rm -rf {} +

--- a/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
@@ -433,7 +433,7 @@ class IOTest : UnitSpec() {
       result shouldBe None
     }
 
-    "parallel execution with single threaded context makes all IOs start at the same time".config(enabled = false) {
+    "parallel execution with single threaded context makes all IOs start at the same time" {
       val order = mutableListOf<Long>()
 
       fun makePar(num: Long): IO<Nothing, Long> =
@@ -455,7 +455,7 @@ class IOTest : UnitSpec() {
       order.toList() shouldBe listOf(1L, 2, 3, 4, 5, 6)
     }
 
-    "parallel execution preserves order for synchronous IOs".config(enabled = false) {
+    "parallel execution preserves order for synchronous IOs" {
       val order = mutableListOf<Long>()
 
       fun IO<Nothing, Long>.order() =
@@ -503,7 +503,7 @@ class IOTest : UnitSpec() {
       order shouldBe listOf(9, 8, 7, 6, 5, 4, 3, 2, 1)
     }
 
-    "parallel mapping is done in the expected CoroutineContext".config(enabled = false) {
+    "parallel mapping is done in the expected CoroutineContext" {
       fun makePar(num: Long) =
         IO(newSingleThreadContext("$num")) {
           // Sleep according to my number
@@ -521,7 +521,7 @@ class IOTest : UnitSpec() {
       result shouldBe "6"
     }
 
-    "parallel IO#defer, IO#suspend and IO#async are run in the expected CoroutineContext".config(enabled = false) {
+    "parallel IO#defer, IO#suspend and IO#async are run in the expected CoroutineContext" {
       val result =
         IO.parTupledN(all,
             IO { Thread.currentThread().name },

--- a/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
+++ b/arrow-fx/src/test/kotlin/arrow/fx/IOTest.kt
@@ -433,7 +433,7 @@ class IOTest : UnitSpec() {
       result shouldBe None
     }
 
-    "parallel execution with single threaded context makes all IOs start at the same time" {
+    "parallel execution with single threaded context makes all IOs start at the same time".config(enabled = false) {
       val order = mutableListOf<Long>()
 
       fun makePar(num: Long): IO<Nothing, Long> =
@@ -455,7 +455,7 @@ class IOTest : UnitSpec() {
       order.toList() shouldBe listOf(1L, 2, 3, 4, 5, 6)
     }
 
-    "parallel execution preserves order for synchronous IOs" {
+    "parallel execution preserves order for synchronous IOs".config(enabled = false) {
       val order = mutableListOf<Long>()
 
       fun IO<Nothing, Long>.order() =
@@ -503,7 +503,7 @@ class IOTest : UnitSpec() {
       order shouldBe listOf(9, 8, 7, 6, 5, 4, 3, 2, 1)
     }
 
-    "parallel mapping is done in the expected CoroutineContext" {
+    "parallel mapping is done in the expected CoroutineContext".config(enabled = false) {
       fun makePar(num: Long) =
         IO(newSingleThreadContext("$num")) {
           // Sleep according to my number
@@ -521,7 +521,7 @@ class IOTest : UnitSpec() {
       result shouldBe "6"
     }
 
-    "parallel IO#defer, IO#suspend and IO#async are run in the expected CoroutineContext" {
+    "parallel IO#defer, IO#suspend and IO#async are run in the expected CoroutineContext".config(enabled = false) {
       val result =
         IO.parTupledN(all,
             IO { Thread.currentThread().name },

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ SUBPROJECT_CONF=https://raw.githubusercontent.com/arrow-kt/arrow/master/subproje
 DOC_CONF=https://raw.githubusercontent.com/arrow-kt/arrow/master/doc-conf.gradle
 PUBLISH_CONF=https://raw.githubusercontent.com/arrow-kt/arrow/master/publish-conf.gradle
 # Gradle options
-org.gradle.jvmargs=-Xmx7g
+org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true
 # Kotlin configuration
 kotlin.incremental=true


### PR DESCRIPTION
SuspendConnection now uses `Platform.unsafeRunSync` internally to cancel a token when the connection is already cancelled.

Instead it should use `startCoroutine` that runs on an empty context, which allows for the cancel token to fork and exit the existing context.