### PR TITLE
Complete test suite to check interception

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RaceTriple.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/RaceTriple.kt
@@ -4,7 +4,9 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.startCoroutine
-import kotlin.coroutines.suspendCoroutine
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.intercepted
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 
 sealed class RaceTriple<A, B, C> {
   data class First<A, B, C>(val winner: A, val fiberB: Fiber<B>, val fiberC: Fiber<C>) : RaceTriple<A, B, C>()
@@ -60,79 +62,83 @@ suspend fun <A, B, C> raceTriple(
   fa: suspend () -> A,
   fb: suspend () -> B,
   fc: suspend () -> C
-): RaceTriple<A, B, C> = suspendCoroutine { cont ->
-  val conn = cont.context.connection()
-  val active = AtomicBooleanW(true)
+): RaceTriple<A, B, C> =
+  suspendCoroutineUninterceptedOrReturn { cont ->
+    val conn = cont.context.connection()
+    val cont = cont.intercepted()
+    val active = AtomicBooleanW(true)
 
-  // Cancellable connection for the left value
-  val connA = SuspendConnection()
-  val promiseA = UnsafePromise<A>()
+    // Cancellable connection for the left value
+    val connA = SuspendConnection()
+    val promiseA = UnsafePromise<A>()
 
-  // Cancellable connection for the right value
-  val connB = SuspendConnection()
-  val promiseB = UnsafePromise<B>()
+    // Cancellable connection for the right value
+    val connB = SuspendConnection()
+    val promiseB = UnsafePromise<B>()
 
-  // Cancellable connection for the right value
-  val connC = SuspendConnection()
-  val promiseC = UnsafePromise<C>()
+    // Cancellable connection for the right value
+    val connC = SuspendConnection()
+    val promiseC = UnsafePromise<C>()
 
-  conn.push(listOf(connA.cancelToken(), connB.cancelToken(), connC.cancelToken()))
+    conn.push(listOf(connA.cancelToken(), connB.cancelToken(), connC.cancelToken()))
 
-  fun <A> onError(
-    error: Throwable,
-    connB: SuspendConnection,
-    connC: SuspendConnection,
-    promise: UnsafePromise<A>
-  ): Unit {
-    if (active.getAndSet(false)) { // if an error finishes first, stop the race.
-      connB.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r2 ->
-        connC.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r3 ->
-          conn.pop()
+    fun <A> onError(
+      error: Throwable,
+      connB: SuspendConnection,
+      connC: SuspendConnection,
+      promise: UnsafePromise<A>
+    ): Unit {
+      if (active.getAndSet(false)) { // if an error finishes first, stop the race.
+        connB.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r2 ->
+          connC.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r3 ->
+            conn.pop()
 
-          val errorResult = r2.fold({
-            r3.fold({ error }, { e3 -> Platform.composeErrors(error, e3) })
-          }, { e2 ->
-            r3.fold({ Platform.composeErrors(error, e2) }, { e3 -> Platform.composeErrors(error, e2, e3) })
+            val errorResult = r2.fold({
+              r3.fold({ error }, { e3 -> Platform.composeErrors(error, e3) })
+            }, { e2 ->
+              r3.fold({ Platform.composeErrors(error, e2) }, { e3 -> Platform.composeErrors(error, e2, e3) })
+            })
+
+            cont.resumeWith(Result.failure(errorResult))
           })
-
-          cont.resumeWith(Result.failure(errorResult))
         })
-      })
-    } else {
-      promise.complete(Result.failure(error))
+      } else {
+        promise.complete(Result.failure(error))
+      }
     }
+
+    fa.startCoroutineCancellable(CancellableContinuation(ctx, connA) { result ->
+      result.fold({ a ->
+        if (active.getAndSet(false)) {
+          conn.pop()
+          cont.resumeWith(Result.success(RaceTriple.First(a, Fiber(promiseB, connB), Fiber(promiseC, connC))))
+        } else {
+          promiseA.complete(Result.success(a))
+        }
+      }, { error -> onError(error, connB, connC, promiseA) })
+    })
+
+    fb.startCoroutineCancellable(CancellableContinuation(ctx, connB) { result ->
+      result.fold({ b ->
+        if (active.getAndSet(false)) {
+          conn.pop()
+          cont.resumeWith(Result.success(RaceTriple.Second(Fiber(promiseA, connA), b, Fiber(promiseC, connC))))
+        } else {
+          promiseB.complete(Result.success(b))
+        }
+      }, { error -> onError(error, connA, connC, promiseB) })
+    })
+
+    fc.startCoroutineCancellable(CancellableContinuation(ctx, connC) { result ->
+      result.fold({ c ->
+        if (active.getAndSet(false)) {
+          conn.pop()
+          cont.resumeWith(Result.success(RaceTriple.Third(Fiber(promiseA, connA), Fiber(promiseB, connB), c)))
+        } else {
+          promiseC.complete(Result.success(c))
+        }
+      }, { error -> onError(error, connA, connB, promiseC) })
+    })
+
+    COROUTINE_SUSPENDED
   }
