### PR TITLE
Fix package name

### DIFF
--- a/arrow-fx-coroutines-kotlinx-coroutines/gradle.properties
+++ b/arrow-fx-coroutines-kotlinx-coroutines/gradle.properties
@@ -1,4 +1,4 @@
 # Maven publishing configuration
-POM_NAME=Arrow-Fx-Coroutines-KotlinX
-POM_ARTIFACT_ID=arrow-fx-coroutines-kotlinx
+POM_NAME=Arrow-Fx-Coroutines-KotlinX-Coroutines
+POM_ARTIFACT_ID=arrow-fx-coroutines-kotlinx-coroutines
 POM_PACKAGING=jar


### PR DESCRIPTION
It fixes the package name when following these changes:

* https://github.com/arrow-kt/arrow-fx/pull/257/commits/5ee1c406ce5b0c85856000d1b118cd333659bd14
* https://github.com/arrow-kt/arrow/commit/a7ce2a2c56f81f8cb2645f5b8f91b18eb8751f8f

I realized about it after checking the deployment.