### PR TITLE
Add iterative terminal operation and a shortcut

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/ResourceTerminalOps.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/ResourceTerminalOps.kt
@@ -42,6 +42,17 @@ import arrow.fx.coroutines.Resource
     }
 
   /**
+   * Compiles this stream into a value by folding the values inside each of
+   * the chunks together. Starting with the provided `init` and combining
+   * the current value with each value inside of each chunk.
+   *
+   * When this method has returned, the stream has not begun execution -- this method simply
+   * compiles the stream down to the target effect type.
+   */
+  suspend fun <B> fold(init: B, f: (B, O) -> B) : Resource<B> =
+    compiler(init) { acc, ch -> ch.fold(acc, f) }
+
+  /**
    * Compiles this stream in to a value by folding
    * the output chunks together, starting with the provided `init` and combining the
    * current value with each output chunk.

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
@@ -17,6 +17,22 @@ package arrow.fx.coroutines.stream
     foldChunks(Unit) { _, _ -> Unit }
 
   /**
+   * Similar to [drain] but applying an effect on each of the objects emitted.
+   * 
+   * This equivalent to doing:
+   * 
+   * ```
+   * stream.effectTap { **operation** }
+   *   .compile()
+   *   .drain()
+   * ```
+   * 
+   * The main difference, apart from being shorter, is that the operation is applied after we compile the stream into [TerminalOps] 
+   */
+  suspend fun forEach(block: (O) -> Unit): Unit =
+    foldChunks(Unit) { _, ch -> ch.forEach(block) }
+
+  /**
    * Compiles this stream in to a value,
    * returning `null` if the stream emitted no values and returning the
    * last value emitted if values were emitted.

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOpsShortcuts.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOpsShortcuts.kt
@@ -1,7 +1,0 @@
-package arrow.fx.coroutines.stream
-
-/**
- * This is a shortcut for [compile] + [TerminalOps.forEach]
- */
-suspend fun <O> Stream<O>.forEach(block: (O) -> Unit): Unit =
-  compile().forEach(block)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOpsShortcuts.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOpsShortcuts.kt
@@ -1,0 +1,7 @@
+package arrow.fx.coroutines.stream
+
+/**
+ * This is a shortcut for [compile] + [TerminalOps.forEach]
+ */
+suspend fun <O> Stream<O>.forEach(block: (O) -> Unit): Unit =
+  compile().forEach(block)

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -21,10 +21,11 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.constant
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
-import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.arbitrary.positiveInts
 import io.kotest.property.arbitrary.set
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
 import kotlin.math.absoluteValue
 import kotlin.math.max
 import kotlin.random.Random
@@ -550,4 +551,13 @@ class StreamTest : StreamSpec(spec = {
       .compile()
       .toList() shouldBe listOf(1, 2)
   }
+
+  "forEach terminal operation" {
+    val count = atomic(0)
+
+    Stream.range(1..10).forEach { count.update { it + 1 } }
+
+    count.value shouldBe 10
+  }
+
 })

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -550,14 +550,12 @@ class StreamTest : StreamSpec(spec = {
       .toList() shouldBe listOf(1, 2)
   }
 
-  "forEach terminal operation" {
-    val count = atomic(0)
-
-    Stream.range(1..10)
+  "fold items without chunks" {
+    val sum = Stream.range(1..10)
       .compile()
-      .forEach { count.update { it + 1 } }
+      .fold(0) { acc, n -> acc + n }
 
-    count.value shouldBe 10
+    sum shouldBe 55
   }
 
 })

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -13,12 +13,10 @@ import arrow.fx.coroutines.charRange
 import arrow.fx.coroutines.intRange
 import arrow.fx.coroutines.longRange
 import arrow.fx.coroutines.milliseconds
-import arrow.fx.coroutines.never
 import arrow.fx.coroutines.throwable
 import arrow.fx.coroutines.timeOutOrNull
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.constant
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.orNull
@@ -555,7 +553,9 @@ class StreamTest : StreamSpec(spec = {
   "forEach terminal operation" {
     val count = atomic(0)
 
-    Stream.range(1..10).forEach { count.update { it + 1 } }
+    Stream.range(1..10)
+      .compile()
+      .forEach { count.update { it + 1 } }
 
     count.value shouldBe 10
   }


### PR DESCRIPTION
Very small PR to add a new terminal operation that "iterates" over each value emitted.

I've also added a shortcut in case we want to avoid calling compile every time. 

Shall I add the shortcuts for the other terminal operations?