### PR TITLE
Fix release after pure interruption

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Compiler.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Compiler.kt
@@ -106,7 +106,7 @@ internal fun <O> interruptBoundary(
       when (val close = view.step) {
         is Pull.Eval.CloseScope -> Pull.Eval.CloseScope(
           close.scopeId,
-          Pair(interruptedScope, close.interruptedScope?.second),
+          Pair(interruptedScope, interruptedError),
           ExitCase.Cancelled
         ).transformWith(view::next)
         else ->

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Pull.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Pull.kt
@@ -171,7 +171,7 @@ sealed class Pull<out O, out R> {
      */ // Flatten this into Scope with a promise for suspension backpressure?
     data class Interrupted<X>(val context: X, val deferredError: Throwable?) : Result<Nothing>() {
       override fun toString(): String =
-        "Pull.Interrupted($context, ${deferredError?.localizedMessage}"
+        "Pull.Interrupted($context, $deferredError)"
     }
 
     inline fun <B> map(f: (R) -> B): Result<B> =


### PR DESCRIPTION
When _pure_ interruption occurs, then `bracket` should be closed with `ExitCase.Cancelled`.

However when an error is thrown from the `release` function, then this should become the final result from the `Stream` since we do not want the `Stream` to silently finish when an error occurred.

This more the fix made in #210 into a separate PR.