### PR TITLE
Queue: support same behavior as Arrow Fx's IO Queue

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/concurrent/Queue.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/concurrent/Queue.kt
@@ -150,6 +150,7 @@ interface Queue<A> : Enqueue<A>, Dequeue1<A>, Dequeue<A> {
     fun <A> unsafeSliding(maxSize: Int): Queue<A> =
       fromStrategy(Strategy.sliding(maxSize))
 
+    /** Creates a queue which stores the first `maxSize` enqueued elements and which never blocks on enqueue. */
     suspend fun <A> dropping(maxSize: Int): Queue<A> =
       fromStrategy(Strategy.dropping(maxSize))
 

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/concurrent/Queue.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/concurrent/Queue.kt
@@ -144,11 +144,11 @@ interface Queue<A> : Enqueue<A>, Dequeue1<A>, Dequeue<A> {
       fromStrategy(Strategy.boundedFifo(maxSize))
 
     /** Creates a queue which stores the last `maxSize` enqueued elements and which never blocks on enqueue. */
-    suspend fun <A> circularBuffer(maxSize: Int): Queue<A> =
-      fromStrategy(Strategy.circularBuffer(maxSize))
+    suspend fun <A> sliding(maxSize: Int): Queue<A> =
+      fromStrategy(Strategy.sliding(maxSize))
 
-    fun <A> unsafeCircularBuffer(maxSize: Int): Queue<A> =
-      fromStrategy(Strategy.circularBuffer(maxSize))
+    fun <A> unsafeSliding(maxSize: Int): Queue<A> =
+      fromStrategy(Strategy.sliding(maxSize))
 
     /** Created a bounded queue that distributed always at max `fairSize` elements to any subscriber. */
     suspend fun <A> fairBounded(maxSize: Int, fairSize: Int): Queue<A> =
@@ -205,11 +205,11 @@ internal object Strategy {
   fun <A> boundedLifo(maxSize: Int): PubSub.Strategy<A, Chunk<A>, IQueue<A>, Int> =
     PubSub.Strategy.bounded(maxSize, lifo()) { it.size }
 
-  /** Strategy for circular buffer, which stores the last `maxSize` enqueued elements and never blocks on enqueue. */
-  fun <A> circularBuffer(maxSize: Int): PubSub.Strategy<A, Chunk<A>, IQueue<A>, Int> =
+  /** Strategy for sliding, which stores the last `maxSize` enqueued elements and never blocks on enqueue. */
+  fun <A> sliding(maxSize: Int): PubSub.Strategy<A, Chunk<A>, IQueue<A>, Int> =
     unbounded { q: IQueue<A>, a ->
-      if (q.size < maxSize) q.enqueue(a)
-      else q.tail().enqueue(a)
+      if (q.size <= maxSize) q.enqueue(a)
+      else q.drop(1).enqueue(a)
     }
 
   /** Unbounded lifo strategy. */

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
@@ -1,7 +1,6 @@
 package arrow.fx.coroutines.stream.concurrent
 
 import arrow.core.Option
-import arrow.core.Right
 import arrow.fx.coroutines.ForkAndForget
 import arrow.fx.coroutines.Promise
 import arrow.fx.coroutines.StreamSpec

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
@@ -1,6 +1,7 @@
 package arrow.fx.coroutines.stream.concurrent
 
 import arrow.core.Option
+import arrow.core.Right
 import arrow.fx.coroutines.ForkAndForget
 import arrow.fx.coroutines.Promise
 import arrow.fx.coroutines.StreamSpec
@@ -135,6 +136,41 @@ class QueueTest : StreamSpec(spec = {
           Stream.constant(batchSize)
             .through(q.dequeueBatch())
             .terminateOnNone()
+        }
+        .compile()
+        .toList() shouldBe expected
+    }
+  }
+
+  "Queue.dropping - accepts maxSize elements while dropping over capacity" {
+    checkAll(Arb.stream(Arb.int()), Arb.positiveInts()) { s, maxSize0 ->
+      val maxSize = maxSize0 % 20 + 1
+      val expected = s.compile().toList().take(maxSize)
+
+      val q = Queue.dropping<Int>(maxSize)
+
+      s.effectMap { q.enqueue1(it) }
+        .drain()
+        .append {
+          q.dequeue().take(expected.size)
+        }
+        .compile()
+        .toList() shouldBe expected
+    }
+  }
+
+  "Queue.dropping - dequeueBatch" {
+    checkAll(Arb.stream(Arb.int()), Arb.positiveInts(), Arb.positiveInts()) { s, maxSize0, batchSize0 ->
+      val maxSize = maxSize0 % 20 + 1
+      val batchSize = batchSize0 % 20 + 1
+      val expected = s.compile().toList().take(maxSize)
+      val q = Queue.dropping<Int>(maxSize)
+
+      s.effectMap { q.enqueue1(it) }
+        .drain().append {
+          Stream.constant(batchSize)
+            .through(q.dequeueBatch())
+            .take(expected.size)
         }
         .compile()
         .toList() shouldBe expected

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
@@ -106,12 +106,12 @@ class QueueTest : StreamSpec(spec = {
     }
   }
 
-  "circularBuffer" {
+  "Queue.sliding - accepts maxSize elements while sliding over capacity" {
     checkAll(Arb.stream(Arb.int()), Arb.positiveInts()) { s, maxSize0 ->
       val maxSize = maxSize0 % 20 + 1
       val expected = s.compile().toList().takeLast(maxSize)
 
-      val q = Queue.circularBuffer<Option<Int>>(maxSize + 1)
+      val q = Queue.sliding<Option<Int>>(maxSize)
 
       s.noneTerminate()
         .effectMap { q.enqueue1(it) }
@@ -122,12 +122,12 @@ class QueueTest : StreamSpec(spec = {
     }
   }
 
-  "dequeueBatch circularBuffer" {
+  "Queue.sliding - dequeueBatch" {
     checkAll(Arb.stream(Arb.int()), Arb.positiveInts(), Arb.positiveInts()) { s, maxSize0, batchSize0 ->
       val maxSize = maxSize0 % 20 + 1
       val batchSize = batchSize0 % 20 + 1
       val expected = s.compile().toList().takeLast(maxSize)
-      val q = Queue.circularBuffer<Option<Int>>(maxSize + 1)
+      val q = Queue.sliding<Option<Int>>(maxSize)
 
       s.noneTerminate()
         .effectMap { q.enqueue1(it) }


### PR DESCRIPTION
This PR renames `Queue.circularBuffer` to `Queue.sliding` and align behavior with `Queue.sliding` as we have today in Arrow Fx. As discussed with @danimontoya based on his usages.
This also algins the behavior with `Channel.conflated` from KotlinX.

Also adds missing support for dropping Queues.