### PR TITLE
Fix flaky test with empty stream

### DIFF
--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ConcurrentlyTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ConcurrentlyTest.kt
@@ -64,9 +64,10 @@ class ConcurrentlyTest : StreamSpec(spec = {
     }
 
     "when background stream fails, primary stream fails even when hung" {
-      checkAll(Arb.stream(Arb.int()), Arb.throwable()) { s, e ->
+      checkAll(Arb.int(), Arb.stream(Arb.int()), Arb.throwable()) { i, s, e ->
         assertThrowable {
-          s.concurrently(Stream.raiseError<Unit>(e))
+          Stream(i).append { s }
+            .concurrently(Stream.raiseError<Unit>(e))
             .effectTap { never() }
             .drain()
         } shouldBe e


### PR DESCRIPTION
We test that if the `concurrently` launched fiber fails, it also fails the parent `Stream`.
When the parent `Stream` finishes it also cancels the `concurrently` launched `Stream`.

In the case that the parent `Stream` is empty, it's possible that the fiber gets canceled before it got a chance to be scheduled. This makes the test fail since it results in `Unit` instead of a failure.