### PR TITLE
Paramterize concurrent ops with CoroutineContext

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/ParJoin.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/ParJoin.kt
@@ -7,6 +7,7 @@ import arrow.core.Some
 import arrow.core.extensions.option.monad.flatten
 import arrow.core.orElse
 import arrow.core.orNull
+import arrow.fx.coroutines.ComputationPool
 import arrow.fx.coroutines.ForkAndForget
 import arrow.fx.coroutines.Platform
 import arrow.fx.coroutines.Semaphore
@@ -14,38 +15,7 @@ import arrow.fx.coroutines.stream.concurrent.NoneTerminatedQueue
 import arrow.fx.coroutines.stream.concurrent.Queue
 import arrow.fx.coroutines.stream.concurrent.SignallingAtomic
 import arrow.fx.coroutines.uncancellable
-
-/**
- * Non-deterministically merges a stream of streams (`outer`) in to a single stream,
- * opening at most `maxOpen` streams at any point in time.
- *
- * The outer stream is evaluated and each resulting inner stream is run concurrently,
- * up to `maxOpen` stream. Once this limit is reached, evaluation of the outer stream
- * is paused until one or more inner streams finish evaluating.
- *
- * When the outer stream stops gracefully, all inner streams continue to run,
- * resulting in a stream that will stop when all inner streams finish
- * their evaluation.
- *
- * When the outer stream fails, evaluation of all inner streams is interrupted
- * and the resulting stream will fail with same failure.
- *
- * When any of the inner streams fail, then the outer stream and all other inner
- * streams are interrupted, resulting in stream that fails with the error of the
- * stream that caused initial failure.
- *
- * Finalizers on each inner stream are run at the end of the inner stream,
- * concurrently with other stream computations.
- *
- * Finalizers on the outer stream are run after all inner streams have been pulled
- * from the outer stream but not before all inner streams terminate -- hence finalizers on the outer stream will run
- * AFTER the LAST finalizer on the very last inner stream.
- *
- * Finalizers on the returned stream are run after the outer stream has finished
- * and all open inner streams have finished.
- *
- * @param maxOpen Maximum number of open inner streams at any time. Must be > 0.
- */
+import kotlin.coroutines.CoroutineContext
 
 // stops the join evaluation
 // all the streams will be terminated. If err is supplied, that will get attached to any error currently present
