### PR TITLE
Deprecate @higherkind & @extension for Either

### DIFF
--- a/arrow-fx-coroutines-stream/src/main/kotlin/arrow/fx/coroutines/stream/Scope.kt
+++ b/arrow-fx-coroutines-stream/src/main/kotlin/arrow/fx/coroutines/stream/Scope.kt
@@ -404,7 +404,7 @@ class Scope private constructor(
     when (interruptible) {
       null -> Either.catch { f() }.mapLeft { it.left() }
       else -> {
-        val res = raceN({ interruptible.deferred.get() }, { Either.catch(f) })
+        val res = raceN({ interruptible.deferred.get() }, { Either.catch { f() } })
         when (res) {
           is Either.Right -> res.b.mapLeft { it.left() }
           is Either.Left -> Either.Left(res.a)

--- a/arrow-fx-coroutines-stream/src/main/kotlin/arrow/fx/coroutines/stream/Scope.kt
+++ b/arrow-fx-coroutines-stream/src/main/kotlin/arrow/fx/coroutines/stream/Scope.kt
@@ -172,7 +172,7 @@ class Scope private constructor(
     val job = coroutineContext[Job]
     val scope = ScopedResource()
     val release: suspend (R, ExitCase) -> Unit = { r, ex -> withContext(NonCancellable) { release(r, ex) } }
-    Either.catch(fr).flatMap { resource ->
+    Either.catch { fr() }.flatMap { resource ->
       scope.acquired { ex: ExitCase -> release(resource, ex) }.map { registered ->
         state.modify {
           if ((conn.isCancelled() || job?.isCancelled == true) && registered) Pair(it, suspend { release(resource, ExitCase.Cancelled(CancellationException())) })
@@ -402,7 +402,7 @@ class Scope private constructor(
    */ // TODO return Pull.Result here, only usage in `Compiler` reconstructs into Pull.Result
   internal suspend fun <A> interruptibleEval(f: suspend () -> A): Either<Either<Throwable, Token>, A> =
     when (interruptible) {
-      null -> Either.catch(f).mapLeft { it.left() }
+      null -> Either.catch { f() }.mapLeft { it.left() }
       else -> {
         val res = raceN({ interruptible.deferred.get() }, { Either.catch(f) })
         when (res) {

--- a/arrow-fx-coroutines-test/src/main/kotlin/arrow/fx/coroutines/predef-test.kt
+++ b/arrow-fx-coroutines-test/src/main/kotlin/arrow/fx/coroutines/predef-test.kt
@@ -31,7 +31,6 @@ import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.intercepted
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.startCoroutine
 
 data class SideEffect(var counter: Int = 0) {
@@ -168,26 +167,6 @@ suspend fun <A> A.suspend(): A =
   }
 
 fun <A> A.suspended(): suspend () -> A =
-  suspend { suspend() }
-
-suspend fun <A> Either<Throwable, A>.suspend(): A =
-  suspendCoroutineUninterceptedOrReturn { cont ->
-    suspend { this }.startCoroutine(Continuation(ComputationPool) {
-      it.fold(
-        {
-          it.fold(
-            { e -> cont.intercepted().resumeWithException(e) },
-            { a -> cont.intercepted().resume(a) }
-          )
-        },
-        { e -> cont.intercepted().resumeWithException(e) }
-      )
-    })
-
-    COROUTINE_SUSPENDED
-  }
-
-fun <A> Either<Throwable, A>.suspended(): suspend () -> A =
   suspend { suspend() }
 
 /**

--- a/arrow-fx-coroutines-test/src/main/kotlin/arrow/fx/coroutines/predef-test.kt
+++ b/arrow-fx-coroutines-test/src/main/kotlin/arrow/fx/coroutines/predef-test.kt
@@ -108,12 +108,6 @@ fun <A> catchSystemErrInto(outStream: OutputStream, thunk: () -> A): A {
 fun Arb.Companion.throwable(): Arb<Throwable> =
   Arb.string().map(::RuntimeException)
 
-fun <A> Arb.Companion.result(right: Arb<A>): Arb<Result<A>> {
-  val failure: Arb<Result<A>> = Arb.throwable().map { e -> Result.failure<A>(e) }
-  val success: Arb<Result<A>> = right.map { a -> Result.success(a) }
-  return Arb.choice(failure, success)
-}
-
 fun <L, R> Arb.Companion.either(left: Arb<L>, right: Arb<R>): Arb<Either<L, R>> {
   val failure: Arb<Either<L, R>> = left.map { l -> l.left() }
   val success: Arb<Either<L, R>> = right.map { r -> r.right() }

--- a/arrow-fx-coroutines-test/src/test/kotlin/arrow/fx/coroutines/PredefTest.kt
+++ b/arrow-fx-coroutines-test/src/test/kotlin/arrow/fx/coroutines/PredefTest.kt
@@ -1,7 +1,5 @@
 package arrow.fx.coroutines
 
-import arrow.core.Either
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
@@ -24,23 +22,6 @@ class PredefTest : ArrowFxSpec(spec = {
 
       x shouldBe COROUTINE_SUSPENDED
       promise.join() shouldBe i
-    }
-  }
-
-  "either.suspended always suspends" {
-    checkAll(Arb.either(Arb.throwable(), Arb.int())) { ea ->
-      val promise = UnsafePromise<Int>()
-
-      val x = ea.suspended()
-        .startCoroutineUninterceptedOrReturn(Continuation(EmptyCoroutineContext) {
-          promise.complete(it)
-        })
-
-      x shouldBe COROUTINE_SUSPENDED
-
-      Either.catch {
-        promise.join()
-      } should either(ea)
     }
   }
 

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
@@ -40,17 +40,21 @@ class CancellableF : ArrowFxSpec(spec = {
 
   "cancelableF works for immediate values" {
     checkAll(Arb.either(Arb.throwable(), Arb.int())) { res ->
-      Either.catch {
+      val res = Either.catch {
         immediateValues(res)
-      } should either(res)
+      }
+      res.mapLeft { it.printStackTrace() }
+      res should either(res)
     }
   }
 
   "cancelableF works for async values" {
     checkAll(Arb.either(Arb.throwable(), Arb.int())) { res ->
-      Either.catch {
+      val res = Either.catch {
         asyncValues(res)
-      } should either(res)
+      }
+      res.mapLeft { it.printStackTrace() }
+      res should either(res)
     }
   }
 

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
@@ -11,13 +11,16 @@ import kotlinx.coroutines.launch
 class CancellableF : ArrowFxSpec(spec = {
 
   "cancelable works for immediate values" {
-    checkAll(Arb.result(Arb.int())) { res ->
+    checkAll(Arb.either(Arb.throwable(), Arb.int())) { res ->
       Either.catch {
         cancellable<Int> { cb ->
-          cb(res)
+          res.fold(
+            { e -> cb(Result.failure(e)) },
+            { a -> cb(Result.success(a)) }
+          )
           CancelToken.unit
         }
-      } shouldBe res.toEither()
+      } should either(res)
     }
   }
 
@@ -43,7 +46,6 @@ class CancellableF : ArrowFxSpec(spec = {
       val res = Either.catch {
         immediateValues(res)
       }
-      res.mapLeft { it.printStackTrace() }
       res should either(res)
     }
   }
@@ -53,7 +55,6 @@ class CancellableF : ArrowFxSpec(spec = {
       val res = Either.catch {
         asyncValues(res)
       }
-      res.mapLeft { it.printStackTrace() }
       res should either(res)
     }
   }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
@@ -1,6 +1,7 @@
 package arrow.fx.coroutines
 
 import arrow.core.Either
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
@@ -47,7 +48,7 @@ class CancellableF : ArrowFxSpec(spec = {
           )
           CancelToken.unit
         }
-      } shouldBe res
+      } should either(res)
     }
   }
 
@@ -62,7 +63,7 @@ class CancellableF : ArrowFxSpec(spec = {
           )
           CancelToken.unit
         }
-      } shouldBe res
+      } should either(res)
     }
   }
 

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
@@ -38,25 +38,31 @@ class CancellableF : ArrowFxSpec(spec = {
   }
 
   "cancelableF works for immediate values" {
-    checkAll(Arb.result(Arb.int())) { res ->
+    checkAll(Arb.either(Arb.throwable(), Arb.int())) { res ->
       Either.catch {
         cancellableF<Int> { cb ->
-          cb(res)
+          res.fold(
+            { e -> cb(Result.failure(e)) },
+            { i -> cb(Result.success(i)) }
+          )
           CancelToken.unit
         }
-      } shouldBe res.toEither()
+      } shouldBe res
     }
   }
 
   "cancelableF works for async values" {
-    checkAll(Arb.result(Arb.int())) { res ->
+    checkAll(Arb.either(Arb.throwable(), Arb.int())) { res ->
       Either.catch {
         cancellableF<Int> { cb ->
           val res = res.suspend()
-          cb(res)
+          res.fold(
+            { e -> cb(Result.failure(e)) },
+            { i -> cb(Result.success(i)) }
+          )
           CancelToken.unit
         }
-      } shouldBe res.toEither()
+      } shouldBe res
     }
   }
 


### PR DESCRIPTION
By replacing `suspend fun catch` with `inline fun catch` in https://github.com/arrow-kt/arrow-core/pull/272, you cannot pass `suspend` lambdas anymore.