### PR TITLE
Outstanding dequeues not completed on tryOffer1

### DIFF
--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
@@ -1,13 +1,17 @@
 package arrow.fx.coroutines.stream.concurrent
 
 import arrow.core.Option
+import arrow.fx.coroutines.ForkAndForget
+import arrow.fx.coroutines.Promise
 import arrow.fx.coroutines.StreamSpec
-import arrow.fx.coroutines.parTupledN
+import arrow.fx.coroutines.milliseconds
 import arrow.fx.coroutines.stream.Stream
 import arrow.fx.coroutines.stream.append
 import arrow.fx.coroutines.stream.compile
 import arrow.fx.coroutines.stream.noneTerminate
+import arrow.fx.coroutines.stream.parJoinUnbounded
 import arrow.fx.coroutines.stream.terminateOnNone
+import arrow.fx.coroutines.timeOutOrNull
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
@@ -17,22 +21,45 @@ import io.kotest.property.arbitrary.positiveInts
 
 class QueueTest : StreamSpec(spec = {
 
+  "Queue with capacity can always take tryOffer1" {
+    checkAll(Arb.int()) { i ->
+      val q = Queue.unbounded<Int>()
+
+      q.tryOffer1(i) shouldBe true
+      q.dequeue().take(1).compile().toList() shouldBe listOf(i)
+    }
+  }
+
+  "Outstanding taker received tryOffer1 value" {
+    checkAll(Arb.int()) { i ->
+      val q = Queue.unbounded<Int>()
+      val start = Promise<Unit>()
+
+      val f = ForkAndForget {
+        start.complete(Unit)
+        q.dequeue1()
+      }
+
+      start.get()
+
+      q.tryOffer1(i) shouldBe true
+      f.join() shouldBe i
+    }
+  }
+
   "unbounded producer/consumer" {
     checkAll(Arb.stream(Arb.int())) { s ->
       val expected = s.compile().toList()
       val n = expected.size
       val q = Queue.unbounded<Int>()
 
-      parTupledN({
-        q.dequeue()
-          .take(n)
-          .compile()
-          .toList()
-      }, {
-        s.through(q.enqueue())
-          .compile()
-          .drain()
-      }).first shouldBe expected
+      Stream(
+        q.dequeue(),
+        s.through(q.enqueue()).drain()
+      ).parJoinUnbounded()
+        .take(n)
+        .compile()
+        .toList() shouldBe expected
     }
   }
 
@@ -111,6 +138,26 @@ class QueueTest : StreamSpec(spec = {
         }
         .compile()
         .toList() shouldBe expected
+    }
+  }
+
+  "dequeue releases subscriber on " - {
+    "interrupt" {
+      val q = Queue.unbounded<Int>()
+      q.dequeue().interruptAfter(100.milliseconds).compile().drain()
+      q.enqueue1(1)
+      q.enqueue1(2)
+      q.dequeue1() shouldBe 1
+    }
+
+    "cancel" {
+      val q = Queue.unbounded<Int>()
+      timeOutOrNull(100.milliseconds) {
+        q.dequeue1()
+      } shouldBe null
+      q.enqueue1(1)
+      q.enqueue1(2)
+      q.dequeue1() shouldBe 1
     }
   }
 })


### PR DESCRIPTION
The `update` function in `PubSub` was not correctly invoking the completion for outstanding dequeues. 

To fix this I replaced the usages of `Promise` to `UnsafePromise` so we can complete the promises in a non-suspending manner. This allows for both `modify` and `update` which can modify the state with `suspend`, and `non-suspend` support.