### PR TITLE
Tweak Bracket test

### DIFF
--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/BracketCaseTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/BracketCaseTest.kt
@@ -6,22 +6,23 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.checkAll
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTimedValue
 
+@ExperimentalTime
 class BracketCaseTest : ArrowFxSpec(spec = {
 
   "Uncancellable back pressures timeoutOrNull" {
     checkAll(Arb.long(10, 100), Arb.long(300, 400)) { a, b ->
-      val start = System.currentTimeMillis()
-
-      val n = timeOutOrNull(a.milliseconds) {
-        uncancellable { sleep(b.milliseconds) }
+      val (n, duration) = measureTimedValue {
+        timeOutOrNull(a.milliseconds) {
+          uncancellable { sleep(b.milliseconds) }
+        }
       }
 
-      val end = System.currentTimeMillis()
-
       n shouldBe null // timed-out so should be null
-      require((end - start) >= b) {
-        "Should've taken longer than $b milliseconds, but took ${end - start}ms. (start=$start, end=$end)"
+      require((duration.inMilliseconds) >= b) {
+        "Should've taken longer than $b milliseconds, but took $duration"
       }
     }
   }


### PR DESCRIPTION
As per https://github.com/arrow-kt/arrow-fx/pull/167#issuecomment-665791522

Change timed test to use measureTimedValue instead of manually calculating time to see if it prevents flakiness