### PR TITLE
Remove TerminalOps from Stream

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/ParJoin.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/ParJoin.kt
@@ -163,7 +163,6 @@ internal suspend fun signalResult(done: SignallingAtomic<Option<Option<Throwable
  *       }
  *     }
  *     .parJoin(10, IOPool)
- *     .compile()
  *     .drain()
  * //sampleEnd
  * ```

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/ParJoin.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/ParJoin.kt
@@ -74,7 +74,6 @@ internal suspend fun <O> runInner(
                 outputQ.enqueue1(Some(s))
               }
               .interruptWhen(done.map { it.isDefined() }) // must be AFTER enqueue to the sync queue, otherwise the process may hang to enq last item while being interrupted
-              .compile()
               .drain()
           }.swap().orNull()
           val e2 = lease.cancel().swap().orNull()
@@ -104,7 +103,6 @@ internal suspend fun <O> Stream<Stream<O>>.runOuter(
         runInner(ctx, inner, done, outputQ, running, available, outerScope)
       }
     }.interruptWhen(done.map { it.isDefined() })
-      .compile()
       .drain()
   }
 
@@ -196,7 +194,6 @@ fun <O> Stream<Stream<O>>.parJoin(
       running.discrete() // Await everyone stop running
         .dropWhile { it > 0 }
         .take(1)
-        .compile()
         .drain()
 
       signalResult(done)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Pull.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Pull.kt
@@ -590,19 +590,6 @@ fun <O> Pull<O, Unit>.firstOrNull(f: (O) -> Boolean): Pull<Nothing, PullUncons1<
     }
   }
 
-///** Returns the last element of the input, if non-empty. */
-//fun <O> Pull<O, Unit>.lastOrNull(): Pull<Nothing, O?> {
-//  fun go(prev: O?, s: Pull<O, Unit>): Pull<Nothing, O?> =
-//    s.unconsOrNull().flatMap { uncons ->
-//      when (uncons) {
-//        null -> Pull.just(prev)
-//        else -> go(uncons.head.lastOrNull() ?: prev, uncons.tail)
-//      }
-//    }
-//
-//  return go(null, this)
-//}
-
 /** Writes a single `true` value if all input matches the predicate, `false` otherwise. */
 fun <O> Pull<O, Unit>.forall(p: (O) -> Boolean): Pull<Nothing, Boolean> =
   unconsOrNull().flatMap { uncons ->

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Pull.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Pull.kt
@@ -590,18 +590,18 @@ fun <O> Pull<O, Unit>.firstOrNull(f: (O) -> Boolean): Pull<Nothing, PullUncons1<
     }
   }
 
-/** Returns the last element of the input, if non-empty. */
-fun <O> Pull<O, Unit>.lastOrNull(): Pull<Nothing, O?> {
-  fun go(prev: O?, s: Pull<O, Unit>): Pull<Nothing, O?> =
-    s.unconsOrNull().flatMap { uncons ->
-      when (uncons) {
-        null -> Pull.just(prev)
-        else -> go(uncons.head.lastOrNull() ?: prev, uncons.tail)
-      }
-    }
-
-  return go(null, this)
-}
+///** Returns the last element of the input, if non-empty. */
+//fun <O> Pull<O, Unit>.lastOrNull(): Pull<Nothing, O?> {
+//  fun go(prev: O?, s: Pull<O, Unit>): Pull<Nothing, O?> =
+//    s.unconsOrNull().flatMap { uncons ->
+//      when (uncons) {
+//        null -> Pull.just(prev)
+//        else -> go(uncons.head.lastOrNull() ?: prev, uncons.tail)
+//      }
+//    }
+//
+//  return go(null, this)
+//}
 
 /** Writes a single `true` value if all input matches the predicate, `false` otherwise. */
 fun <O> Pull<O, Unit>.forall(p: (O) -> Boolean): Pull<Nothing, Boolean> =

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
@@ -378,10 +378,10 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *
    * //sampleStart
    * suspend fun main(): Unit =
-   *   Stream.empty()
+   *   Stream.empty<Int>()
    *     .takeLastOrNull(5)
    *     .toList()
-   *     .let(::println) // []
+   *     .let(::println) // [null]
    * //sampleEnd
    * ```
    */

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
@@ -382,25 +382,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
   fun take(n: Long): Stream<O> =
     asPull.take(n).void().stream()
 
-//  /**
-//   * Emits the first element this stream.
-//   *
-//   * ```kotlin:ank:playground
-//   * import arrow.fx.coroutines.stream.*
-//   *
-//   * //sampleStart
-//   * suspend fun main(): Unit =
-//   *   Stream.range(0..1000)
-//   *     .first()
-//   *     .compile()
-//   *     .toList()
-//   *     .let(::println) // [0]
-//   * //sampleEnd
-//   * ```
-//   */
-//  fun first(): Stream<O> =
-//    take(1)
-
   /**
    * Emits the last `n` elements of the input.
    *
@@ -2254,12 +2235,6 @@ fun <O> Stream<Option<O>>.terminateOnNone(): Stream<O> =
  */
 fun <O> Stream<O>.noneTerminate(): Stream<Option<O>> =
   map { Some(it) }.append { Stream.just(None) }
-
-/**
- * Turn [Stream] into [TerminalOps] to consume the stream.
- */
-fun <O> Stream<O>.compile(): TerminalOps<O> =
-  TerminalOps(this)
 
 private val EmptyStream: Stream<Nothing> = Stream(Pull.done)
 

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
@@ -47,7 +47,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 2, 3)
    *     .flatMap { i -> Stream(i, i, i) }
-   *     .compile()
    *     .toList()
    *     .let(::println) // [1, 1, 1, 2, 2, 2, 3, 3, 3]
    * //sampleEnd
@@ -68,7 +67,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *     .append { Stream.raiseError(RuntimeException("Boom!")) }
    *     .append { Stream(4, 5, 6) }
    *     .attempt()
-   *     .compile()
    *     .toList()
    *     .let(::println) // [Right(b=1), Right(b=2), Right(b=3), Left(a=java.lang.RuntimeException: Boom!)]
    * //sampleEnd
@@ -109,7 +107,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *     .buffer(4)
    *     .effectTap { i -> buf.add("<$i") }
    *     .take(10)
-   *     .compile()
    *     .toList()
    *     .let(::println) // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
    *
@@ -143,7 +140,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *     .bufferAll()
    *     .effectTap { i -> buf.add("<$i") }
    *     .take(4)
-   *     .compile()
    *     .toList()
    *     .let(::println) // [0, 1, 2, 3]
    *
@@ -170,7 +166,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *     .effectTap { i -> buf.add(">$i") }
    *     .bufferBy { it % 2 == 0 }
    *     .effectTap { i -> buf.add("<$i") }
-   *     .compile()
    *     .toList()
    *     .let(::println) // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
    *
@@ -220,7 +215,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(1..10)
    *     .delete { it % 2 == 0 }
-   *     .compile()
    *     .toList()
    *     .let(::println) // [1, 3, 4, 5, 6, 7, 8, 9, 10]
    * //sampleEnd
@@ -249,7 +243,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..10)
    *     .drop(5)
-   *     .compile()
    *     .toList()
    *     .let(::println) // [5, 6, 7, 8, 9, 10]
    * //sampleEnd
@@ -268,7 +261,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..5)
    *     .tail()
-   *     .compile()
    *     .toList()
    *     .let(::println) // [1, 2, 3, 4, 5]
    * //sampleEnd
@@ -290,7 +282,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..10)
    *     .dropLast(5)
-   *     .compile()
    *     .toList()
    *     .let(::println) // [0, 1, 2, 3, 4]
    * //sampleEnd
@@ -328,7 +319,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..10)
    *     .dropWhile { it != 4 }
-   *     .compile()
    *     .toList()
    *     .let(::println) // [4, 5, 6, 7, 8, 9, 10]
    * //sampleEnd
@@ -347,7 +337,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..10)
    *     .dropThrough { it != 4 }
-   *     .compile()
    *     .toList()
    *     .let(::println) // [5, 6, 7, 8, 9, 10]
    * //sampleEnd
@@ -373,7 +362,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..1000)
    *     .take(5)
-   *     .compile()
    *     .toList()
    *     .let(::println) // [0, 1, 2, 3, 4]
    * //sampleEnd
@@ -392,7 +380,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.empty()
    *     .takeLastOrNull(5)
-   *     .compile()
    *     .toList()
    *     .let(::println) // []
    * //sampleEnd
@@ -418,7 +405,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..1000)
    *     .takeLast(5)
-   *     .compile()
    *     .toList()
    *     .let(::println) // [996, 997, 998, 999, 1000]
    * //sampleEnd
@@ -443,7 +429,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(null, 1, 2, null, 3)
    *     .first { it != null }
-   *     .compile()
    *     .toList()
    *     .let(::println) // [1]
    * //sampleEnd
