### PR TITLE
Fix flaky pipe test

### DIFF
--- a/.github/workflows/build_arrow-fx.yml
+++ b/.github/workflows/build_arrow-fx.yml
@@ -1,6 +1,6 @@
 name: "arrow-fx: build"
 
-on: push
+on: pull_request
 
 jobs:
   arrow-fx_build:

--- a/.github/workflows/build_arrow-fx.yml
+++ b/.github/workflows/build_arrow-fx.yml
@@ -1,6 +1,6 @@
 name: "arrow-fx: build"
 
-on: pull_request
+on: push
 
 jobs:
   arrow-fx_build:

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/BracketCaseTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/BracketCaseTest.kt
@@ -10,7 +10,7 @@ import io.kotest.property.checkAll
 class BracketCaseTest : ArrowFxSpec(spec = {
 
   "Uncancellable back pressures timeoutOrNull" {
-    checkAll(Arb.long(20, 40), Arb.long(90, 100)) { a, b ->
+    checkAll(Arb.long(10, 100), Arb.long(300, 400)) { a, b ->
       val start = System.currentTimeMillis()
 
       val n = timeOutOrNull(a.milliseconds) {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/TimerTest.kt
@@ -111,8 +111,7 @@ class TimerTest : ArrowFxSpec(spec = {
   "timeout wins suspend" {
     checkAll(Arb.int()) { i ->
       timeOutOrNull(100.milliseconds) {
-        sleep(1.milliseconds)
-        i
+        i.suspend()
       } shouldBe i
     }
   }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -777,7 +777,7 @@ class StreamTest : StreamSpec(spec = {
         }
 
         Stream.iterate(0, Int::inc)
-          .flatMap { Stream(it) }
+          .flatMap { Stream(it).delayBy(1.milliseconds) }
           .interruptWhen { Right(sleep(50.milliseconds)) }
           .through(p)
           .compile()

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -778,7 +778,7 @@ class StreamTest : StreamSpec(spec = {
 
         Stream.iterate(0, Int::inc)
           .flatMap { Stream(it).delayBy(10.milliseconds) }
-          .interruptWhen { Right(sleep(50.milliseconds)) }
+          .interruptWhen { Right(sleep(100.milliseconds)) }
           .through(p)
           .compile()
           .toList().let { result ->

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -780,7 +780,7 @@ class StreamTest : StreamSpec(spec = {
 
         Stream.iterate(0, Int::inc)
           .flatMap { Stream(it).delayBy(5.milliseconds) }
-          .interruptWhen { Right(sleep(200.milliseconds)) }
+          .interruptWhen { Right(sleep(300.milliseconds)) }
           .through(p)
           .compile()
           // .foldChunks(mutableListOf<Int>()) { acc, ch ->

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -194,18 +194,18 @@ class StreamTest : StreamSpec(spec = {
 
     "unfold" {
       Stream.unfold(Pair(0, 1)) { (f1, f2) ->
-          if (f1 <= 13) Pair(Pair(f1, f2), Pair(f2, f1 + f2))
-          else null
-        }.map { it.first }
+        if (f1 <= 13) Pair(Pair(f1, f2), Pair(f2, f1 + f2))
+        else null
+      }.map { it.first }
         .compile()
         .toList() shouldBe listOf(0, 1, 1, 2, 3, 5, 8, 13)
     }
 
     "unfoldChunk" {
       Stream.unfoldChunk(4L) { s ->
-          if (s > 0) Pair(Chunk.longs(longArrayOf(s, s)), s - 1)
-          else null
-        }.compile()
+        if (s > 0) Pair(Chunk.longs(longArrayOf(s, s)), s - 1)
+        else null
+      }.compile()
         .toList() shouldBe listOf(4L, 4, 3, 3, 2, 2, 1, 1)
     }
 
@@ -217,9 +217,9 @@ class StreamTest : StreamSpec(spec = {
 
     "unfoldChunkEffect" {
       Stream.unfoldChunkEffect(true) { s ->
-          if (s) Pair(Chunk.booleans(booleanArrayOf(s)), false)
-          else null
-        }
+        if (s) Pair(Chunk.booleans(booleanArrayOf(s)), false)
+        else null
+      }
         .compile()
         .toList() shouldBe listOf(true)
     }
@@ -668,13 +668,13 @@ class StreamTest : StreamSpec(spec = {
         val enableInterrupt = Semaphore(0)
         val interrupt = Stream.effect { enableInterrupt.acquire() }.flatMap { Stream(false) }
         s.effectMap { i ->
-            // enable interruption and hang when hitting a value divisible by 7
-            if (i % 7 == 0) {
-              enableInterrupt.release()
-              barrier.acquire()
-              i
-            } else i
-          }.interruptWhen(interrupt)
+          // enable interruption and hang when hitting a value divisible by 7
+          if (i % 7 == 0) {
+            enableInterrupt.release()
+            barrier.acquire()
+            i
+          } else i
+        }.interruptWhen(interrupt)
           .compile()
           // as soon as we hit a value divisible by 7, we enable interruption then hang before emitting it,
           // so there should be no elements in the output that are divisible by 7
@@ -696,11 +696,11 @@ class StreamTest : StreamSpec(spec = {
       checkAll(Arb.stream(Arb.int()), Arb.throwable()) { s, e ->
         Either.catch {
           Stream.effect { Semaphore(0) }.flatMap { semaphore ->
-              Stream(1)
-                .append { s }
-                .interruptWhen { sleep(20.milliseconds); Either.Left(e) }
-                .flatMap { Stream.effect_ { semaphore.acquire() } }
-            }
+            Stream(1)
+              .append { s }
+              .interruptWhen { sleep(20.milliseconds); Either.Left(e) }
+              .flatMap { Stream.effect_ { semaphore.acquire() } }
+          }
             .compile()
             .toList()
         } shouldBe Either.Left(e)
@@ -762,27 +762,29 @@ class StreamTest : StreamSpec(spec = {
     }
 
     "if a pipe is interrupted, it will not restart evaluation" {
-      val p: Pipe<Int, Int> = Pipe {
-        fun loop(acc: Int, pull: Pull<Int, Unit>): Pull<Int, Unit> =
-          pull.uncons1OrNull().flatMap { uncons1 ->
-            when (uncons1) {
-              null -> Pull.output1(acc)
-              else -> Pull.output1(uncons1.head)
-                .flatMap { loop(acc + uncons1.head, uncons1.tail) }
+      checkAll(Arb.int()) {
+        val p: Pipe<Int, Int> = Pipe {
+          fun loop(acc: Int, pull: Pull<Int, Unit>): Pull<Int, Unit> =
+            pull.uncons1OrNull().flatMap { uncons1 ->
+              when (uncons1) {
+                null -> Pull.output1(acc)
+                else -> Pull.output1(uncons1.head)
+                  .flatMap { loop(acc + uncons1.head, uncons1.tail) }
+              }
             }
-          }
 
-        loop(0, it.asPull()).stream()
-      }
-
-      Stream.iterate(0, Int::inc)
-        .flatMap { Stream(it).delayBy(20.milliseconds) }
-        .interruptWhen { Right(sleep(150.milliseconds)) }
-        .through(p)
-        .compile()
-        .toList().let { result ->
-          result shouldBe listOfNotNull(result.firstOrNull()) + result.drop(1).filter { it != 0 }
+          loop(0, it.asPull()).stream()
         }
+
+        Stream.iterate(0, Int::inc)
+          .flatMap { Stream(it).delayBy(20.milliseconds) }
+          .interruptWhen { Right(sleep(150.milliseconds)) }
+          .through(p)
+          .compile()
+          .toList().let { result ->
+            result shouldBe listOfNotNull(result.firstOrNull()) + result.drop(1).filter { it != 0 }
+          }
+      }
     }
 
     "resume on append with pull" {
@@ -832,17 +834,17 @@ class StreamTest : StreamSpec(spec = {
         val expected = s.compile().toList()
 
         Stream.effect { Semaphore(0) }.flatMap { semaphore ->
-            s.interruptWhen { Right(sleep(20.milliseconds)) }
-              .map { None }
-              .append { s.map { Option(it) } }
-              .interruptWhen { Right(never()) }
-              .flatMap {
-                when (it) {
-                  is None -> Stream.effect { semaphore.acquire(); None }
-                  is Some -> Stream(Some(it.t))
-                }
-              }.filterOption()
-          }
+          s.interruptWhen { Right(sleep(20.milliseconds)) }
+            .map { None }
+            .append { s.map { Option(it) } }
+            .interruptWhen { Right(never()) }
+            .flatMap {
+              when (it) {
+                is None -> Stream.effect { semaphore.acquire(); None }
+                is Some -> Stream(Some(it.t))
+              }
+            }.filterOption()
+        }
           .compile()
           .toList() shouldBe expected
       }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -696,11 +696,11 @@ class StreamTest : StreamSpec(spec = {
       checkAll(Arb.stream(Arb.int()), Arb.throwable()) { s, e ->
         Either.catch {
           Stream.effect { Semaphore(0) }.flatMap { semaphore ->
-            Stream(1)
-              .append { s }
-              .interruptWhen { sleep(20.milliseconds); Either.Left(e) }
-              .flatMap { Stream.effect_ { semaphore.acquire() } }
-          }
+              Stream(1)
+                .append { s }
+                .interruptWhen { sleep(20.milliseconds); Either.Left(e) }
+                .flatMap { Stream.effect_ { semaphore.acquire() } }
+            }
             .compile()
             .toList()
         } shouldBe Either.Left(e)
@@ -777,7 +777,7 @@ class StreamTest : StreamSpec(spec = {
         }
 
         Stream.iterate(0, Int::inc)
-          .flatMap { Stream(it).delayBy(1.milliseconds) }
+          .flatMap { Stream(it).delayBy(10.milliseconds) }
           .interruptWhen { Right(sleep(50.milliseconds)) }
           .through(p)
           .compile()

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -762,7 +762,7 @@ class StreamTest : StreamSpec(spec = {
     }
 
     "if a pipe is interrupted, it will not restart evaluation" {
-      checkAll(Arb.int()) {
+      checkAll(1000, Arb.int()) {
         val p: Pipe<Int, Int> = Pipe {
           fun loop(acc: Int, pull: Pull<Int, Unit>): Pull<Int, Unit> =
             pull.uncons1OrNull().flatMap { uncons1 ->
@@ -777,7 +777,7 @@ class StreamTest : StreamSpec(spec = {
         }
 
         Stream.iterate(0, Int::inc)
-          .flatMap { Stream(it).delayBy(1.milliseconds) }
+          .flatMap { Stream(it).delayBy(5.milliseconds) }
           .interruptWhen { Right(sleep(50.milliseconds)) }
           .through(p)
           .compile()

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -762,7 +762,7 @@ class StreamTest : StreamSpec(spec = {
     }
 
     "if a pipe is interrupted, it will not restart evaluation" {
-      checkAll(1000, Arb.int()) {
+      io.kotest.property.checkAll(1000, Arb.int()) {
         val p: Pipe<Int, Int> = Pipe {
           fun loop(acc: Int, pull: Pull<Int, Unit>): Pull<Int, Unit> =
             pull.uncons1OrNull().flatMap { uncons1 ->
@@ -777,7 +777,7 @@ class StreamTest : StreamSpec(spec = {
         }
 
         Stream.iterate(0, Int::inc)
-          .flatMap { Stream(it).delayBy(5.milliseconds) }
+          .flatMap { Stream(it).delayBy(1.milliseconds) }
           .interruptWhen { Right(sleep(50.milliseconds)) }
           .through(p)
           .compile()

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -777,8 +777,8 @@ class StreamTest : StreamSpec(spec = {
         }
 
         Stream.iterate(0, Int::inc)
-          .flatMap { Stream(it).delayBy(100.milliseconds) }
-          .interruptWhen { Right(sleep(200.milliseconds)) }
+          .flatMap { Stream(it) }
+          .interruptWhen { Right(sleep(50.milliseconds)) }
           .through(p)
           .compile()
           .toList().let { result ->

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -776,19 +776,21 @@ class StreamTest : StreamSpec(spec = {
           loop(0, it.asPull()).stream()
         }
 
-        val start = System.currentTimeMillis()
+        // val start = System.currentTimeMillis()
 
         Stream.iterate(0, Int::inc)
-          .flatMap { Stream(it).delayBy(10.milliseconds) }
-          .interruptWhen { Right(sleep(150.milliseconds)) }
+          .flatMap { Stream(it).delayBy(5.milliseconds) }
+          .interruptWhen { Right(sleep(200.milliseconds)) }
           .through(p)
           .compile()
-          .foldChunks(mutableListOf<Int>()) { acc, ch ->
-            println("First: $ch after ${System.currentTimeMillis() - start}")
-            acc.addAll(ch.toList())
-            acc
-          }.let { result ->
-            println("Finished: $result after ${System.currentTimeMillis() - start}")
+          // .foldChunks(mutableListOf<Int>()) { acc, ch ->
+          //   println("First: $ch after ${System.currentTimeMillis() - start}")
+          //   acc.addAll(ch.toList())
+          //   acc
+          // }
+          .toList()
+        .let { result ->
+            // println("Finished: $result after ${System.currentTimeMillis() - start}")
             result shouldBe listOfNotNull(result.firstOrNull()) + result.drop(1).filter { it != 0 }
           }
       }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -777,8 +777,8 @@ class StreamTest : StreamSpec(spec = {
         }
 
         Stream.iterate(0, Int::inc)
-          .flatMap { Stream(it).delayBy(20.milliseconds) }
-          .interruptWhen { Right(sleep(150.milliseconds)) }
+          .flatMap { Stream(it).delayBy(100.milliseconds) }
+          .interruptWhen { Right(sleep(200.milliseconds)) }
           .through(p)
           .compile()
           .toList().let { result ->


### PR DESCRIPTION
While testing CI in this branch I noticed the precision of `sleep` degrade in the tests, and this caused flakiness.

This PR
- increases the `sleep` duration for `Uncancellable back pressures timeoutOrNull`
- refactors `if a pipe is interrupted, it will not restart evaluation` to use `Promise` as a latch instead of `sleep` which makes it pass consistently in a now `checkAll` property test.