### PR TITLE
Deprecate parTraverseN/parSequenceN with semaphore limit as Long

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,15 @@
+## Issue
+[n](https://github.com/arrow-kt/arrow-fx/issues/n)
+
+## Status
+**READY/IN DEVELOPMENT/HOLD**
+
+## Description
+<!-- A few sentences describing the overall goals of the pull request's commits. -->
+
+## Todos
+- [ ] Tests
+- [ ] Documentation
+
+## Related PRs
+* None


### PR DESCRIPTION
## Issue
[324](https://github.com/arrow-kt/arrow-fx/issues/324)

## Status
**READY**

## Description
The current apis parTraverseN and parSequenceN use semaphore limit as `Long` type, and convert to `Int` which can lead to overflow issue. 

This pr deprecates these methods, sets a validation check to fail the api if limit is more than `Int` range, and introduces new apis that takes limit as `Int` type.

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
Would like help on if I need to do something about deploying @nomisRev 

## Related PRs
* None