@@ -469,10 +454,10 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * //sampleStart
    * suspend fun main(): Unit {
    *   Stream.range(0..10).exists { it == 4 }
-   *     .compile().toList().let(::println) //[true]
+   *     .toList().let(::println) //[true]
    *
    *   Stream.range(0..10).exists { it == 11 }
-   *     .compile().toList().let(::println) //[false]
+   *     .toList().let(::println) //[false]
    * }
    * //sampleEnd
    * ```
@@ -500,7 +485,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..1000)
    *     .takeWhile { it != 5 }
-   *     .compile()
    *     .toList()
    *     .let(::println) // [0, 1, 2, 3, 4]
    * //sampleEnd
@@ -519,7 +503,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..1000)
    *     .takeThrough { it != 5 }
-   *     .compile()
    *     .toList()
    *     .let(::println) // [0, 1, 2, 3, 4, 5]
    * //sampleEnd
@@ -540,7 +523,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *   Stream(1,2,3)
    *     .repeat()
    *     .take(8)
-   *     .compile()
    *     .toList()
    *     .let(::println) // [1, 2, 3, 1, 2, 3, 1, 2]
    * //sampleEnd
@@ -561,7 +543,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1,2,3)
    *     .repeatN(3)
-   *     .compile()
    *     .toList()
    *     .let(::println) // [1, 2, 3, 1, 2, 3, 1, 2, 3]
    * //sampleEnd
@@ -581,7 +562,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 2, 3)
    *     .effectMap { print(it) }
-   *     .compile()
    *     .drain() // 123
    * //sampleEnd
    * ```
@@ -600,7 +580,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 2, 3)
    *     .effectTap { print(it) } // 123
-   *     .compile()
    *     .toList()
    *     .let(::println) // [1, 2, 3]
    * //sampleEnd
@@ -623,7 +602,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *       sleep((i * 10).milliseconds)
    *       Pair(i, acc + i)
    *     }
-   *     .compile()
    *     .toList()
    *     .let(::println) // [(1,1), (2,3), (3,5), (4,7)]
    * //sampleEnd
@@ -655,7 +633,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream("Hello", "World!")
    *     .map(String::length)
-   *     .compile()
    *     .toList().let(::println) // [5, 6]
    * //sampleEnd
    * ```
@@ -673,7 +650,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 2, 3).append { Stream(4, 5, 6) }
    *     .mapChunks { ch -> ch.map { it + 1 } }
-   *     .compile()
    *     .toList().let(::println) // [2, 3, 4, 5, 6, 7]
    * //sampleEnd
    * ```
@@ -698,7 +674,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream("Hello", "World")
    *   .mapAccumulate(0) { l, s -> Pair(l + s.length, s.first()) }
-   *   .compile()
    *   .toList()
    *   .let(::println) //[(5,H), (10,W)]
    * //sampleEnd
@@ -723,7 +698,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *   Stream(1,2,3).append { Stream(4,5,6) }
    *   .unchunk()
    *   .chunks()
-   *   .compile()
    *   .toList()
    *   .let(::println) //[Chunk(1), Chunk(2), Chunk(3), Chunk(4), Chunk(5), Chunk(6)]
    * //sampleEnd
@@ -749,7 +723,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1).append { Stream(2, 3).append { Stream(4, 5, 6) } }
    *   .chunks()
-   *   .compile()
    *   .toList()
    *   .let(::println) //[Chunk(1), Chunk(2, 3), Chunk(4, 5, 6)]
    * //sampleEnd
@@ -775,7 +748,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1).append { Stream(2, 3).append { Stream(4, 5, 6) } }
    *   .chunkLimit(2)
-   *   .compile()
    *   .toList()
    *   .let(::println) //[Chunk(1), Chunk(2, 3), Chunk(4, 5), Chunk(6)]
    * //sampleEnd
@@ -806,7 +778,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 2).append { Stream(3, 4).append { Stream(5, 6, 7) } }
    *   .chunkMin(3)
-   *   .compile()
    *   .toList()
    *   .let(::println) //[Chunk(1, 2, 3, 4), Chunk(5, 6, 7)]
    * //sampleEnd
@@ -853,7 +824,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *   .repeat()
    *   .chunkN(2)
    *   .take(6)
-   *   .compile()
    *   .toList()
    *   .let(::println) //[Chunk(1, 2), Chunk(3, 1), Chunk(2, 3), Chunk(1, 2), Chunk(3, 1), Chunk(2)]
    * //sampleEnd
@@ -879,7 +849,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream.range(0..10)
    *     .filter { it % 2 == 0 }
-   *     .compile()
    *     .toList()
    *     .let(::println) //[0, 2, 4, 6, 8]
    * //sampleEnd
@@ -905,7 +874,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, -1, 2, -2, 3, -3, 4, -4)
    *   .filterWithPrevious { previous, current -> previous < current }
-   *   .compile()
    *   .toList()
    *   .let(::println) //[1, 2, 3, 4]
    * //sampleEnd
@@ -953,7 +921,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 2, 3, 4, 5)
    *   .fold(0) { acc, b -> acc + b }
-   *   .compile()
    *   .toList()
    *   .let(::println) //[15]
    * //sampleEnd
@@ -975,7 +942,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 1, 1, 1, 1)
    *   .foldMap(Int.monoid()) { it + 1 }
-   *   .compile()
    *   .toList()
    *   .let(::println) //[10]
    * //sampleEnd
@@ -996,7 +962,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1,2,3,4)
    *   .effectScan(0) { acc,i -> acc + i }
-   *   .compile()
    *   .toList()
    *   .let(::println) //[0, 1, 3, 6, 10]
    * //sampleEnd
@@ -1032,7 +997,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * //sampleStart
    * suspend fun main(): Unit =
    *   Stream(1, 2, 3).zip(Stream(4, 5, 6, 7))
-   *   .compile()
    *   .toList()
    *   .let(::println) //[(1,4), (2,5), (3,6)]
    * //sampleEnd
@@ -1066,7 +1030,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 2, 3)
    *   .zipWith(Stream(4, 5, 6, 7)) { acc, b -> acc + b }
-   *   .compile()
    *   .toList()
    *   .let(::println) //[5, 7, 9]
    * //sampleEnd
@@ -1090,7 +1053,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream("The", "quick", "brown", "fox")
    *   .zipWithIndex()
-   *   .compile()
    *   .toList()
    *   .let(::println) //[(The,0), (quick,1), (brown,2), (fox,3)]
    * //sampleEnd
@@ -1119,7 +1081,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream("The", "quick", "brown", "fox")
    *   .zipWithNext()
-   *   .compile()
    *   .toList()
    *   .let(::println) //[(The,quick), (quick,brown), (brown,fox), (fox,null)]
    * //sampleEnd
@@ -1158,7 +1119,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream("The", "quick", "brown", "fox")
    *   .zipWithPrevious()
-   *   .compile()
    *   .toList()
    *   .let(::println) //[(null,The), (The,quick), (quick,brown), (brown,fox)]
    * //sampleEnd
@@ -1181,7 +1141,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream("The", "quick", "brown", "fox")
    *   .zipWithPreviousAndNext()
-   *   .compile()
    *   .toList()
    *   .let(::println) //[(null,The, quick), (The, quick,brown), (quick,brown,fox), (brown,fox,null)]
    * //sampleEnd
@@ -1203,7 +1162,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream("uno", "dos", "tres", "cuatro")
    *   .zipWithScan(0) { acc, b -> acc + b.length }
-   *   .compile()
    *   .toList()
    *   .let(::println) //[(uno,0), (dos,3), (tres,6), (cuatro,10)]
    * //sampleEnd
@@ -1228,7 +1186,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream("uno", "dos", "tres", "cuatro")
    *   .zipWithScan1(0) { acc, b -> acc + b.length }
-   *   .compile()
    *   .toList()
    *   .let(::println) //[(uno,3), (dos,6), (tres,10), (cuatro,16)]
    * //sampleEnd
@@ -1254,7 +1211,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 2, 3, 4, 5)
    *   .forall { it < 10 }
-   *   .compile()
    *   .toList()
    *   .let(::println) //[true]
    * //sampleEnd
@@ -1285,7 +1241,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1, 2, 3, 4)
    *   .void()
-   *   .compile()
    *   .toList().let(::println) //[]
    * //sampleEnd
    * ```
@@ -1303,7 +1258,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * suspend fun main(): Unit =
    *   Stream(1,2,3).append { Stream.raiseError<Int>(RuntimeException()).append { Stream(4, 5, 6) } }
    *     .mask()
-   *     .compile()
    *     .toList().let(::println) //[1, 2, 3]
    * //sampleEnd
    * ```
@@ -1343,7 +1297,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    *   signalling.discrete()
    *     .concurrently(data.effectMap { signalling.set(it) })
    *     .takeWhile { it < 9 }
-   *     .compile()
    *     .toList()
    *     .let(::println) //[0, 1, 2, 3, 4, 5, 6, 7, 8]
    * }
@@ -1528,8 +1481,8 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
       effect { arrow.fx.coroutines.sleep(d) }
 
     /**
-     * Alias for `sleep(d).drain`. Often used in conjunction with `++` (i.e., `sleep_(..) ++ s`) as a more
-     * performant version of `sleep(..) >> s`.
+     * Alias for `sleep(d).void`. Often used in conjunction with [append] (i.e., `sleep_(..).append { s }`) as a more
+     * performant version of `sleep(..).flatMap { s }`.
      */
     fun sleep_(d: Duration): Stream<Nothing> =
       sleep(d).void()
