### PR TITLE
Configuration: recover the previous build step

### DIFF
--- a/.github/workflows/build_arrow-fx.yml
+++ b/.github/workflows/build_arrow-fx.yml
@@ -21,9 +21,7 @@ jobs:
         cd $BASEDIR
         git clone https://github.com/arrow-kt/arrow.git
     - name: Build with Gradle
-      run: |
-        ./gradlew build
-        #$BASEDIR/arrow/scripts/project-build.sh $ARROW_LIB
+      run: $BASEDIR/arrow/scripts/project-build.sh $ARROW_LIB
     #- name: Run benchmark for master branch
     #  run: |
     #    git checkout master


### PR DESCRIPTION
It's already fixed in `arrow` repository.