### PR TITLE
Revert parTupledN and parMapN derivation

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt
@@ -93,6 +93,6 @@ suspend fun <A, B> Iterable<A>.parTraverse(ctx: CoroutineContext, f: suspend (A)
   if (ctx === EmptyCoroutineContext || ctx[ContinuationInterceptor] == null) map { a -> f(a) }
   else toList().foldRight(suspend { emptyList<B>() }) { a, acc ->
     suspend {
-      parMapN(ctx, { f(a) }, { acc.invoke() }) { (a, b) -> listOf(a) + b }
+      parMapN(ctx, { f(a) }, { acc.invoke() }) { a, b -> listOf(a) + b }
     }
   }.invoke()

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTupledN.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTupledN.kt
@@ -10,66 +10,6 @@ import kotlin.coroutines.intrinsics.intercepted
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 
 /**
- * Parallel maps [fa], [fb] in parallel on [ComputationPool].
- * Cancelling this operation cancels both operations running in parallel.
- *
- * @see parMapN for the same function that can race on any [CoroutineContext].
- */
-suspend fun <A, B, C> parMapN(fa: suspend () -> A, fb: suspend () -> B, f: (Pair<A, B>) -> C): C =
-  f(parTupledN(ComputationPool, fa, fb))
-
-/**
- * Parallel maps [fa], [fb], [fc] in parallel on [ComputationPool].
- * Cancelling this operation cancels both operations running in parallel.
- *
- * @see parMapN for the same function that can race on any [CoroutineContext].
- */
-suspend fun <A, B, C, D> parMapN(
-  fa: suspend () -> A,
-  fb: suspend () -> B,
-  fc: suspend () -> C,
-  f: (Triple<A, B, C>) -> D
-): D =
-  f(parTupledN(ComputationPool, fa, fb, fc))
-
-/**
- * Parallel maps [fa], [fb] on the provided [CoroutineContext].
- * Cancelling this operation cancels both tasks running in parallel.
- *
- * **WARNING** this function forks [fa], [fb] but if it runs in parallel depends
- * on the capabilities of the provided [CoroutineContext].
- * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
- *
- * @see parMapN for a function that ensures it runs in parallel on the [ComputationPool].
- */
-suspend fun <A, B, C> parMapN(
-  ctx: CoroutineContext,
-  fa: suspend () -> A,
-  fb: suspend () -> B,
-  f: (Pair<A, B>) -> C
-): C =
-  f(parTupledN(ctx, fa, fb))
-
-/**
- * Parallel maps [fa], [fb], [fc] on the provided [CoroutineContext].
- * Cancelling this operation cancels both tasks running in parallel.
- *
- * **WARNING** this function forks [fa], [fb] & [fc] but if it runs in parallel depends
- * on the capabilities of the provided [CoroutineContext].
- * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
- *
- * @see parMapN for a function that ensures it runs in parallel on the [ComputationPool].
- */
-suspend fun <A, B, C, D> parMapN(
-  ctx: CoroutineContext,
-  fa: suspend () -> A,
-  fb: suspend () -> B,
-  fc: suspend () -> C,
-  f: (Triple<A, B, C>) -> D
-): D =
-  f(parTupledN(ctx, fa, fb, fc))
-
-/**
  * Tuples [fa], [fb] in parallel on [ComputationPool].
  * Cancelling this operation cancels both operations running in parallel.
  *
@@ -96,12 +36,60 @@ suspend fun <A, B, C> parTupledN(fa: suspend () -> A, fb: suspend () -> B, fc: s
  *
  * @see parTupledN for a function that ensures it runs in parallel on the [ComputationPool].
  */
+suspend fun <A, B> parTupledN(ctx: CoroutineContext, fa: suspend () -> A, fb: suspend () -> B): Pair<A, B> =
+  parMapN(ctx, fa, fb, ::Pair)
+
+/**
+ * Tuples [fa], [fb] & [fc] on the provided [CoroutineContext].
+ * Cancelling this operation cancels both tasks running in parallel.
+ *
+ * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parTupledN for a function that ensures it runs in parallel on the [ComputationPool].
+ */
+suspend fun <A, B, C> parTupledN(ctx: CoroutineContext, fa: suspend () -> A, fb: suspend () -> B, fc: suspend () -> C): Triple<A, B, C> =
+  parMapN(ctx, fa, fb, fc, ::Triple)
+
+/**
+ * Parallel maps [fa], [fb] in parallel on [ComputationPool].
+ * Cancelling this operation cancels both operations running in parallel.
+ *
+ * @see parMapN for the same function that can race on any [CoroutineContext].
+ */
+suspend fun <A, B, C> parMapN(fa: suspend () -> A, fb: suspend () -> B, f: (A, B) -> C): C =
+  parMapN(ComputationPool, fa, fb, f)
+
+/**
+ * Parallel maps [fa], [fb], [fc] in parallel on [ComputationPool].
+ * Cancelling this operation cancels both operations running in parallel.
+ *
+ * @see parMapN for the same function that can race on any [CoroutineContext].
+ */
+suspend fun <A, B, C, D> parMapN(
+  fa: suspend () -> A,
+  fb: suspend () -> B,
+  fc: suspend () -> C,
+  f: (A, B, C) -> D
+): D = parMapN(ComputationPool, fa, fb, fc, f)
+
+/**
+ * Parallel maps [fa], [fb] on the provided [CoroutineContext].
+ * Cancelling this operation cancels both tasks running in parallel.
+ *
+ * **WARNING** this function forks [fa], [fb] but if it runs in parallel depends
+ * on the capabilities of the provided [CoroutineContext].
+ * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
+ *
+ * @see parMapN for a function that ensures it runs in parallel on the [ComputationPool].
+ */
 @Suppress("UNCHECKED_CAST")
-suspend fun <A, B> parTupledN(
+suspend fun <A, B, C> parMapN(
   ctx: CoroutineContext,
   fa: suspend () -> A,
-  fb: suspend () -> B
-): Pair<A, B> =
+  fb: suspend () -> B,
+  f: (A, B) -> C
+): C =
   suspendCoroutineUninterceptedOrReturn { cont ->
     val conn = cont.context.connection()
     val cont = cont.intercepted()
@@ -119,9 +107,9 @@ suspend fun <A, B> parTupledN(
       conn.pop()
       cb(
         try {
-          Result.success(Pair(a, b))
+          Result.success(f(a, b))
         } catch (e: Throwable) {
-          Result.failure<Pair<A, B>>(e.nonFatalOrThrow())
+          Result.failure<C>(e.nonFatalOrThrow())
         }
       )
     }
@@ -130,7 +118,7 @@ suspend fun <A, B> parTupledN(
       is Throwable -> Unit // Do nothing we already finished
       else -> other.cancelToken().cancel.startCoroutine(Continuation(EmptyCoroutineContext) { r ->
         conn.pop()
-        cb(Result.failure<Pair<A, B>>(r.fold({ e }, { e2 -> Platform.composeErrors(e, e2) })))
+        cb(Result.failure(r.fold({ e }, { e2 -> Platform.composeErrors(e, e2) })))
       })
     }
 
@@ -164,20 +152,22 @@ suspend fun <A, B> parTupledN(
   }
 
 /**
- * Tuples [fa], [fb] & [fc] on the provided [CoroutineContext].
+ * Parallel maps [fa], [fb], [fc] on the provided [CoroutineContext].
  * Cancelling this operation cancels both tasks running in parallel.
  *
- * **WARNING** it runs in parallel depending on the capabilities of the provided [CoroutineContext].
+ * **WARNING** this function forks [fa], [fb] & [fc] but if it runs in parallel depends
+ * on the capabilities of the provided [CoroutineContext].
  * We ensure they start in sequence so it's guaranteed to finish on a single threaded context.
  *
- * @see parTupledN for a function that ensures it runs in parallel on the [ComputationPool].
+ * @see parMapN for a function that ensures it runs in parallel on the [ComputationPool].
  */
-suspend fun <A, B, C> parTupledN(
+suspend fun <A, B, C, D> parMapN(
   ctx: CoroutineContext,
   fa: suspend () -> A,
   fb: suspend () -> B,
-  fc: suspend () -> C
-): Triple<A, B, C> =
+  fc: suspend () -> C,
+  f: (A, B, C) -> D
+): D =
   suspendCoroutineUninterceptedOrReturn { cont ->
     val conn = cont.context.connection()
     val cont = cont.intercepted()
@@ -196,7 +186,7 @@ suspend fun <A, B, C> parTupledN(
 
     fun complete(a: A, b: B, c: C) {
       conn.pop()
-      cb(Result.success(Triple(a, b, c)))
+      cb(Result.success(f(a, b, c)))
     }
 
     fun tryComplete(result: Triple<A?, B?, C?>?): Unit {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/InterruptionTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/InterruptionTest.kt
@@ -39,7 +39,7 @@ class InterruptionTest : StreamSpec(spec = {
 
       latch.get()
       f.cancel()
-      timeOutOrNull(50.milliseconds) { exit.get() } shouldBe ExitCase.Cancelled
+      exit.get() shouldBe ExitCase.Cancelled
     }
   }
 


### PR DESCRIPTION
Currently `parMapN` is derived from `parTupledN` meaning that for `parMapN` you always do a redundant allocation, this was originally due to how we derived `Applicative` functions. So this also reduces `parTraverse` with `n` allocation for a list of size `n`.

Additionally, we always deal with tupled functions in `parMapN` that forces users to always destructure. Additionally, it disallows us to use method references in a convenient way. [reference](
https://github.com/arrow-kt/arrow-fx/pull/248/files?file-filters%5B%5D=.kt&file-filters%5B%5D=.md#diff-c62032ca8b6b0243e4ffb313cbc8df73R69)