@@ -1546,13 +1499,11 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleEnd
      * suspend fun main(): Unit {
      *   Stream.effect { 10 }
-     *     .compile()
      *     .toList()
      *     .let(::println) // [10]
      *
      *   Either.catch {
      *     Stream.effect { throw RuntimeException() }
-     *       .compile()
      *       .toList()
      *   }.let(::println) // Left(java.lang.RuntimeException)
      * }
@@ -1574,7 +1525,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleEnd
      * suspend fun main(): Unit =
      *   Stream.effect_ { println("Ran") }
-     *     .compile()
      *     .toList()
      *     .let(::println) // []
      * //sampleStart
@@ -1599,7 +1549,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * suspend fun main(): Unit {
      *   Stream.constant(0)
      *     .take(5)
-     *     .compile()
      *     .toList()
      *     .let(::println) // [0, 0, 0, 0, 0]
      * }
@@ -1618,7 +1567,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleEnd
      * suspend fun main(): Unit =
      *   Stream.force { Stream(1, 2, 3) }
-     *     .compile()
      *     .toList()
      *     .let(::println) // [1, 2, 3]
      * //sampleStart
@@ -1644,7 +1592,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * suspend fun main(): Unit =
      *   Stream.iterateEffect(0) { it + 1 }
      *     .take(10)
-     *     .compile()
      *     .toList()
      *     .let(::println) // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
      * //sampleStart
@@ -1670,7 +1617,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleEnd
      * suspend fun main(): Unit =
      *   Stream.unfold(0) { i -> if (i < 5) Pair(i, i + 1) else null }
-     *     .compile()
      *     .toList()
      *     .let(::println) //[0, 1, 2, 3, 4]
      * //sampleStart
@@ -1710,7 +1656,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      *     if (i < 5) Pair(Chunk(i) { i }, i + 1)
      *     else null
      *   }
-     *     .compile()
      *     .toList()
      *     .let(::println) //[1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
      * //sampleEnd
@@ -1748,7 +1693,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleStart
      * suspend fun main(): Unit =
      *   Stream.just(1)
-     *     .compile()
      *     .toList()
      *     .let(::println) //[0]
      * //sampleEnd
@@ -1839,7 +1783,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleStart
      * suspend fun main(): Unit =
      *   Stream.range(0..20 step 2)
-     *     .compile()
      *     .toList().let(::println) // [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
      * //sampleEnd
      * ```
@@ -1860,7 +1803,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleStart
      * suspend fun main(): Unit =
      *   Stream.range(0L..15 step 3)
-     *     .compile()
      *     .toList().let(::println) // [0, 3, 6, 9, 12, 15]
      * //sampleEnd
      * ```
@@ -1881,7 +1823,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleStart
      * suspend fun main(): Unit =
      *   Stream.range('a'..'z' step 2)
-     *     .compile()
      *     .toList()
      *     .let(::println) // [a, c, e, g, i, k, m, o, q, s, u, w, y]
      * //sampleEnd
@@ -1910,7 +1851,7 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleStart
      * suspend fun main(): Unit =
      *   timeOutOrNull(1.seconds) {
-     *     Stream.never<Int>().compile().drain()
+     *     Stream.never<Int>().drain()
      *   }.let(::println)
      * //sampleEnd
      * ```
@@ -1927,7 +1868,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * //sampleStart
      * suspend fun main(): Unit =
      *   Stream.emits(1, 2, 3)
-     *     .compile()
      *     .toList()
      *     .let(::println) // [1, 2, 3]
      * //sampleEnd
@@ -1975,7 +1915,6 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
  * suspend fun main(): Unit =
  *   Stream(1,2,3)
  *     .zipAll(Stream(4,5,6,7), 0,0)
- *     .compile()
  *     .toList().let(::println) // [(1,4), (2,5), (3,6), (0,7)]
  * //sampleEnd
  *```
@@ -1995,7 +1934,6 @@ fun <O, B> Stream<O>.zipAll(that: Stream<B>, pad1: O, pad2: B): Stream<Pair<O, B
  * suspend fun main(): Unit =
  *   Stream(1,2,3)
  *     .zipAllWith(Stream(4,5,6,7), 0, 0) { acc, b -> acc + b }
- *     .compile()
  *     .toList().let(::println) // [5, 7, 9, 7]
  * //sampleEnd
  *```
@@ -2053,7 +1991,6 @@ fun <A, B, C> Stream<A>.zipAllWith(
  * //sampleStart
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3).onComplete { Stream(4, 5) }
- *     .compile()
  *     .toList().let(::println) // [1, 2, 3, 4, 5]
  * //sampleEnd
  *```
@@ -2076,7 +2013,6 @@ fun <O> Stream<O>.onComplete(s2: () -> Stream<O>): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream("Hel", "l", "o Wor", "ld")
  *     .repartition(String.semigroup()) { s -> Chunk.iterable(s.split(" ")) }
- *     .compile()
  *     .toList()
  *     .let(::println) //[Hello, World]
  * //sampleEnd
@@ -2114,7 +2050,6 @@ fun <O> Stream<O>.repartition(S: Semigroup<O>, f: (O) -> Chunk<O>): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(1, 2, null, 3, None)
  *     .filterNull()
- *     .compile()
  *     .toList()
  *     .let(::println) //[1, 2, 3]
  * //sampleEnd
@@ -2133,7 +2068,6 @@ fun <O : Any> Stream<O?>.filterNull(): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(1, 2, null, 3, null)
  *     .terminateOnNull()
- *     .compile()
  *     .toList()
  *     .let(::println) //[1, 2]
  * //sampleEnd
@@ -2152,7 +2086,6 @@ fun <O> Stream<O>.terminateOnNull(): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3, 4)
  *     .terminateOn { it == 3 }
- *     .compile()
  *     .toList()
  *     .let(::println) //[1, 2]
  * //sampleEnd
@@ -2186,7 +2119,6 @@ fun <O> Stream<O>.terminateOn(terminator: (O) -> Boolean): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(Some(1), Some(2), None, Some(3), None)
  *     .filterOption()
- *     .compile()
  *     .toList()
  *     .let(::println) //[1, 2, 3]
  * //sampleEnd
@@ -2207,7 +2139,6 @@ fun <O> Stream<Option<O>>.filterOption(): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(Some(1), Some(2), None, Some(3), None)
  *     .terminateOnNone()
- *     .compile()
  *     .toList()
  *     .let(::println) //[1, 2]
  * //sampleEnd
@@ -2251,7 +2182,6 @@ fun <O> emptyStream(): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3)
  *     .interleave(Stream(4, 5, 6, 7))
- *     .compile()
  *     .toList()
  *     .let(::println) //[1, 4, 2, 5, 3, 6]
  * //sampleEnd
@@ -2270,7 +2200,6 @@ fun <O> Stream<O>.interleave(that: Stream<O>): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3)
  *     .interleaveAll(Stream(4, 5, 6, 7))
- *     .compile()
  *     .toList()
  *     .let(::println) //[1, 4, 2, 5, 3, 6, 7]
  * //sampleEnd
@@ -2293,7 +2222,6 @@ fun <O> Stream<O>.interleaveAll(that: Stream<O>): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3, 4, 5)
  *     .intersperse(0)
- *     .compile()
  *     .toList()
  *     .let(::println) //[1, 0, 2, 0, 3, 0, 4, 0, 5]
  * //sampleEnd
@@ -2324,7 +2252,6 @@ fun <O> Stream<O>.intersperse(separator: O): Stream<O> =
  * //sampleStart
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3).append { Stream(4, 5, 6) }
- *     .compile()
  *     .toList().let(::println) // [1, 2, 3, 4, 5, 6]
  * //sampleEnd
  *```
@@ -2341,7 +2268,6 @@ fun <O> Stream<O>.append(s2: () -> Stream<O>): Stream<O> =
  * //sampleStart
  * suspend fun main(): Unit =
  *   (Chunk(-1, 0) prependTo Stream(1, 2, 3))
- *   .compile()
  *   .toList().let(::println) // [-1, 0, 1, 2, 3]
  * //sampleEnd
  * ```
@@ -2358,7 +2284,6 @@ infix fun <O> Chunk<O>.prependTo(s: Stream<O>): Stream<O> =
  * //sampleStart
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3).cons(Chunk(-1, 0))
- *     .compile()
  *     .toList().let(::println) // [-1, 0, 1, 2, 3]
  * //sampleEnd
  * ```
@@ -2375,7 +2300,6 @@ fun <O> Stream<O>.cons(c: Chunk<O>): Stream<O> =
  * //sampleStart
  * suspend fun main(): Unit =
  *   (0 prependTo Stream(1, 2, 3))
- *   .compile()
  *   .toList().let(::println) // [0, 1, 2, 3]
  * //sampleEnd
  * ```
@@ -2392,7 +2316,6 @@ infix fun <O> O.prependTo(s: Stream<O>): Stream<O> =
  * //sampleStart
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3).cons1(0)
- *     .compile()
  *     .toList()
  *   .  let(::println) // [0, 1, 2, 3]
  * //sampleEnd
@@ -2412,7 +2335,6 @@ fun <O> Stream<O>.cons1(o: O): Stream<O> =
  *   Stream(1, 2, 3)
  *     .append { Stream.raiseError(RuntimeException()) }
  *     .handleErrorWith { _: Throwable -> Stream.just(0) }
- *     .compile()
  *     .toList()
  *     .let(::println) // [1, 2, 3, 0]
  * //sampleEnd
