### PR TITLE
Fix computation block in parTraverse

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt
@@ -195,7 +195,7 @@ suspend fun <A, B, E> Iterable<A>.parTraverseEither(
 ): Either<E, List<B>> =
   either {
     coroutineScope {
-      map { async(ctx) { !f.invoke(it) } }.awaitAll()
+      map { async(ctx) { f.invoke(it)() } }.awaitAll()
     }
   }
 


### PR DESCRIPTION
Fixes:

 > e: /arrow-fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt: (196, 3): Type mismatch: inferred type is Either<E, List<Unit>> but Either<E, List<B>> was expected
e: /arrow-fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt: (197, 5): Type mismatch: inferred type is List<Unit> but List<B> was expected
e: /arrow-fx/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt: (198, 26): Unresolved reference: !