@@ -84,6 +54,7 @@ internal suspend fun incrementRunning(running: SignallingAtomic<Int>): Unit =
 // note that supplied scope's resources must be leased before the inner stream forks the execution to another thread
 // and that it must be released once the inner stream terminates or fails.
 internal suspend fun <O> runInner(
+  ctx: CoroutineContext,
   inner: Stream<O>,
   done: SignallingAtomic<Option<Option<Throwable>>>,
   outputQ: NoneTerminatedQueue<Chunk<O>>,
@@ -97,7 +68,7 @@ internal suspend fun <O> runInner(
       else -> {
         available.acquire()
         incrementRunning(running)
-        ForkAndForget {
+        ForkAndForget(ctx) {
           val e = Either.catch {
             inner.chunks()
               .effectMap { s ->
@@ -122,6 +93,7 @@ internal suspend fun <O> runInner(
 
 // runs the outer stream, interrupts when kill == true, and then decrements the `running`
 internal suspend fun <O> Stream<Stream<O>>.runOuter(
+  ctx: CoroutineContext,
   done: SignallingAtomic<Option<Option<Throwable>>>,
   outputQ: NoneTerminatedQueue<Chunk<O>>,
   running: SignallingAtomic<Int>,
@@ -130,7 +102,7 @@ internal suspend fun <O> Stream<Stream<O>>.runOuter(
   val r = Either.catch {
     this@runOuter.flatMap { inner ->
       Stream.getScope.effectMap { outerScope ->
-        runInner(inner, done, outputQ, running, available, outerScope)
+        runInner(ctx, inner, done, outputQ, running, available, outerScope)
       }
     }.interruptWhen(done.map { it.isDefined() })
       .compile()
@@ -150,15 +122,42 @@ internal suspend fun signalResult(done: SignallingAtomic<Option<Option<Throwable
   done.get().flatten().fold({ Unit }, { throw it })
 
 /**
- * Merges both Streams into an Stream of A and B represented by Either<A, B>.
- * This operation is equivalent to a normal merge but for different types.
+ * Non-deterministically merges a stream of streams (`outer`) in to a single stream,
+ * opening at most `maxOpen` streams at any point in time.
+ *
+ * The outer stream is evaluated and each resulting inner stream is run concurrently,
+ * up to `maxOpen` stream. Once this limit is reached, evaluation of the outer stream
+ * is paused until one or more inner streams finish evaluating.
+ *
+ * When the outer stream stops gracefully, all inner streams continue to run,
+ * resulting in a stream that will stop when all inner streams finish
+ * their evaluation.
+ *
+ * When the outer stream fails, evaluation of all inner streams is interrupted
+ * and the resulting stream will fail with same failure.
+ *
+ * When any of the inner streams fail, then the outer stream and all other inner
+ * streams are interrupted, resulting in stream that fails with the error of the
+ * stream that caused initial failure.
+ *
+ * Finalizers on each inner stream are run at the end of the inner stream,
+ * concurrently with other stream computations.
+ *
+ * Finalizers on the outer stream are run after all inner streams have been pulled
+ * from the outer stream but not before all inner streams terminate -- hence finalizers on the outer stream will run
+ * AFTER the LAST finalizer on the very last inner stream.
+ *
+ * Finalizers on the returned stream are run after the outer stream has finished
+ * and all open inner streams have finished.
+ *
+ * @param maxOpen Maximum number of open inner streams at any time. Must be > 0.
  */
-fun <A, B> Stream<A>.either(other: Stream<B>): Stream<Either<A, B>> =
-  Stream(this.map { Either.Left(it) }, other.map { Either.Right(it) })
-    .parJoin(2)
-
-fun <O> Stream<Stream<O>>.parJoin(maxOpen: Int): Stream<O> {
+fun <O> Stream<Stream<O>>.parJoin(
+  ctx: CoroutineContext = ComputationPool,
+  maxOpen: Int
+): Stream<O> {
   require(maxOpen > 0) { "maxOpen must be > 0, was: $maxOpen" }
+
   return Stream.effect {
     val done = SignallingAtomic<Option<Option<Throwable>>>(None)
     val available = Semaphore(maxOpen.toLong())
@@ -170,7 +169,7 @@ fun <O> Stream<Stream<O>>.parJoin(maxOpen: Int): Stream<O> {
     val outputQ = Queue.synchronousNoneTerminated<Chunk<O>>()
 
     Stream.bracket({
-      ForkAndForget { runOuter(done, outputQ, running, available) }
+      ForkAndForget(ctx) { runOuter(ctx, done, outputQ, running, available) }
     }, {
       stop(done, outputQ, None)
 
@@ -189,5 +188,5 @@ fun <O> Stream<Stream<O>>.parJoin(maxOpen: Int): Stream<O> {
 }
 
 /** Like [parJoin] but races all inner streams simultaneously without limit. */
-fun <O> Stream<Stream<O>>.parJoinUnbounded(): Stream<O> =
-  parJoin(Int.MAX_VALUE)
+fun <O> Stream<Stream<O>>.parJoinUnbounded(ctx: CoroutineContext = ComputationPool): Stream<O> =
+  parJoin(ctx, Int.MAX_VALUE)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
@@ -18,7 +18,6 @@ import arrow.fx.coroutines.Resource
 import arrow.fx.coroutines.forkAndForget
 import arrow.fx.coroutines.guaranteeCase
 import arrow.fx.coroutines.prependTo
-import arrow.fx.coroutines.stream.concurrent.Queue
 import arrow.fx.coroutines.stream.concurrent.Signal
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
@@ -1363,7 +1362,7 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * //sampleEnd
    * ```
    */
-  fun <O2> concurrently(ctx: CoroutineContext = ComputationPool, other: Stream<O2>): Stream<O> =
+  fun <O2> concurrently(other: Stream<O2>, ctx: CoroutineContext = ComputationPool): Stream<O> =
     effect { Pair(Promise<Unit>(), Promise<Either<Throwable, Unit>>()) }
       .flatMap { (interrupt, doneR) ->
         bracket(
@@ -1401,7 +1400,7 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    */
   fun <B> either(ctx: CoroutineContext = ComputationPool, other: Stream<B>): Stream<Either<O, B>> =
     Stream(this.map { Left(it) }, other.map { Right(it) })
-      .parJoin(ctx, 2)
+      .parJoin(2, ctx)
 
   /**
    * Starts this stream and cancels it as finalization of the returned stream.


### PR DESCRIPTION
Parameterizing the concurrent ops with CoroutineContext allows for easier fine-grained control.

Running streams that consume blocking apis can simply be run now with `Stream(ioStream1, ioStream2, ioStream3).parJoin(IOPool, 3)` or `normalStream.concurrently(IOPool,  ioStream)`