@@ -2436,7 +2358,6 @@ fun <O> Stream<Stream<O>>.flatten(): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3, 4, 5)
  *     .fold1 { a, b -> a + b }
- *     .compile()
  *     .toList()
  *     .let(::println) // [15]
  * //sampleEnd
@@ -2473,7 +2394,6 @@ fun <O> Stream<O>.reduceSemigroup(S: Semigroup<O>): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3, 4, 5)
  *     .foldMonoid(Int.monoid())
- *     .compile()
  *     .toList()
  *     .let(::println) // [15]
  * //sampleEnd
@@ -2494,7 +2414,6 @@ fun <O> Stream<O>.foldMonoid(MO: Monoid<O>): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream(1,2,3,4)
  *   .scan(0) { a, b -> a + b }
- *   .compile()
  *   .toList()
  *   .let(::println) // [0, 1, 3, 6, 10]
  * //sampleEnd
@@ -2520,7 +2439,6 @@ fun <O, O2> Stream<O>.scan(init: O2, f: (O2, O) -> O2): Stream<O2> =
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3, 4)
  *     .scanMonoid(Int.monoid())
- *     .compile()
  *     .toList()
  *     .let(::println) //[0, 1, 3, 6, 10]
  * //sampleEnd
@@ -2540,7 +2458,6 @@ fun <O> Stream<O>.scanMonoid(MO: Monoid<O>): Stream<O> =
  * suspend fun main(): Unit =
  *   Stream("a", "aa", "aaa", "aaaa")
  *     .scanMap(Int.monoid()) { it.length }
- *     .compile()
  *     .toList()
  *     .let(::println) //[0, 1, 3, 6, 10]
  * //sampleEnd
@@ -2570,7 +2487,6 @@ private fun <O, O2> Pull<O, Unit>.scan_(init: O2, f: (O2, O) -> O2): Pull<O2, Un
  * suspend fun main(): Unit =
  *   Stream(1, 2, 3, 4)
  *    .scan1 { a, b -> a + b }
- *    .compile()
  *    .toList()
  *    .let(::println) //[1, 3, 6, 10]
  * //sampleEnd
@@ -2620,7 +2536,6 @@ fun <O, S, O2> Stream<O>.scanChunks(
  *
  * suspend fun main(): Unit =
  *   Stream.range(0..100).take(5)
- *     .compile()
  *     .toList().let(::println) // [0, 1, 2, 3, 4]
  * //sampleEnd
  * ```

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
@@ -1,60 +1,101 @@
 package arrow.fx.coroutines.stream
 
 /**
+ * Runs all the effects of this [Stream] and collects all emitted values into a [List].
+ * If the [Stream] doesn't emit any values it returns [emptyList].
+ *
+ * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
+ * If any errors are raised while streaming, it's thrown from this `suspend` scope.
+ */
+suspend fun <O> Stream<O>.toList(): List<O> =
+  compiler(mutableListOf()) { acc, ch -> acc.apply { addAll(ch.toList()) } }
+
+/**
+ * Runs all the effects of this [Stream] and collects all emitted values into a [Set].
+ * If the [Stream] doesn't emit any values it returns [emptySet].
+ *
+ * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
+ * If any errors are raised while streaming, it's thrown from this `suspend` scope.
+ */
+suspend fun <O> Stream<O>.toSet(): Set<O> =
+  compiler(mutableSetOf()) { acc, ch -> acc.apply { addAll(ch.toList()) } }
+
+/**
+ * Runs all the effects of this [Stream] and ignores all emitted values.
+ *
+ * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
+ * If any errors are raised while streaming, it's thrown from this `suspend` scope.
+ */
+suspend fun <O> Stream<O>.drain(): Unit =
+  foldChunks(Unit) { _, _ -> Unit }
+
+/**
+ * Runs the first effect of this [Stream], and returns `null` if the stream emitted a value
+ * and returns the value if emitted.
+ *
+ * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
+ * If any errors are raised while streaming, it's thrown from this `suspend` scope.
+ */
+suspend fun <O> Stream<O>.firstOrNull(): O? =
+  take(1).foldChunks<O, O?>(null) { acc, c ->
+    acc ?: c.firstOrNull()
+  }
+
+/**
+ * Runs the first effect of this [Stream], raising a [NoSuchElementException] if the stream emitted no values
+ * and returns the value if emitted.
+ *
+ * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
+ * If any errors are raised while streaming, it's thrown from this `suspend` scope.
+ */
+suspend fun <O> Stream<O>.firstOrError(): O? =
+  firstOrNull() ?: throw NoSuchElementException()
+
+/**
+ * Runs all the effects of this [Stream], and returns `null` if the stream emitted no values
+ * and returning the last value emitted if values were emitted.
+ *
+ * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
+ * If any errors are raised while streaming, it's thrown from this `suspend` scope.
+ */
+suspend fun <O> Stream<O>.lastOrNull(): O? =
+  foldChunks<O, O?>(null) { acc, c -> c.lastOrNull() ?: acc }
+
+/**
+ * Runs all the effects of this [Stream], raising a [NoSuchElementException] if the stream emitted no values
+ * and returning the last value emitted otherwise.
+ *
+ * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
+ * If any errors are raised while streaming, it's thrown from this `suspend` scope.
+ */
+suspend fun <O> Stream<O>.lastOrError(): O =
+  lastOrNull() ?: throw NoSuchElementException()
+
+/**
+ * Folds all the effects of this stream in to a value by folding
+ * the output chunks together, starting with the provided [init] and combining the
+ * current value with each output chunk using [f]
+ *
+ * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
+ * If any errors are raised while streaming, it's thrown from this `suspend` scope.
+ */
+suspend fun <O, B> Stream<O>.foldChunks(init: B, f: (B, Chunk<O>) -> B): B =
+  compiler(init, f)
+
+/**
  * DSL boundary to access terminal operators
  *
  * Terminal operators consume the stream
  */ // TODO report inline results in Exception in thread "main" java.lang.VerifyError: Bad type on operand stack
 /* inline */ class TerminalOps<O>(private val s: Stream<O>) {
 
-  suspend fun toList(): List<O> =
-    compiler(mutableListOf()) { acc, ch -> acc.apply { addAll(ch.toList()) } }
-
-  suspend fun toSet(): Set<O> =
-    compiler(mutableSetOf()) { acc, ch -> acc.apply { addAll(ch.toList()) } }
-
-  suspend fun drain(): Unit =
-    foldChunks(Unit) { _, _ -> Unit }
-
-  /**
-   * Compiles this stream in to a value,
-   * returning `null` if the stream emitted no values and returning the
-   * last value emitted if values were emitted.
-   *
-   * When this method has returned, the stream has not begun execution -- this method simply
-   * compiles the stream down to the target effect type.
-   */
-  suspend fun lastOrNull(): O? =
-    foldChunks<O?>(null) { acc, c -> c.lastOrNull() ?: acc }
-
-  /**
-   * Compiles this stream in to a value,
-   * raising a `NoSuchElementException` if the stream emitted no values
-   * and returning the last value emitted otherwise.
-   *
-   * When this method has returned, the stream has not begun execution -- this method simply
-   * compiles the stream down to the target effect type.
-   */
-  suspend fun lastOrError(): O =
-    lastOrNull() ?: throw NoSuchElementException()
-
-  /**
-   * Compiles this stream in to a value by folding
-   * the output chunks together, starting with the provided `init` and combining the
-   * current value with each output chunk.
-   *
-   * When this method has returned, the stream has not begun execution -- this method simply
-   * compiles the stream down to the target effect type.
-   */
-  suspend fun <B> foldChunks(init: B, f: (B, Chunk<O>) -> B): B =
-    compiler(init, f)
-
   val resource: ResourceTerminalOps<O> =
     ResourceTerminalOps(s)
 
-  private suspend fun <B> compiler(init: () -> B, foldChunk: (B, Chunk<O>) -> B): B =
-    s.asPull.compiler(init.invoke(), foldChunk)
-
-  private suspend fun <B> compiler(init: B, foldChunk: (B, Chunk<O>) -> B): B =
-    s.asPull.compiler(init, foldChunk)
 }
+
+private suspend fun <O, B> Stream<O>.compiler(init: () -> B, foldChunk: (B, Chunk<O>) -> B): B =
+  asPull.compiler(init.invoke(), foldChunk)
+
+private suspend fun <O, B> Stream<O>.compiler(init: B, foldChunk: (B, Chunk<O>) -> B): B =
+  asPull.compiler(init, foldChunk)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
@@ -33,6 +33,17 @@ suspend fun <O> Stream<O>.drain(): Unit =
  * Runs the first effect of this [Stream], and returns `null` if the stream emitted a value
  * and returns the value if emitted.
  *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.stream.*
+ *
+ * //sampleStart
+ * suspend fun main(): Unit =
+ *   Stream.range(0..1000)
+ *     .firstOrNull()
+ *     .let(::println) // 0
+ * //sampleEnd
+ * ```
+ *
  * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
  * If any errors are raised while streaming, it's thrown from this `suspend` scope.
  */
@@ -54,6 +65,17 @@ suspend fun <O> Stream<O>.firstOrError(): O? =
 /**
  * Runs all the effects of this [Stream], and returns `null` if the stream emitted no values
  * and returning the last value emitted if values were emitted.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.stream.*
+ *
+ * //sampleStart
+ * suspend fun main(): Unit =
+ *   Stream(1, 2, 3)
+ *     .lastOrNull()
+ *     .let(::println) // 3
+ * //sampleEnd
+ * ```
  *
  * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
  * If any errors are raised while streaming, it's thrown from this `suspend` scope.
@@ -81,21 +103,6 @@ suspend fun <O> Stream<O>.lastOrError(): O =
  */
 suspend fun <O, B> Stream<O>.foldChunks(init: B, f: (B, Chunk<O>) -> B): B =
   compiler(init, f)
-
-/**
- * DSL boundary to access terminal operators
- *
- * Terminal operators consume the stream
- */ // TODO report inline results in Exception in thread "main" java.lang.VerifyError: Bad type on operand stack
-/* inline */ class TerminalOps<O>(private val s: Stream<O>) {
-
-  val resource: ResourceTerminalOps<O> =
-    ResourceTerminalOps(s)
-
-}
-
-private suspend fun <O, B> Stream<O>.compiler(init: () -> B, foldChunk: (B, Chunk<O>) -> B): B =
-  asPull.compiler(init.invoke(), foldChunk)
 
 private suspend fun <O, B> Stream<O>.compiler(init: B, foldChunk: (B, Chunk<O>) -> B): B =
   asPull.compiler(init, foldChunk)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/callbacks.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/callbacks.kt
@@ -35,7 +35,6 @@ interface EmitterSyntax<A> {
  *       emit(2, 3, 4)
  *       end()
  *     }
- *     .compile()
  *     .toList()
  *     .let(::println) //[1, 2, 3, 4]
  * //sampleEnd
@@ -105,7 +104,6 @@ fun <A> Stream.Companion.callback(@BuilderInference f: suspend EmitterSyntax<A>.
  *
  *   val result = getUsernames()
  *     .effectTap { println(it) }
- *     .compile()
  *     .toList()
  *   //sampleEnd
  *   println(result)

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancelBoundary.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancelBoundary.kt
@@ -7,7 +7,6 @@ class CancelBoundary : StringSpec({
 
   suspend fun forever(): Unit {
     while (true) {
-      println("I am getting dizzy...")
       cancelBoundary() // cancellable computation loop
     }
   }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/CallbackTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/CallbackTest.kt
@@ -37,7 +37,7 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
       }
 
       effect.get() shouldBe false
-      s.compile().drain()
+      s.drain()
       effect.get() shouldBe true
     }
   }
@@ -48,7 +48,6 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
         list.forEach { emit(it) }
         end()
       }
