### PR TITLE
Fix timeOutOrNull to return on the  context

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/timer.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/timer.kt
@@ -8,6 +8,7 @@ import kotlin.coroutines.startCoroutine
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.intercepted
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -87,7 +88,7 @@ suspend fun <A> timeOutOrNull(duration: Duration, fa: suspend () -> A): A? =
         timeOut.fold({
           if (isActive.compareAndSet(true, false)) {
             faConn.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) {
-              it.fold({ uCont.resume(null) }, uCont::resumeWithException)
+              it.fold({ uCont.intercepted().resume(null) }, uCont::resumeWithException)
             })
           }
         }, uCont::resumeWithException)

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/PredefTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/PredefTest.kt
@@ -4,7 +4,7 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
-import io.kotest.property.checkAll
+import io.kotest.property.arbitrary.string
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
@@ -40,6 +40,24 @@ class PredefTest : ArrowFxSpec(spec = {
       Either.catch {
         promise.join()
       } shouldBe ea
+    }
+  }
+
+  "shift" {
+    checkAll(Arb.string(), Arb.string()) { a, b ->
+      val t0 = threadName.invoke()
+
+      singleThreadContext(a)
+        .zip(singleThreadContext(b))
+        .use { (ui, io) ->
+          t0 shouldBe threadName.invoke()
+
+          ui.shift()
+          threadName.invoke() shouldBe a
+
+          io.shift()
+          threadName.invoke() shouldBe b
+        }
     }
   }
 })

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
@@ -14,6 +14,58 @@ class TimerTest : ArrowFxSpec(spec = {
   suspend fun timeMilis(): Long =
     System.currentTimeMillis()
 
+  "sleep returns on the original context" {
+    single.use { ctx ->
+      checkAll(Arb.int()) {
+        evalOn(ctx) {
+          val n0 = threadName.invoke()
+          sleep(10.milliseconds)
+          val n = threadName.invoke()
+
+          n0 shouldBe n
+        }
+      }
+    }
+  }
+
+  "timeOutOrNull" - {
+    "returns to original context without timing out" {
+      singleThreadContext("1").zip(single).use { (one, single) ->
+        checkAll(Arb.int()) {
+          evalOn(single) {
+            val n0 = threadName.invoke()
+
+            timeOutOrNull(1.minutes) {
+              one.shift()
+              threadName.invoke() shouldBe "1"
+              Unit.suspend()
+            }
+
+            n0 shouldBe threadName.invoke()
+          }
+        }
+      }
+    }
+
+    "returns to original context when timing out" {
+      singleThreadContext("1").zip(single).use { (one, single) ->
+        checkAll(Arb.int()) {
+          evalOn(single) {
+            val n0 = threadName.invoke()
+
+            timeOutOrNull(50.milliseconds) {
+              one.shift()
+              threadName.invoke() shouldBe "1"
+              never<Unit>()
+            } shouldBe null
+
+            n0 shouldBe threadName.invoke()
+          }
+        }
+      }
+    }
+  }
+
   "sleep should last specified time" {
     checkAll(Arb.positiveInts(max = 50)) { i ->
       val length = i.toLong()

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
@@ -23,6 +23,7 @@ import java.io.OutputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.intercepted
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
@@ -198,4 +199,13 @@ inline fun <A> assertThrowable(executable: () -> A): Throwable =
     fail("Expected an exception but found: $a")
   } catch (e: Throwable) {
     e
+  }
+
+internal suspend fun CoroutineContext.shift(): Unit =
+  suspendCoroutineUninterceptedOrReturn { cont ->
+    suspend { this }.startCoroutine(Continuation(this) {
+      cont.resume(Unit)
+    })
+
+    COROUTINE_SUSPENDED
   }


### PR DESCRIPTION
- Fixes `timeOutOrNull` or null to return on the previous context.

@rachelcarmena @aballano
I suspect this was the reason for the flaky `Uncancellable back pressures timeoutOrNull` test.
So let's keep an eye on this together ;)