-
-  fa.startCoroutineCancellable(CancellableContinuation(ctx, connA) { result ->
-    result.fold({ a ->
-      if (active.getAndSet(false)) {
-        conn.pop()
-        cont.resumeWith(Result.success(RaceTriple.First(a, Fiber(promiseB, connB), Fiber(promiseC, connC))))
-      } else {
-        promiseA.complete(Result.success(a))
-      }
-    }, { error -> onError(error, connB, connC, promiseA) })
-  })
-
-  fb.startCoroutineCancellable(CancellableContinuation(ctx, connB) { result ->
-    result.fold({ b ->
-      if (active.getAndSet(false)) {
-        conn.pop()
-        cont.resumeWith(Result.success(RaceTriple.Second(Fiber(promiseA, connA), b, Fiber(promiseC, connC))))
-      } else {
-        promiseB.complete(Result.success(b))
-      }
-    }, { error -> onError(error, connA, connC, promiseB) })
-  })
-
-  fc.startCoroutineCancellable(CancellableContinuation(ctx, connC) { result ->
-    result.fold({ c ->
-      if (active.getAndSet(false)) {
-        conn.pop()
-        cont.resumeWith(Result.success(RaceTriple.Third(Fiber(promiseA, connA), Fiber(promiseB, connB), c)))
-      } else {
-        promiseC.complete(Result.success(c))
-      }
-    }, { error -> onError(error, connA, connB, promiseC) })
-  })
-}

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ArrowFxSpec.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ArrowFxSpec.kt
@@ -74,6 +74,9 @@ abstract class ArrowFxSpec(
     spec()
   }
 
