### PR TITLE
Use of KOTEST_VERSION property

### DIFF
--- a/arrow-fx-coroutines/build.gradle
+++ b/arrow-fx-coroutines/build.gradle
@@ -15,10 +15,10 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
     compile "io.arrow-kt:arrow-core:$VERSION_NAME"
 
-    testImplementation "io.kotest:kotest-runner-junit5-jvm:4.0.6" // for kotest framework
-    testImplementation "io.kotest:kotest-assertions-core-jvm:4.0.6" // for kotest core jvm assertions
-    testImplementation "io.kotest:kotest-property-jvm:4.0.6" // for kotest property test
-    testImplementation "io.kotest:kotest-runner-console-jvm:4.0.6"
+    testImplementation "io.kotest:kotest-runner-junit5-jvm:$KOTEST_VERSION" // for kotest framework
+    testImplementation "io.kotest:kotest-assertions-core-jvm:$KOTEST_VERSION" // for kotest core jvm assertions
+    testImplementation "io.kotest:kotest-property-jvm:$KOTEST_VERSION" // for kotest property test
+    testImplementation "io.kotest:kotest-runner-console-jvm:$KOTEST_VERSION"
 }
 
 compileTestKotlin {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
@@ -111,13 +111,9 @@ fun <L, R> Arb.Companion.either(left: Arb<L>, right: Arb<R>): Arb<Either<L, R>> 
   return Arb.choice(failure, success)
 }
 
-fun Arb.Companion.intRange(min: Int = 0, max: Int = 1000): Arb<IntRange> =
-  Arb.int(min, max).flatMap { a ->
-    Arb.int(min, max).map { b ->
-      val first = min(a, b)
-      val last = max(a, b)
-      first..last
-    }
+fun Arb.Companion.intRange(min: Int = Int.MIN_VALUE, max: Int = Int.MAX_VALUE): Arb<IntRange> =
+  Arb.bind(Arb.int(min, max), Arb.int(min, max)) { a, b ->
+    if (a < b) a..b else b..a
   }
 
 fun Arb.Companion.longRange(min: Long = Long.MIN_VALUE, max: Long = Long.MAX_VALUE): Arb<LongRange> =

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
@@ -14,7 +14,6 @@ import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.char
 import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.constant
-import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.map


### PR DESCRIPTION
In order to help to the progressive use of Kotest.

**Note**: it corresponds to `4.1.0` instead of `4.0.6`. Let's see if it works...