-        .compile()
         .toList() shouldBe list
     }
   }
@@ -60,7 +59,6 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
         end()
       }
         .chunks()
-        .compile()
         .toList() shouldBe listOf(Chunk(*list))
     }
   }
@@ -72,7 +70,6 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
         end()
       }
         .chunks()
-        .compile()
         .toList() shouldBe listOf(Chunk.iterable(list))
     }
   }
@@ -85,7 +82,6 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
         end()
       }
         .chunks()
-        .compile()
         .toList() shouldBe listOf(ch, ch2)
     }
   }
@@ -96,7 +92,6 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
         countToCallback(4, { it }, { emit(it) }) { end() }
       }
     }
-      .compile()
       .toList() shouldBe listOf(1, 2, 3, 4, 5)
   }
 
@@ -114,7 +109,6 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
         if (it == 1) ref.get() shouldBe false
         else Unit
       }
-      .compile()
       .drain()
   }
 
@@ -122,7 +116,7 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
     checkAll(Arb.throwable()) { e ->
       val s = Stream.cancellable<Int> {
         throw e
-      }.compile()
+      }
 
       assertThrowable {
         s.drain()
@@ -134,7 +128,7 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
     checkAll(Arb.throwable()) { e ->
       val s = Stream.cancellable<Int> {
         e.suspend()
-      }.compile()
+      }
 
       assertThrowable {
         s.drain()
@@ -153,7 +147,7 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
 
       val f = ForkAndForget {
         parTupledN(
-          { s.compile().drain() },
+          { s.drain() },
           { latch.complete(Unit) }
         )
       }
@@ -180,7 +174,7 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
           emit(Unit)
           done.complete(i)
           CancelToken.unit
-        }.compile()
+        }
           .lastOrError()
       }
 
@@ -209,7 +203,7 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
       end()
       CancelToken { effect.set(true) }
     }
