### PR TITLE
Configuration: download test reports

### DIFF
--- a/.github/workflows/build_arrow-fx.yml
+++ b/.github/workflows/build_arrow-fx.yml
@@ -36,3 +36,17 @@ jobs:
     #  run: |
     #    export PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d/ -f3)
     #    ./gradlew :arrow-benchmarks-fx:compareBenchmarksCI
+    - name: Prepare test reports
+      if: ${{ always() }}
+      run: |
+        mkdir test-reports
+        for report in `ls -d ./**/build/reports/tests/test`; do
+          arrow_module=$(echo $report | cut -d/ -f2)
+          cp -r $report test-reports/$arrow_module
+        done
+    - name: Make test reports available to download
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v1
+      with:
+        name: test-reports
+        path: test-reports


### PR DESCRIPTION
# Goal

It will be possible to browse test reports despite of the build check result.

# Screenshot

![Screenshot from 2020-06-29 16-46-39](https://user-images.githubusercontent.com/22792183/86020394-27f44700-ba28-11ea-9ced-58505bd2f1c3.png)


# Example

Example of failing tests: https://github.com/arrow-kt/arrow-fx/runs/818689776