+  suspend fun checkAll(property: suspend PropertyContext.() -> Unit): PropertyContext =
+    checkAll(iterations, Arb.unit()) { property() }
+
   suspend fun <A> checkAll(
     genA: Arb<A>,
     property: suspend PropertyContext.(A) -> Unit

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/FiberTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/FiberTest.kt
@@ -8,6 +8,24 @@ import io.kotest.property.checkAll
 
 class FiberTest : ArrowFxSpec(spec = {
 
+  "ForkConnected returns on the original context" {
+    val forkCtxName = "forkCtx"
+    val forker = singleThreadContext(forkCtxName)
+    checkAll(Arb.int()) { i ->
+      single.zip(forker).use { (single, forker) ->
+        evalOn(single) {
+          threadName() shouldBe singleThreadName
+
+          val f = ForkConnected(forker) { Pair(i.suspend(), threadName()) }
+
+          f.join() shouldBe Pair(i, forkCtxName)
+
+          threadName() shouldBe singleThreadName
+        }
+      }
+    }
+  }
+
   "ForkConnected get cancelled by its parent" {
     val start = Promise<Unit>()
     val p = Promise<ExitCase>()
@@ -89,6 +107,25 @@ class FiberTest : ArrowFxSpec(spec = {
     }
   }
 
+  "ForkScoped returns on the original context" {
+    val forkCtxName = "forkCtx"
+    val forker = singleThreadContext(forkCtxName)
+
+    checkAll(Arb.int()) { i ->
+      single.zip(forker).use { (single, forker) ->
+        evalOn(single) {
+          threadName() shouldBe singleThreadName
+
+          val f = ForkScoped(forker, { never() }) { Pair(i.suspend(), threadName()) }
+
+          f.join() shouldBe Pair(i, forkCtxName)
+
+          threadName() shouldBe singleThreadName
+        }
+      }
+    }
+  }
+
   "ForkScoped get cancelled by interrupt token" {
     val start = Promise<Unit>()
     val p = Promise<ExitCase>()
@@ -151,6 +188,25 @@ class FiberTest : ArrowFxSpec(spec = {
     checkAll(Arb.int()) { i ->
       val f = suspend { i }.forkScoped { never<Unit>() }
       f.cancel() shouldBe Unit
+    }
+  }
+
+  "ForkAndForget returns on the original context" {
+    val forkCtxName = "forkCtx"
+    val forker = singleThreadContext(forkCtxName)
+
+    checkAll(Arb.int()) { i ->
+      single.zip(forker).use { (single, forker) ->
+        evalOn(single) {
+          threadName() shouldBe singleThreadName
+
+          val f = ForkAndForget(forker) { Pair(i.suspend(), threadName()) }
+
+          f.join() shouldBe Pair(i, forkCtxName)
+
+          threadName() shouldBe singleThreadName
+        }
+      }
     }
   }
 

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTupledNTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTupledNTest.kt
@@ -7,9 +7,28 @@ import io.kotest.property.arbitrary.bool
 import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.string
-import io.kotest.property.checkAll
+import java.util.concurrent.Executors
 
 class ParTupledNTest : ArrowFxSpec(spec = {
+
+  "parTupledN 2 returns to original context" {
+    val mapCtxName = "parTupled2"
+    val mapCtx = fromExecutor { Executors.newFixedThreadPool(2, NamedThreadFactory { mapCtxName }) }
+
+    checkAll {
+      single.zip(mapCtx).use { (single, mapCtx) ->
+        evalOn(single) {
+          threadName() shouldBe singleThreadName
+
+          val (s1, s2) = parTupledN(mapCtx, { threadName() }, { threadName() })
+
+          s1 shouldBe mapCtxName
+          s2 shouldBe mapCtxName
+          threadName() shouldBe singleThreadName
+        }
+      }
+    }
+  }
 
   "ParTupledN 2 runs in parallel" {
     checkAll(Arb.int(), Arb.int()) { a, b ->
@@ -77,6 +96,26 @@ class ParTupledNTest : ArrowFxSpec(spec = {
 
       pa.get() shouldBe Pair(a, ExitCase.Cancelled)
       r shouldBe Either.Left(e)
+    }
+  }
+
+  "parTupledN 3 returns to original context" {
+    val mapCtxName = "parTupled3"
+    val mapCtx = fromExecutor { Executors.newFixedThreadPool(3, NamedThreadFactory { mapCtxName }) }
+
+    checkAll {
+      single.zip(mapCtx).use { (single, mapCtx) ->
+        evalOn(single) {
+          threadName() shouldBe singleThreadName
+
+          val (s1, s2, s3) = parTupledN(mapCtx, { threadName() }, { threadName() }, { threadName() })
+
+          s1 shouldBe mapCtxName
+          s2 shouldBe mapCtxName
+          s3 shouldBe mapCtxName
+          threadName() shouldBe singleThreadName
+        }
+      }
     }
   }
 

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RaceNTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RaceNTest.kt
@@ -1,14 +1,38 @@
 package arrow.fx.coroutines
 
 import arrow.core.Either
+import arrow.core.identity
+import arrow.core.orNull
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bool
 import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
+import java.util.concurrent.Executors
 
 class RaceNTest : ArrowFxSpec(spec = {
+
+  "race2 returns to original context" {
+    val racerName = "race2"
+    val racer = fromExecutor { Executors.newFixedThreadPool(2, NamedThreadFactory { racerName }) }
+
+    checkAll(Arb.int(1..2)) { choose ->
+      single.zip(racer).use { (single, raceCtx) ->
+        evalOn(single) {
+          threadName() shouldBe singleThreadName
+
+          val racedOn = when (choose) {
+            1 -> raceN(raceCtx, { threadName() }, { never<Nothing>() }).swap().orNull()
+            else -> raceN(raceCtx, { never<Nothing>() }, { threadName() }).orNull()
+          }
+
+          racedOn shouldBe racerName
+          threadName() shouldBe singleThreadName
+        }
+      }
+    }
+  }
 
   "race2 can join first" {
     checkAll(Arb.int()) { i ->
@@ -23,9 +47,9 @@ class RaceNTest : ArrowFxSpec(spec = {
   }
 
   "first racer out of 2 always wins on a single thread" {
-      single.use { ctx ->
-        raceN(ctx, threadName, threadName)
-      } shouldBe Either.Left("single")
+    single.use { ctx ->
+      raceN(ctx, threadName, threadName)
+    } shouldBe Either.Left("single")
   }
 
   "Cancelling race 2 cancels all participants" {
@@ -68,6 +92,31 @@ class RaceNTest : ArrowFxSpec(spec = {
     }
   }
 
+  "race3 returns to original context" {
+    val racerName = "race3"
+    val racer = fromExecutor { Executors.newFixedThreadPool(3, NamedThreadFactory { racerName }) }
+
+    checkAll(Arb.int(1..3)) { choose ->
+      single.zip(racer).use { (single, raceCtx) ->
+        evalOn(single) {
+          threadName() shouldBe singleThreadName
+
+          val racedOn = when (choose) {
+            1 -> raceN(raceCtx, { threadName() }, { never<Nothing>() }, { never<Nothing>() })
+              .fold(::identity, { null }, { null })
+            2 -> raceN(raceCtx, { never<Nothing>() }, { threadName() }, { never<Nothing>() })
+              .fold({ null }, ::identity, { null })
+            else -> raceN(raceCtx, { never<Nothing>() }, { never<Nothing>() }, { threadName() })
+              .fold({ null }, { null }, ::identity)
+          }
+
+          racedOn shouldBe racerName
+          threadName() shouldBe singleThreadName
+        }
+      }
+    }
+  }
+
   "race3 can join first" {
     checkAll(Arb.int()) { i ->
       raceN({ i }, { never<Unit>() }, { never<Unit>() }) shouldBe Race3.First(i)
@@ -87,9 +136,9 @@ class RaceNTest : ArrowFxSpec(spec = {
   }
 
   "first racer out of 3 always wins on a single thread" {
-      single.use { ctx ->
-        raceN(ctx, threadName, threadName, threadName)
-      } shouldBe Race3.First("single")
+    single.use { ctx ->
+      raceN(ctx, threadName, threadName, threadName)
+    } shouldBe Race3.First("single")
   }
 
   "Cancelling race 3 cancels all participants" {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RacePairTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RacePairTest.kt
@@ -34,6 +34,30 @@ class RacePairTest : ArrowFxSpec(spec = {
     }
   }
 
+  "race pair returns to original context on failure" {
+    val racerName = "racePair"
+    val racer = fromExecutor { Executors.newFixedThreadPool(2, NamedThreadFactory { racerName }) }
+
+    checkAll(Arb.int(1..2), Arb.throwable()) { choose, e ->
+      single.zip(racer).use { (single, raceCtx) ->
+        evalOn(single) {
+          threadName() shouldBe singleThreadName
+
+          Either.catch {
+            when (choose) {
+              1 -> racePair(raceCtx, { e.suspend() }, { never<Nothing>() })
+                .fold({ a, _ -> a }, { _, _ -> null })
+              else -> racePair(raceCtx, { never<Nothing>() }, { e.suspend() })
+                .fold({ _, _ -> null }, { _, b -> b })
+            }
+          } shouldBe Either.Left(e)
+
+          threadName() shouldBe singleThreadName
+        }
+      }
+    }
+  }
+
   "race pair mirrors left winner" {
     checkAll(Arb.either(Arb.throwable(), Arb.int())) { fa ->
 

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RacePairTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/RacePairTest.kt
@@ -7,8 +7,32 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bool
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
+import java.util.concurrent.Executors
 
 class RacePairTest : ArrowFxSpec(spec = {
+
+  "race pair returns to original context" {
+    val racerName = "racePair"
+    val racer = fromExecutor { Executors.newFixedThreadPool(2, NamedThreadFactory { racerName }) }
+
+    checkAll(Arb.int(1..2)) { choose ->
+      single.zip(racer).use { (single, raceCtx) ->
+        evalOn(single) {
+          threadName() shouldBe singleThreadName
+
+          val racedOn = when (choose) {
+            1 -> racePair(raceCtx, { threadName() }, { never<Nothing>() })
+              .fold({ a, _ -> a }, { _, _ -> null })
+            else -> racePair(raceCtx, { never<Nothing>() }, { threadName() })
+              .fold({ _, _ -> null }, { _, b -> b })
+          }
+
+          racedOn shouldBe racerName
+          threadName() shouldBe singleThreadName
+        }
+      }
+    }
+  }
 
   "race pair mirrors left winner" {
     checkAll(Arb.either(Arb.throwable(), Arb.int())) { fa ->

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
@@ -159,7 +159,7 @@ class TimerTest : ArrowFxSpec(spec = {
       } shouldBe i
     }
   }
-  
+
   "time-out cancels the token" {
     checkAll(Arb.int()) { i ->
       val promise = Promise<Int>()

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
@@ -1,5 +1,6 @@
 package arrow.fx.coroutines
 
+import arrow.core.Either
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
@@ -31,7 +32,7 @@ class TimerTest : ArrowFxSpec(spec = {
   "timeOutOrNull" - {
     "returns to original context without timing out" {
       singleThreadContext("1").zip(single).use { (one, single) ->
-        checkAll(Arb.int()) {
+        checkAll {
           evalOn(single) {
             val n0 = threadName.invoke()
 
@@ -49,7 +50,7 @@ class TimerTest : ArrowFxSpec(spec = {
 
     "returns to original context when timing out" {
       singleThreadContext("1").zip(single).use { (one, single) ->
-        checkAll(Arb.int()) {
+        checkAll {
           evalOn(single) {
             val n0 = threadName.invoke()
 
@@ -58,6 +59,48 @@ class TimerTest : ArrowFxSpec(spec = {
               threadName.invoke() shouldBe "1"
               never<Unit>()
             } shouldBe null
+
+            n0 shouldBe threadName.invoke()
+          }
+        }
+      }
+    }
+
+    "returns to original context on failure" {
+      singleThreadContext("1").zip(single).use { (one, single) ->
+        checkAll(Arb.throwable()) { e ->
+          evalOn(single) {
+            val n0 = threadName.invoke()
+
+            Either.catch {
+              timeOutOrNull(50.milliseconds) {
+                one.shift()
+                threadName.invoke() shouldBe "1"
+                e.suspend()
+              }
+            } shouldBe Either.Left(e)
+
+            n0 shouldBe threadName.invoke()
+          }
+        }
+      }
+    }
+
+    "returns to original context on CancelToken failure" {
+      singleThreadContext("1").zip(single).use { (one, single) ->
+        checkAll(Arb.throwable()) { e ->
+          evalOn(single) {
+            val n0 = threadName.invoke()
+
+            Either.catch {
+              timeOutOrNull(50.milliseconds) {
+                cancellableF<Nothing> {
+                  one.shift()
+                  threadName.invoke() shouldBe "1"
+                  CancelToken { e.suspend() }
+                }
+              }
+            } shouldBe Either.Left(e)
 
             n0 shouldBe threadName.invoke()
           }
@@ -114,6 +157,20 @@ class TimerTest : ArrowFxSpec(spec = {
         sleep(1.milliseconds)
         i
       } shouldBe i
+    }
+  }
+  
+  "time-out cancels the token" {
+    checkAll(Arb.int()) { i ->
+      val promise = Promise<Int>()
+
+      timeOutOrNull(1.milliseconds) {
+        cancellable<Nothing> {
+          CancelToken { promise.complete(i) }
+        }
+      } shouldBe null
+
+      promise.get() shouldBe i
     }
   }
 })

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/predef-test.kt
@@ -18,10 +18,12 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.string
+import kotlinx.atomicfu.atomic
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.ThreadFactory
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.intercepted
@@ -38,10 +40,18 @@ data class SideEffect(var counter: Int = 0) {
   }
 }
 
-val single = singleThreadContext("single")
+val singleThreadName = "single"
+val single = singleThreadContext(singleThreadName)
 
 val threadName: suspend () -> String =
   { Thread.currentThread().name }
+
+class NamedThreadFactory(private val mkName: (Int) -> String) : ThreadFactory {
+  private val count = atomic(0)
+  override fun newThread(r: Runnable): Thread =
+    Thread(r, mkName(count.value))
+      .apply { isDaemon = true }
+}
 
 fun unsafeEquals(other: CancelToken): Matcher<CancelToken> = object : Matcher<CancelToken> {
   override fun test(value: CancelToken): MatcherResult {


### PR DESCRIPTION
Follow up PR #203, which exposed returning to incorrect contexts in `timeOutOrNull`.

This PR adds these tests for all operators and optimizes them further from `suspendCoroutine` to `suspendCoroutineUninterceptedOrReturn`.

All other operators in this PR were working correctly but add tests to prevent regression.
For example, the interception in `Fiber#join` comes from `suspendCoroutine` in the `cancellable` builder.