-      .compile()
+
       .drain()
 
     effect.get() shouldBe false

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/CancellationTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/CancellationTest.kt
@@ -68,7 +68,7 @@ private suspend fun <A> assertCancellable(fa: (latch: Promise<Unit>) -> Stream<A
   val fiber = ForkAndForget {
     guaranteeCase(
       fa = {
-        fa(latch).compile().drain()
+        fa(latch).drain()
       },
       finalizer = { ex -> p.complete(ex) }
     )
@@ -88,7 +88,6 @@ private suspend fun <A> Stream<A>.assertCancellable(): Unit {
       fa = {
         Stream.effect { start.complete(Unit) }
           .flatMap { this@assertCancellable }
-          .compile()
           .drain()
       },
       finalizer = { ex -> p.complete(ex) }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ConcurrentlyTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ConcurrentlyTest.kt
@@ -19,10 +19,9 @@ class ConcurrentlyTest : StreamSpec(spec = {
   "concurrently" - {
     "when background stream terminates, overall stream continues" {
       checkAll(Arb.stream(Arb.int()), Arb.stream(Arb.int())) { s1, s2 ->
-        val expected = s1.compile().toList()
+        val expected = s1.toList()
         s1.delayBy(25.milliseconds)
           .concurrently(s2)
-          .compile()
           .toList() shouldBe expected
       }
     }
@@ -32,7 +31,6 @@ class ConcurrentlyTest : StreamSpec(spec = {
         assertThrowable {
           s.delayBy(25.milliseconds)
             .concurrently(Stream.raiseError<Unit>(e))
-            .compile()
             .drain()
         } shouldBe e
       }
@@ -47,7 +45,6 @@ class ConcurrentlyTest : StreamSpec(spec = {
         assertThrowable {
           fg.concurrently(bg)
             .onFinalize { semaphore.acquire() } // Hangs if bg doesn't go through terminate
-            .compile()
             .drain()
         } shouldBe e
       }
@@ -62,7 +59,6 @@ class ConcurrentlyTest : StreamSpec(spec = {
 
         fg.concurrently(bg)
           .onFinalize { semaphore.acquire() } // Hangs if bg doesn't go through terminate
-          .compile()
           .drain()
       }
     }
@@ -72,7 +68,6 @@ class ConcurrentlyTest : StreamSpec(spec = {
         assertThrowable {
           s.concurrently(Stream.raiseError<Unit>(e))
             .effectTap { never() }
-            .compile()
             .drain()
         } shouldBe e
       }
@@ -98,7 +93,6 @@ class ConcurrentlyTest : StreamSpec(spec = {
           Stream.bracket({ Unit }, { finRef.update { it + "Outer" } })
             .flatMap { s.concurrently(runner) }
             .interruptWhen { Either.catch { halt.get() } }
-            .compile()
             .toList()
         }
 
@@ -112,7 +106,7 @@ class ConcurrentlyTest : StreamSpec(spec = {
         } else {
           // still the outer finalizer shall be run, but there is no failure in `s`
           finalizers shouldBe listOf("Outer")
-          r shouldBe Either.Right(s.compile().toList())
+          r shouldBe Either.Right(s.toList())
         }
       }
     }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/InterruptionTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/InterruptionTest.kt
@@ -33,7 +33,6 @@ class InterruptionTest : StreamSpec(spec = {
           .effectMap {
             guaranteeCase({ latch.complete(Unit); never<Unit>() }) { ex -> exit.complete(ex) }
           }.interruptWhen { Right(latch.get().also { sleep(20.milliseconds) }) }
-          .compile()
           .toList()
       }
 
@@ -47,7 +46,6 @@ class InterruptionTest : StreamSpec(spec = {
     checkAll(Arb.stream(Arb.int())) { s ->
       s.effectMap { never<Unit>() }
         .interruptWhen { Right(sleep(20.milliseconds)) }
-        .compile()
         .toList() shouldBe emptyList()
     }
   }
@@ -61,7 +59,6 @@ class InterruptionTest : StreamSpec(spec = {
           s.effectMap { semaphore.acquire() }
             .interruptWhen(interrupt)
         }
-        .compile()
         .toList() shouldBe emptyList()
     }
   }
@@ -70,7 +67,6 @@ class InterruptionTest : StreamSpec(spec = {
     checkAll(Arb.int()) { i ->
       Stream.constant(i)
         .interruptWhen { Right(sleep(20.milliseconds)) }
-        .compile()
         .drain() // Finishes and gets interrupted
     }
   }
@@ -80,7 +76,6 @@ class InterruptionTest : StreamSpec(spec = {
       Stream.constant(i)
         .interruptWhen { Right(sleep(20.milliseconds)) }
         .flatMap { Stream(1) }
-        .compile()
         .drain()
     }
   }
@@ -91,7 +86,6 @@ class InterruptionTest : StreamSpec(spec = {
 
     loop(0)
       .interruptWhen { Right(sleep(20.milliseconds)) }
-      .compile()
       .drain()
   }
 
@@ -101,7 +95,6 @@ class InterruptionTest : StreamSpec(spec = {
 
     loop()
       .interruptWhen { Right(sleep(20.milliseconds)) }
-      .compile()
       .drain()
   }
 
@@ -111,29 +104,25 @@ class InterruptionTest : StreamSpec(spec = {
 
     loop()
       .interruptWhen { Right(sleep(20.milliseconds)) }
-      .compile()
       .drain()
   }
 
   "effect stream" - {
     Stream.effect { Unit }.repeat()
       .interruptWhen { Right(sleep(20.milliseconds)) }
-      .compile()
       .drain()
   }
 
   "Constant drained stream" - {
     Stream.constant(true)
       .interruptWhen { Right(sleep(20.milliseconds)) }
-      .compile()
       .drain()
   }
 
   "terminates when interruption stream is infinitely false" - {
     checkAll(Arb.stream(Arb.int())) { s ->
-      val expected = s.compile().toList()
+      val expected = s.toList()
       s.interruptWhen(Stream.constant(false))
-        .compile()
         .toList() shouldBe expected
     }
   }
@@ -151,7 +140,6 @@ class InterruptionTest : StreamSpec(spec = {
           i
         } else i
       }.interruptWhen(interrupt)
-        .compile()
         // as soon as we hit a value divisible by 7, we enable interruption then hang before emitting it,
         // so there should be no elements in the output that are divisible by 7
         // this also checks that interruption works fine even if one or both streams are in a hung state
@@ -163,7 +151,6 @@ class InterruptionTest : StreamSpec(spec = {
     checkAll(Arb.stream(Arb.int())) { s ->
       s.interruptWhen { Right(sleep(20.milliseconds)) }
         .flatMap { Stream.never<Int>() }
-        .compile()
         .toList() shouldBe emptyList()
     }
   }
@@ -176,9 +163,7 @@ class InterruptionTest : StreamSpec(spec = {
             .append { s }
             .interruptWhen { sleep(20.milliseconds); Either.Left(e) }
             .flatMap { Stream.effect_ { semaphore.acquire() } }
-        }
-          .compile()
-          .toList()
+        }.toList()
       } shouldBe Either.Left(e)
     }
   }
@@ -187,39 +172,36 @@ class InterruptionTest : StreamSpec(spec = {
     Stream.never<Unit>()
       .interruptWhen { Right(sleep(20.milliseconds)) }
       .append { Stream(5) }
-      .compile()
       .toList() shouldBe listOf(5)
   }
 
   "hang in effectMap and then resume on append" - {
     checkAll(Arb.stream(Arb.int())) { s ->
-      val expected = s.compile().toList()
+      val expected = s.toList()
 
       s.interruptWhen { Right(sleep(20.milliseconds)) }
         .effectMap { never<Int>() }
-        .drain()
+        .void()
         .append { s }
-        .compile()
         .toList() shouldBe expected
     }
   }
 
   "effectMap + filterOption and then resume on append" - {
     checkAll(Arb.stream(Arb.int())) { s ->
-      val expected = s.compile().toList()
+      val expected = s.toList()
 
       s.interruptWhen { Right(sleep(20.milliseconds)) }
         .effectMap { never<Option<Int>>() }
         .append { s.map { Some(it) } }
         .filterOption()
-        .compile()
         .toList() shouldBe expected
     }
   }
 
   "interruption works when flatMap is followed by filterOption" - {
     checkAll(Arb.stream(Arb.int())) { s ->
-      val expected = s.compile().toList()
+      val expected = s.toList()
 
       s.append { Stream(1) }
         .interruptWhen { Right(sleep(50.milliseconds)) }
@@ -232,7 +214,6 @@ class InterruptionTest : StreamSpec(spec = {
           }
         }
         .filterOption()
-        .compile()
         .toList() shouldBe expected
     }
   }
@@ -260,7 +241,6 @@ class InterruptionTest : StreamSpec(spec = {
         .flatMap { Stream(it) }
         .interruptWhen { Right(latch.get()) }
         .through(p)
-        .compile()
         .toList()
         .let { result ->
           result shouldBe listOfNotNull(result.firstOrNull()) + result.drop(1).filter { it != 0 }
@@ -283,7 +263,6 @@ class InterruptionTest : StreamSpec(spec = {
       .stream()
       .interruptScope()
       .append { Stream(5) }
-      .compile()
       .toList() shouldBe listOf(5)
   }
 
@@ -292,7 +271,6 @@ class InterruptionTest : StreamSpec(spec = {
       .interruptWhen { Right(sleep(20.milliseconds)) }
       .effectMap { never<Int>() }
       .append { Stream(5) }
-      .compile()
       .toList() shouldBe listOf(5)
   }
 
@@ -302,7 +280,6 @@ class InterruptionTest : StreamSpec(spec = {
     timeOutOrNull(500.milliseconds) {
       Stream.effect { guarantee(latch::get) { latch.complete(Unit) } }
         .interruptAfter(50.milliseconds)
-        .compile()
         .drain()
 
       latch.get()
@@ -312,7 +289,7 @@ class InterruptionTest : StreamSpec(spec = {
 
   "nested-interrupt" - {
     io.kotest.property.checkAll(500, Arb.stream(Arb.int())) { s ->
-      val expected = s.compile().toList()
+      val expected = s.toList()
 
       s.interruptWhen { Right(sleep(50.milliseconds)) }
         .map { None }
@@ -324,7 +301,6 @@ class InterruptionTest : StreamSpec(spec = {
             is Some -> Stream(Some(it.t))
           }
         }.filterOption()
-        .compile()
         .toList() shouldBe expected
     }
   }
@@ -333,7 +309,6 @@ class InterruptionTest : StreamSpec(spec = {
     Stream.effect { never<Unit>() }
       .interruptWhen { never() }
       .interruptWhen { Right(Unit) }
-      .compile()
       .toList() shouldBe emptyList()
   }
 
@@ -343,7 +318,6 @@ class InterruptionTest : StreamSpec(spec = {
       .append { Stream(1).delayBy(20.milliseconds) }
       .interruptWhen { Right(Unit) }
       .append { Stream(2) }
-      .compile()
       .toList() shouldBe listOf(2)
   }
 

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/InterruptionTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/InterruptionTest.kt
@@ -329,8 +329,7 @@ class InterruptionTest : StreamSpec(spec = {
       guaranteeCase({
         latch.complete(Unit)
         Stream.never<Unit>()
-          .compile()
-          .resource
+          .asResource()
           .drain()
           .use { Unit }
       }, { ex -> stop.complete(ex) })

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/PullTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/PullTest.kt
@@ -11,7 +11,6 @@ class PullTest : ArrowFxSpec(spec = {
   "pull can output chunks" {
     checkAll(Arb.chunk(Arb.int())) { ch ->
       Stream(Pull.output(ch))
-        .compile()
         .toList() shouldBe ch.toList()
     }
   }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ScopeTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ScopeTest.kt
@@ -41,7 +41,6 @@ class ScopeTest : ArrowFxSpec(spec = {
       }
     }
       .attempt()
-      .compile()
       .drain()
 
     buffer shouldBe (0..10).toList()
@@ -54,13 +53,11 @@ class ScopeTest : ArrowFxSpec(spec = {
       .flatMap { Stream.raiseError<Unit>(RuntimeException()) }
       .handleErrorWith { Stream.empty() }
       .append { events.recordBracketEvents(2) }
-      .compile()
       .drain()
 
     events.get() shouldBe listOf(Acquired(1), Released(1), Acquired(2), Released(2))
   }
 
-  // TODO Fix scoping
   "last scope extended, not all scopes - 1" {
     val st = Atomic(emptyList<String>())
 
@@ -105,7 +102,6 @@ class ScopeTest : ArrowFxSpec(spec = {
       .scope()
       .repeat()
       .take(4)
-      .compile()
       .drain()
 
     c.get() shouldBe 0
@@ -121,7 +117,6 @@ class ScopeTest : ArrowFxSpec(spec = {
     }
       .scope()
       .append { Stream.effect { counter.count() } }
-      .compile()
       .toList() shouldBe listOf(1, 1, 0)
   }
 
@@ -148,7 +143,6 @@ class ScopeTest : ArrowFxSpec(spec = {
       .foldMap(Stream.monoid(), Stream.Companion::resource)
       .effectTap { st.record("use") }
       .append { Stream.effect_ { st.record("done") } }
-      .compile()
       .drain()
 
     st.get() shouldBe listOf(
@@ -190,7 +184,6 @@ class ScopeTest : ArrowFxSpec(spec = {
       .foldMap(Stream.monoid(), Stream.Companion::resourceWeak)
       .effectTap { st.record("use") }
       .append { Stream.effect_ { st.record("done") } }
-      .compile()
       .drain()
 
     st.get() shouldBe listOf(

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ScopeTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ScopeTest.kt
@@ -64,8 +64,7 @@ class ScopeTest : ArrowFxSpec(spec = {
     Stream.just("start")
       .onFinalize { st.record("first finalize") }
       .onFinalize { st.record("second finalize") }
-      .compile()
-      .resource
+      .asResource()
       .lastOrError()
       .use { st.record(it) }
 
@@ -80,8 +79,7 @@ class ScopeTest : ArrowFxSpec(spec = {
         Stream.bracket({ "c" }, { st.record("third finalize") })
       }
     }
-      .compile()
-      .resource
+      .asResource()
       .lastOrError()
       .use { st.record(it) }
 

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -215,8 +215,7 @@ class StreamTest : StreamSpec(spec = {
   "filterNotNull" {
     checkAll(Arb.stream(Arb.int().orNull())) { s ->
       s.filterNotNull()
-        .compile()
-        .toList() shouldBe s.compile().toList().filterNotNull()
+        .toList() shouldBe s.toList().filterNotNull()
     }
   }
 

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -33,19 +33,17 @@ class StreamTest : StreamSpec(spec = {
   "constructors" - {
     "empty() is empty" {
       Stream.empty<Int>()
-        .compile()
         .toList() shouldBe emptyList()
     }
 
     "Stream.unit" {
       Stream.unit
-        .compile()
         .toList() shouldBe listOf(Unit)
     }
 
     "never() should timeout" {
       timeOutOrNull(10.milliseconds) {
-        Stream.never<Int>().compile().toList()
+        Stream.never<Int>().toList()
       } shouldBe null
     }
 
@@ -54,7 +52,6 @@ class StreamTest : StreamSpec(spec = {
         checkAll(Arb.throwable()) { e ->
           assertThrowable {
             Stream.raiseError<Int>(e)
-              .compile()
               .drain()
           } shouldBe e
         }
@@ -65,7 +62,6 @@ class StreamTest : StreamSpec(spec = {
           assertThrowable {
             Stream.just(1)
               .append { Stream.raiseError(e) }
-              .compile()
               .drain()
           } shouldBe e
         }
@@ -76,7 +72,6 @@ class StreamTest : StreamSpec(spec = {
           Stream.just(i)
             .append { Stream.raiseError(e) }
             .take(1)
-            .compile()
             .toList() shouldBe listOf(i)
         }
       }
@@ -86,7 +81,6 @@ class StreamTest : StreamSpec(spec = {
       checkAll(Arb.chunk(Arb.int())) { ch ->
         Stream.chunk(ch)
           .chunks()
-          .compile()
           .toList() shouldBe listOf(ch)
       }
     }
@@ -94,7 +88,6 @@ class StreamTest : StreamSpec(spec = {
     "effect" {
       checkAll(Arb.int()) { i ->
         Stream.effect { i }
-          .compile()
           .toList() shouldBe listOf(i)
       }
     }
@@ -103,7 +96,6 @@ class StreamTest : StreamSpec(spec = {
       checkAll(Arb.int()) { i ->
         var effect: Int? = null
         Stream.effect_ { effect = i }
-          .compile()
           .drain()
         effect shouldBe i
       }
@@ -112,7 +104,6 @@ class StreamTest : StreamSpec(spec = {
     "effectUnChunk" {
       checkAll(Arb.chunk(Arb.int())) { ch ->
         Stream.effectUnChunk { ch }
-          .compile()
           .toList() shouldBe ch.toList()
       }
     }
@@ -122,7 +113,6 @@ class StreamTest : StreamSpec(spec = {
         Stream.constant(i, n)
           .take(n * 2)
           .chunks()
-          .compile()
           .toList() shouldBe if (n == 0) emptyList() else listOf(Chunk(n) { i }, Chunk(n) { i })
       }
     }
@@ -130,7 +120,6 @@ class StreamTest : StreamSpec(spec = {
     "iterable" {
       checkAll(Arb.set(Arb.int())) { s ->
         Stream.iterable(s)
-          .compile()
           .toSet() shouldBe s
       }
     }
@@ -138,7 +127,6 @@ class StreamTest : StreamSpec(spec = {
     "iterate" {
       Stream.iterate(0, Int::inc)
         .take(100)
-        .compile()
         .toList() shouldBe (0..99).toList()
     }
 
@@ -148,14 +136,12 @@ class StreamTest : StreamSpec(spec = {
 
       Stream.iterateEffect(0) { it.increment() }
         .take(100)
-        .compile()
         .toList() shouldBe (0..99).toList()
     }
 
     "range(IntRange).toList() - IntRange.toList()" {
       checkAll(Arb.intRange(min = -500, max = 500)) { range ->
         Stream.range(range)
-          .compile()
           .toList() shouldBe range.toList()
       }
     }
@@ -163,7 +149,6 @@ class StreamTest : StreamSpec(spec = {
     "range(LongRange).toList() - LongRange.toList()" {
       checkAll(Arb.longRange(min = -500, max = 500)) { range ->
         Stream.range(range)
-          .compile()
           .toList() shouldBe range.toList()
       }
     }
@@ -171,7 +156,6 @@ class StreamTest : StreamSpec(spec = {
     "range(CharRange).toList() - CharRange.toList()" {
       checkAll(Arb.charRange()) { range ->
         Stream.range(range)
-          .compile()
           .toList() shouldBe range.toList()
       }
     }
@@ -181,7 +165,6 @@ class StreamTest : StreamSpec(spec = {
         if (f1 <= 13) Pair(Pair(f1, f2), Pair(f2, f1 + f2))
         else null
       }.map { it.first }
-        .compile()
         .toList() shouldBe listOf(0, 1, 1, 2, 3, 5, 8, 13)
     }
 
@@ -189,13 +172,11 @@ class StreamTest : StreamSpec(spec = {
       Stream.unfoldChunk(4L) { s ->
         if (s > 0) Pair(Chunk.longs(longArrayOf(s, s)), s - 1)
         else null
-      }.compile()
-        .toList() shouldBe listOf(4L, 4, 3, 3, 2, 2, 1, 1)
+      }.toList() shouldBe listOf(4L, 4, 3, 3, 2, 2, 1, 1)
     }
 
     "unfoldEffect" {
       Stream.unfoldEffect(10) { s -> if (s > 0) Pair(s, s - 1) else null }
-        .compile()
         .toList() shouldBe (10 downTo 1).toList()
     }
 
@@ -204,14 +185,12 @@ class StreamTest : StreamSpec(spec = {
         if (s) Pair(Chunk.booleans(booleanArrayOf(s)), false)
         else null
       }
-        .compile()
         .toList() shouldBe listOf(true)
     }
 
     "emits - array.toList()" {
       checkAll(Arb.list(Arb.int())) { ints ->
         Stream.emits(*ints.toTypedArray())
-          .compile()
           .toList() shouldBe ints
       }
     }
@@ -219,7 +198,6 @@ class StreamTest : StreamSpec(spec = {
     "invoke - array.toList()" {
       checkAll(Arb.list(Arb.int())) { ints ->
         Stream.emits(*ints.toTypedArray())
-          .compile()
           .toList() shouldBe ints
       }
     }
@@ -229,7 +207,6 @@ class StreamTest : StreamSpec(spec = {
         val n = n0 % 20
         Stream.random(seed)
           .take(n)
-          .compile()
           .toList() shouldBe Random(seed).run { List(max(n, 0)) { nextInt() } }
       }
     }
@@ -237,13 +214,13 @@ class StreamTest : StreamSpec(spec = {
 
   "append" {
     checkAll(Arb.stream(Arb.int()), Arb.stream(Arb.int())) { s1, s2 ->
-      s1.append { s2 }.compile().toList() shouldBe s1.compile().toList() + s2.compile().toList()
+      s1.append { s2 }.toList() shouldBe s1.toList() + s2.toList()
     }
   }
 
   "flatMap" {
     checkAll(Arb.stream(Arb.int()), Arb.stream(Arb.int())) { s1, s2 ->
-      s1.flatMap { s2 }.compile().toList() shouldBe s1.compile().toList().flatMap { s2.compile().toList() }
+      s1.flatMap { s2 }.toList() shouldBe s1.toList().flatMap { s2.toList() }
     }
   }
 
@@ -254,27 +231,25 @@ class StreamTest : StreamSpec(spec = {
 
         s
           .take(n)
-          .compile()
-          .toList() shouldBe s.compile().toList().take(max(n, 0))
+          .toList() shouldBe s.toList().take(max(n, 0))
       }
     }
 
     "takeLast" {
       checkAll(Arb.stream(Arb.int()), Arb.int(-10..1000)) { s, n0 ->
         val n = n0 % 20
-        s.takeLast(n).compile().toList() shouldBe s.compile().toList().takeLast(max(0, n))
+        s.takeLast(n).toList() shouldBe s.toList().takeLast(max(0, n))
       }
     }
 
     "takeWhile - identity" {
       checkAll(Arb.stream(Arb.int()), Arb.int(-10..1000)) { s, n0 ->
         val n = n0 % 20
-        val l = s.compile().toList()
+        val l = s.toList()
         val set = l.take(max(0, n)).toSet()
 
         s
           .takeWhile(set::contains)
-          .compile()
           .toList() shouldBe l.takeWhile(set::contains)
       }
     }
@@ -282,7 +257,7 @@ class StreamTest : StreamSpec(spec = {
     "takeThrough" {
       checkAll(Arb.stream(Arb.int()), Arb.positiveInts()) { s, n0 ->
         val n = n0 % 20 + 1
-        val l = s.compile().toList()
+        val l = s.toList()
         val isEven = { i: Int -> i % n == 0 }
 
         val head = l.takeWhile(isEven)
@@ -291,7 +266,6 @@ class StreamTest : StreamSpec(spec = {
 
         s
           .takeThrough(isEven)
-          .compile()
           .toList() shouldBe rhs
       }
     }
@@ -302,46 +276,43 @@ class StreamTest : StreamSpec(spec = {
       checkAll(Arb.stream(Arb.int().orNull()), Arb.int()) { s, n ->
         s
           .drop(n)
-          .compile()
-          .toList() shouldBe s.compile().toList().drop(max(n, 0))
+          .toList() shouldBe s.toList().drop(max(n, 0))
       }
     }
 
     "last" {
       checkAll(Arb.stream(Arb.int()), Arb.int(-10..1000)) { s, n0 ->
         val n = n0 % 10
-        s.dropLast(n).compile().toList() shouldBe s.compile().toList().dropLast(max(0, n))
+        s.dropLast(n).toList() shouldBe s.toList().dropLast(max(0, n))
       }
     }
 
     "tail" {
       checkAll(Arb.stream(Arb.int())) { s ->
-        s.tail().compile().toList() shouldBe s.compile().toList().drop(1)
+        s.tail().toList() shouldBe s.toList().drop(1)
       }
     }
 
     "dropWhile" {
       checkAll(Arb.stream(Arb.int()), Arb.int(-10..1000)) { s, n0 ->
-        val l = s.compile().toList()
+        val l = s.toList()
         val n = n0 % 10
         val set = l.take(max(0, n)).toSet()
 
         s.dropWhile(set::contains)
-          .compile()
           .toList() shouldBe l.dropWhile(set::contains)
       }
     }
 
     "dropThrough" {
       checkAll(Arb.stream(Arb.int()), Arb.positiveInts()) { s, n ->
-        val l = s.compile().toList()
+        val l = s.toList()
         val set = l.take(n).toSet()
 
         val expected = l.dropWhile(set::contains).drop(1)
 
         s
           .dropThrough(set::contains)
-          .compile()
           .toList() shouldBe expected
       }
     }
@@ -350,13 +321,13 @@ class StreamTest : StreamSpec(spec = {
   "chunk" - {
     "chunked" {
       val s = Stream(1, 2).append { Stream(3, 4) }
-      s.take(3).chunks().compile().toList() shouldBe listOf(Chunk(1, 2), Chunk(3))
+      s.take(3).chunks().toList() shouldBe listOf(Chunk(1, 2), Chunk(3))
     }
 
     "map identity" {
       checkAll(Arb.list(Arb.list(Arb.int()))) { lli ->
         val s = lli.foldMap(Stream.monoid<Int>()) { Stream.iterable(it) }
-        s.chunks().map { it.toList() }.compile().toList() shouldBe lli
+        s.chunks().map { it.toList() }.toList() shouldBe lli
       }
     }
 
@@ -364,28 +335,28 @@ class StreamTest : StreamSpec(spec = {
       checkAll(Arb.list(Arb.list(Arb.int()))) { lli ->
         val s =
           if (lli.isEmpty()) Stream.empty() else lli.map { Stream.iterable(it) }.reduce { a, b -> a.append { b } }
-        s.chunks().flatMap { Stream.chunk(it) }.compile().toList() shouldBe lli.flatten()
+        s.chunks().flatMap { Stream.chunk(it) }.toList() shouldBe lli.flatten()
       }
     }
 
     "chunkLimit" {
       checkAll(Arb.stream(Arb.int()), Arb.positiveInts()) { s, n0 ->
         val n = n0 % 20 + 1
-        val sizes = s.chunkLimit(n).compile().toList().map { it.size() }
+        val sizes = s.chunkLimit(n).toList().map { it.size() }
         sizes.all { it <= n } shouldBe true
-        sizes.combineAll(Int.monoid()) shouldBe s.compile().toList().size
+        sizes.combineAll(Int.monoid()) shouldBe s.toList().size
       }
     }
 
     "chunkMin" {
       checkAll(Arb.stream(Arb.int()), Arb.int()) { s, n0 ->
         val n = n0 % 20 + 1
-        val chunked = s.chunkMin(n, true).compile().toList()
-        val chunkedSmaller = s.chunkMin(n, false).compile().toList()
-        val unchunked = s.compile().toList()
-        val smallerSet = s.take(n - 1).compile().toList()
-        val smallerN = s.take(n - 1).chunkMin(n, false).compile().toList()
-        val smallerY = s.take(n - 1).chunkMin(n, true).compile().toList()
+        val chunked = s.chunkMin(n, true).toList()
+        val chunkedSmaller = s.chunkMin(n, false).toList()
+        val unchunked = s.toList()
+        val smallerSet = s.take(n - 1).toList()
+        val smallerN = s.take(n - 1).chunkMin(n, false).toList()
+        val smallerY = s.take(n - 1).chunkMin(n, true).toList()
         // All but last list have n values
         chunked.dropLast(1).all { it.size() >= n }
         // Equivalent to last chunk with allowFewerTotal
@@ -406,7 +377,6 @@ class StreamTest : StreamSpec(spec = {
   "repartition" {
     Stream("Hel", "l", "o Wor", "ld")
       .repartition(String.semigroup()) { s -> Chunk.iterable(s.split(" ")) }
-      .compile()
       .toList() shouldBe listOf("Hello", "World")
   }
 
@@ -415,8 +385,7 @@ class StreamTest : StreamSpec(spec = {
       checkAll(Arb.stream(Arb.int()), Arb.positiveInts()) { s, n ->
         s
           .buffer(n)
-          .compile()
-          .toList() shouldBe s.compile().toList()
+          .toList() shouldBe s.toList()
       }
     }
 
@@ -428,7 +397,6 @@ class StreamTest : StreamSpec(spec = {
         s2.effectMap { i -> counter += 1; i }
           .buffer(n)
           .take(n + 1)
-          .compile()
           .drain()
 
         counter shouldBe (n * 2)
@@ -440,14 +408,13 @@ class StreamTest : StreamSpec(spec = {
     "identity" {
       checkAll(Arb.stream(Arb.int())) { s ->
         s.bufferAll()
-          .compile()
-          .toList() shouldBe s.compile().toList()
+          .toList() shouldBe s.toList()
       }
     }
 
     "buffers results of effectMap" {
       checkAll(Arb.stream(Arb.int())) { s ->
-        val size = s.compile().toList().size
+        val size = s.toList().size
         val expected = size * 2
         var counter = 0
 
@@ -455,7 +422,6 @@ class StreamTest : StreamSpec(spec = {
           .effectMap { i -> counter += 1; i }
           .bufferAll()
           .take(size + 1)
-          .compile()
           .drain()
 
         counter shouldBe expected
@@ -467,14 +433,13 @@ class StreamTest : StreamSpec(spec = {
     "identity" {
       checkAll(Arb.stream(Arb.int())) { s ->
         s.bufferBy { it >= 0 }
-          .compile()
-          .toList() shouldBe s.compile().toList()
+          .toList() shouldBe s.toList()
       }
     }
 
     "buffers results of effectMap" {
       checkAll(Arb.stream(Arb.int())) { s ->
-        val size = s.compile().toList().size
+        val size = s.toList().size
         val expected = size * 2 + 1
         var counter = 0
 
@@ -488,7 +453,6 @@ class StreamTest : StreamSpec(spec = {
 
         s3.bufferBy { it >= 0 }
           .take(size + 2)
-          .compile()
           .drain()
 
         counter shouldBe expected
@@ -501,7 +465,6 @@ class StreamTest : StreamSpec(spec = {
       checkAll(Arb.throwable(), Arb.int()) { e, i ->
         Stream.raiseError<Int>(e)
           .handleErrorWith { Stream.just(i) }
-          .compile()
           .toList() shouldBe listOf(i)
       }
     }
@@ -511,7 +474,6 @@ class StreamTest : StreamSpec(spec = {
         val effect = SideEffect()
         Stream.just(i)
           .handleErrorWith { Stream.effect { effect.increment() } }
-          .compile()
           .toList() shouldBe listOf(i)
 
         effect.counter shouldBe 0
@@ -525,7 +487,6 @@ class StreamTest : StreamSpec(spec = {
 
       infinite
         .take(n)
-        .compile()
         .toList() shouldBe List(n) { i }
     }
   }
@@ -533,21 +494,18 @@ class StreamTest : StreamSpec(spec = {
   "terminateOn" {
     Stream(1, 2, 3, 4)
       .terminateOn { it % 3 == 0 }
-      .compile()
       .toList() shouldBe listOf(1, 2)
   }
 
   "terminateOnNull" {
     Stream(1, 2, null, 4)
       .terminateOnNull()
-      .compile()
       .toList() shouldBe listOf(1, 2)
   }
 
   "terminateOnNone" {
     Stream(Some(1), Some(2), None, Some(4))
       .terminateOnNone()
-      .compile()
       .toList() shouldBe listOf(1, 2)
   }
 })

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
@@ -7,7 +7,6 @@ import arrow.fx.coroutines.StreamSpec
 import arrow.fx.coroutines.milliseconds
 import arrow.fx.coroutines.stream.Stream
 import arrow.fx.coroutines.stream.append
-import arrow.fx.coroutines.stream.compile
 import arrow.fx.coroutines.stream.noneTerminate
 import arrow.fx.coroutines.stream.parJoinUnbounded
 import arrow.fx.coroutines.stream.terminateOnNone


### PR DESCRIPTION
Removes `TerminalOps` in favor of more precises signatures.

Closes #245.