### PR TITLE
Result doesn't need to be nullable

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
@@ -84,7 +84,7 @@ suspend fun <O> Stream<O>.lastOrNull(): O? =
   foldChunks<O, O?>(null) { acc, c -> c.lastOrNull() ?: acc }
 
 /**
- * Runs all the effects of this [Stream], raising a [NoSuchElementException] if the stream emitted no values
+ * Runs all the effects of this [Stream], raising a [NoSuchElementException] if the stream emitted no values,
  * and returning the last value emitted otherwise.
  *
  * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/TerminalOps.kt
@@ -59,7 +59,7 @@ suspend fun <O> Stream<O>.firstOrNull(): O? =
  * This a terminal operator, meaning this functions `suspend`s until the [Stream] finishes.
  * If any errors are raised while streaming, it's thrown from this `suspend` scope.
  */
-suspend fun <O> Stream<O>.firstOrError(): O? =
+suspend fun <O> Stream<O>.firstOrError(): O =
   firstOrNull() ?: throw NoSuchElementException()
 
 /**


### PR DESCRIPTION
In the terminal operation `firstOrError` we return `O?`. However, there is possible way to return null as we throw an instance of `NoSuchElementException`.