### PR TITLE
Complete parTraverse ops for Either and Validated

### DIFF
--- a/arrow-fx-coroutines-test/src/main/kotlin/arrow/fx/coroutines/predef-test.kt
+++ b/arrow-fx-coroutines-test/src/main/kotlin/arrow/fx/coroutines/predef-test.kt
@@ -1,9 +1,15 @@
 package arrow.fx.coroutines
 
 import arrow.core.Either
+import arrow.core.Validated
+import arrow.core.ValidatedNel
 import arrow.core.identity
+import arrow.core.invalid
+import arrow.core.invalidNel
 import arrow.core.left
 import arrow.core.right
+import arrow.core.valid
+import arrow.core.validNel
 import io.kotest.assertions.fail
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
@@ -118,6 +124,18 @@ fun <A> Arb.Companion.result(right: Arb<A>): Arb<Result<A>> {
 fun <L, R> Arb.Companion.either(left: Arb<L>, right: Arb<R>): Arb<Either<L, R>> {
   val failure: Arb<Either<L, R>> = left.map { l -> l.left() }
   val success: Arb<Either<L, R>> = right.map { r -> r.right() }
+  return Arb.choice(failure, success)
+}
+
+fun <L, R> Arb.Companion.validated(left: Arb<L>, right: Arb<R>): Arb<Validated<L, R>> {
+  val failure: Arb<Validated<L, R>> = left.map { l -> l.invalid() }
+  val success: Arb<Validated<L, R>> = right.map { r -> r.valid() }
+  return Arb.choice(failure, success)
+}
+
+fun <L, R> Arb.Companion.validatedNel(left: Arb<L>, right: Arb<R>): Arb<ValidatedNel<L, R>> {
+  val failure: Arb<ValidatedNel<L, R>> = left.map { l -> l.invalidNel() }
+  val success: Arb<ValidatedNel<L, R>> = right.map { r -> r.validNel() }
   return Arb.choice(failure, success)
 }
 

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverse.kt
@@ -1,12 +1,7 @@
+@file:JvmMultifileClass
+@file:JvmName("ParTraverse")
 package arrow.fx.coroutines
 
-import arrow.core.Either
-import arrow.core.Validated
-import arrow.core.ap
-import arrow.core.computations.either
-import arrow.core.identity
-import arrow.core.valid
-import arrow.typeclasses.Semigroup
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -238,44 +233,3 @@ suspend fun <A, B> Iterable<A>.parTraverse(
 ): List<B> = coroutineScope {
   map { async(ctx) { f.invoke(it) } }.awaitAll()
 }
-
-suspend fun <A, B, E> Iterable<A>.parTraverseEither(
-  f: suspend (A) -> Either<E, B>
-): Either<E, List<B>> =
-  parTraverseEither(Dispatchers.Default, f)
-
-suspend fun <A, B, E> Iterable<A>.parTraverseEither(
-  ctx: CoroutineContext = EmptyCoroutineContext,
-  f: suspend (A) -> Either<E, B>
-): Either<E, List<B>> =
-  either {
-    coroutineScope {
-      map { async(ctx) { f.invoke(it)() } }.awaitAll()
-    }
-  }
-
-suspend fun <A, B, E> Iterable<A>.parTraverseValidated(
-  semigroup: Semigroup<E>,
-  f: suspend (A) -> Validated<E, B>
-): Validated<E, List<B>> =
-  parTraverseValidated(Dispatchers.Default, semigroup, f)
-
-suspend fun <A, B, E> Iterable<A>.parTraverseValidated(
-  ctx: CoroutineContext = EmptyCoroutineContext,
-  semigroup: Semigroup<E>,
-  f: suspend (A) -> Validated<E, B>
-): Validated<E, List<B>> =
-  coroutineScope {
-    map { async(ctx) { f.invoke(it) } }.awaitAll()
-      .sequence(semigroup)
-  }
-
-@PublishedApi // TODO should be in Arrow Core
-internal inline fun <E, A, B> Iterable<A>.traverse(semigroup: Semigroup<E>, f: (A) -> Validated<E, B>): Validated<E, List<B>> =
-  fold(emptyList<B>().valid() as Validated<E, List<B>>) { acc, a ->
-    f(a).ap(semigroup, acc.map { bs: List<B> -> { b: B -> bs + b } })
-  }
-
-@PublishedApi // TODO should be in Arrow Core
-internal fun <E, A> Iterable<Validated<E, A>>.sequence(semigroup: Semigroup<E>): Validated<E, List<A>> =
-  traverse(semigroup, ::identity)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverseEither.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverseEither.kt
@@ -1,0 +1,173 @@
+@file:JvmMultifileClass
+@file:JvmName("ParTraverse")
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import arrow.core.computations.either
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Sequences all tasks in [n] parallel processes on [Dispatchers.Default] and return the result.
+ *
+ * Cancelling this operation cancels all running tasks
+ */
+suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEitherN(n: Int): Either<A, List<B>> =
+  parTraverseEitherN(Dispatchers.Default, n) { it() }
+
+/**
+ * Sequences all tasks in [n] parallel processes on [ctx] and return the result.
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor], this function will not run in parallel.
+ *
+ * Cancelling this operation cancels all running tasks
+ */
+suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEitherN(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  n: Int
+): Either<A, List<B>> =
+  parTraverseEitherN(ctx, n) { it() }
+
+/**
+ * Sequences all tasks in parallel on [Dispatchers.Default] and return the result.
+ * If one of the tasks returns [Either.Left], then it will short-circuit the operation and
+ * cancelling all this running tasks, and returning the first encountered [Either.Left].
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEither(): Either<A, List<B>> =
+  parTraverseEither(Dispatchers.Default) { it() }
+
+/**
+ * Sequences all tasks in parallel on [ctx] and return the result.
+ * If one of the tasks returns [Either.Left], then it will short-circuit the operation and
+ * cancelling all this running tasks, and returning the first encountered [Either.Left].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor], this function will not run in parallel.
+ *
+ * Cancelling this operation cancels all running tasks.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ * import kotlinx.coroutines.Dispatchers
+ *
+ * typealias Task = suspend () -> Unit
+ *
+ * suspend fun main(): Unit {
+ *   //sampleStart
+ *   fun getTask(id: Int): Task =
+ *     suspend { println("Working on task $id on ${Thread.currentThread().name}") }
+ *
+ *   val res = listOf(1, 2, 3)
+ *     .map(::getTask)
+ *     .parSequenceEither(Dispatchers.IO)
+ *   //sampleEnd
+ *   println(res)
+ * }
+ * ```
+ */
+suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEither(
+  ctx: CoroutineContext = EmptyCoroutineContext
+): Either<A, List<B>> =
+  parTraverseEither(ctx) { it() }
+
+/**
+ * Traverses this [Iterable] and runs [f] in [n] parallel operations on [Dispatchers.Default].
+ * If one of the [f] returns [Either.Left], then it will short-circuit the operation and
+ * cancelling all this running [f], and returning the first encountered [Either.Left].
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <A, B, E> Iterable<A>.parTraverseEitherN(
+  n: Int,
+  f: suspend (A) -> Either<E, B>
+): Either<E, List<B>> =
+  parTraverseEitherN(Dispatchers.Default, n, f)
+
+/**
+ * Traverses this [Iterable] and runs [f] in [n] parallel operations on [Dispatchers.Default].
+ * If one of the [f] returns [Either.Left], then it will short-circuit the operation and
+ * cancelling all this running [f], and returning the first encountered [Either.Left].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor], this function will not run in parallel.
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <A, B, E> Iterable<A>.parTraverseEitherN(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  n: Int,
+  f: suspend (A) -> Either<E, B>
+): Either<E, List<B>> {
+  val semaphore = Semaphore(n)
+  return parTraverseEither(ctx) { a ->
+    semaphore.withPermit { f(a) }
+  }
+}
+
+/**
+ * Traverses this [Iterable] and runs all mappers [f] on [Dispatchers.Default].
+ * If one of the [f] returns [Either.Left], then it will short-circuit the operation and
+ * cancelling all this running [f], and returning the first encountered [Either.Left].
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <A, B, E> Iterable<A>.parTraverseEither(
+  f: suspend (A) -> Either<E, B>
+): Either<E, List<B>> =
+  parTraverseEither(Dispatchers.Default, f)
+
+/**
+ * Traverses this [Iterable] and runs all mappers [f] on [CoroutineContext].
+ * If one of the [f] returns [Either.Left], then it will short-circuit the operation and
+ * cancelling all this running [f], and returning the first encountered [Either.Left].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor], this function will not run in parallel.
+ *
+ * Cancelling this operation cancels all running tasks.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ * import arrow.fx.coroutines.*
+ * import kotlinx.coroutines.Dispatchers
+ *
+ * object Error
+ * data class User(val id: Int, val createdOn: String)
+ *
+ * suspend fun main(): Unit {
+ *   //sampleStart
+ *   suspend fun getUserById(id: Int): Either<Error, User> =
+ *     if(id == 2) Error.left()
+ *     else User(id, Thread.currentThread().name).right()
+ *
+ *   val res = listOf(1, 2, 3)
+ *     .parTraverseEither(Dispatchers.IO, ::getUserById)
+ *  //sampleEnd
+ *  println(res)
+ * }
+ * ```
+ */
+suspend fun <A, B, E> Iterable<A>.parTraverseEither(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  f: suspend (A) -> Either<E, B>
+): Either<E, List<B>> =
+  either {
+    coroutineScope {
+      map { async(ctx) { f.invoke(it)() } }.awaitAll()
+    }
+  }

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverseEither.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverseEither.kt
@@ -60,15 +60,17 @@ suspend fun <A, B> Iterable<suspend () -> Either<A, B>>.parSequenceEither(): Eit
  * Cancelling this operation cancels all running tasks.
  *
  * ```kotlin:ank:playground
+ * import arrow.core.*
  * import arrow.fx.coroutines.*
  * import kotlinx.coroutines.Dispatchers
  *
- * typealias Task = suspend () -> Unit
+ * object Error
+ * typealias Task = suspend () -> Either<Throwable, Unit>
  *
  * suspend fun main(): Unit {
  *   //sampleStart
  *   fun getTask(id: Int): Task =
- *     suspend { println("Working on task $id on ${Thread.currentThread().name}") }
+ *     suspend { Either.catch { println("Working on task $id on ${Thread.currentThread().name}") } }
  *
  *   val res = listOf(1, 2, 3)
  *     .map(::getTask)
@@ -152,13 +154,17 @@ suspend fun <A, B, E> Iterable<A>.parTraverseEither(
  * suspend fun main(): Unit {
  *   //sampleStart
  *   suspend fun getUserById(id: Int): Either<Error, User> =
- *     if(id == 2) Error.left()
+ *     if(id == 4) Error.left()
  *     else User(id, Thread.currentThread().name).right()
  *
  *   val res = listOf(1, 2, 3)
  *     .parTraverseEither(Dispatchers.IO, ::getUserById)
+ *
+ *   val res2 = listOf(1, 4, 2, 3)
+ *     .parTraverseEither(Dispatchers.IO, ::getUserById)
  *  //sampleEnd
  *  println(res)
+ *  println(res2)
  * }
  * ```
  */

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverseValidated.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverseValidated.kt
@@ -1,0 +1,188 @@
+@file:JvmMultifileClass
+@file:JvmName("ParTraverse")
+
+package arrow.fx.coroutines
+
+import arrow.core.Validated
+import arrow.core.ap
+import arrow.core.identity
+import arrow.core.valid
+import arrow.typeclasses.Semigroup
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Traverses this [Iterable] and runs [f] in [n] parallel operations on [CoroutineContext].
+ * If one or more of the tasks returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceValidatedN(semigroup: Semigroup<E>, n: Int): Validated<E, List<A>> =
+  parTraverseValidatedN(Dispatchers.Default, semigroup, n) { it() }
+
+/**
+ * Traverses this [Iterable] and runs [f] in [n] parallel operations on [CoroutineContext].
+ * If one or more of the tasks returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor], this function will not run in parallel.
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceValidatedN(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  semigroup: Semigroup<E>,
+  n: Int
+): Validated<E, List<A>> =
+  parTraverseValidatedN(ctx, semigroup, n) { it() }
+
+/**
+ * Traverses this [Iterable] and runs [f] in [n] parallel operations on [Dispatchers.Default].
+ * If one or more of the [f] returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <E, A, B> Iterable<A>.parTraverseValidatedN(
+  semigroup: Semigroup<E>,
+  n: Int,
+  f: suspend (A) -> Validated<E, B>
+): Validated<E, List<B>> =
+  parTraverseValidatedN(Dispatchers.Default, semigroup, n, f)
+
+/**
+ * Traverses this [Iterable] and runs [f] in [n] parallel operations on [CoroutineContext].
+ * If one or more of the [f] returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor], this function will not run in parallel.
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <E, A, B> Iterable<A>.parTraverseValidatedN(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  semigroup: Semigroup<E>,
+  n: Int,
+  f: suspend (A) -> Validated<E, B>
+): Validated<E, List<B>> {
+  val semaphore = Semaphore(n)
+  return parTraverseValidated(ctx, semigroup) { a ->
+    semaphore.withPermit { f(a) }
+  }
+}
+
+/**
+ * Sequences all tasks in parallel on [Dispatchers.Default] and return the result.
+ * If one or more of the tasks returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceEither(semigroup: Semigroup<E>): Validated<E, List<A>> =
+  parTraverseValidated(Dispatchers.Default, semigroup) { it() }
+
+/**
+ * Sequences all tasks in parallel on [ctx] and return the result.
+ * If one or more of the tasks returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor], this function will not run in parallel.
+ *
+ * Cancelling this operation cancels all running tasks.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ * import kotlinx.coroutines.Dispatchers
+ *
+ * typealias Task = suspend () -> Unit
+ *
+ * suspend fun main(): Unit {
+ *   //sampleStart
+ *   fun getTask(id: Int): Task =
+ *     suspend { println("Working on task $id on ${Thread.currentThread().name}") }
+ *
+ *   val res = listOf(1, 2, 3)
+ *     .map(::getTask)
+ *     .parSequenceEither(Dispatchers.IO)
+ *   //sampleEnd
+ *   println(res)
+ * }
+ * ```
+ */
+suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceValidated(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  semigroup: Semigroup<E>
+): Validated<E, List<A>> =
+  parTraverseValidated(ctx, semigroup) { it() }
+
+/**
+ * Traverses this [Iterable] and runs all mappers [f] on [Dispatchers.Default].
+ * If one or more of the [f] returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
+ *
+ * Cancelling this operation cancels all running tasks.
+ */
+suspend fun <E, A, B> Iterable<A>.parTraverseValidated(
+  semigroup: Semigroup<E>,
+  f: suspend (A) -> Validated<E, B>
+): Validated<E, List<B>> =
+  parTraverseValidated(Dispatchers.Default, semigroup, f)
+
+/**
+ * Traverses this [Iterable] and runs all mappers [f] on [CoroutineContext].
+ * If one or more of the [f] returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor], this function will not run in parallel.
+ *
+ * Cancelling this operation cancels all running tasks.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.core.*
+ * import arrow.fx.coroutines.*
+ * import kotlinx.coroutines.Dispatchers
+ *
+ * object Error
+ * data class User(val id: Int, val createdOn: String)
+ *
+ * suspend fun main(): Unit {
+ *   //sampleStart
+ *   suspend fun getUserById(id: Int): Either<Error, User> =
+ *     if(id == 2) Error.left()
+ *     else User(id, Thread.currentThread().name).right()
+ *
+ *   val res = listOf(1, 2, 3)
+ *     .parTraverseValidated(Dispatchers.IO, ::getUserById)
+ *  //sampleEnd
+ *  println(res)
+ * }
+ * ```
+ */
+suspend fun <E, A, B> Iterable<A>.parTraverseValidated(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  semigroup: Semigroup<E>,
+  f: suspend (A) -> Validated<E, B>
+): Validated<E, List<B>> =
+  coroutineScope {
+    map { async(ctx) { f.invoke(it) } }.awaitAll()
+      .sequence(semigroup)
+  }
+
+@PublishedApi // TODO should be in Arrow Core
+internal inline fun <E, A, B> Iterable<A>.traverse(semigroup: Semigroup<E>, f: (A) -> Validated<E, B>): Validated<E, List<B>> =
+  fold(emptyList<B>().valid() as Validated<E, List<B>>) { acc, a ->
+    f(a).ap(semigroup, acc.map { bs: List<B> -> { b: B -> bs + b } })
+  }
+
+@PublishedApi // TODO should be in Arrow Core
+internal fun <E, A> Iterable<Validated<E, A>>.sequence(semigroup: Semigroup<E>): Validated<E, List<A>> =
+  traverse(semigroup, ::identity)

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverseValidated.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTraverseValidated.kt
@@ -81,7 +81,7 @@ suspend fun <E, A, B> Iterable<A>.parTraverseValidatedN(
 }
 
 /**
- * Sequences all tasks in parallel on [Dispatchers.Default] and return the result.
+ * Sequences all tasks in parallel on [Dispatchers.Default] and returns the result.
  * If one or more of the tasks returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
  *
  * Cancelling this operation cancels all running tasks.
@@ -90,7 +90,7 @@ suspend fun <E, A> Iterable<suspend () -> Validated<E, A>>.parSequenceEither(sem
   parTraverseValidated(Dispatchers.Default, semigroup) { it() }
 
 /**
- * Sequences all tasks in parallel on [ctx] and return the result.
+ * Sequences all tasks in parallel on [ctx] and returns the result.
  * If one or more of the tasks returns [Validated.Invalid] then all the [Validated.Invalid] results will be combined using [semigroup].
  *
  * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTraverseEitherTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTraverseEitherTest.kt
@@ -1,0 +1,94 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import arrow.core.extensions.either.applicative.applicative
+import arrow.core.extensions.list.traverse.sequence
+import arrow.core.left
+import arrow.core.right
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.string
+
+class ParTraverseEitherTest : ArrowFxSpec(spec = {
+  "parTraverseEither can traverse effect full computations" {
+    val ref = Atomic(0)
+    (0 until 100).parTraverseEither {
+      ref.update { it + 1 }.right()
+    }
+    ref.get() shouldBe 100
+  }
+
+  "parTraverseEither runs in parallel" {
+    val promiseA = Promise<Unit>()
+    val promiseB = Promise<Unit>()
+    val promiseC = Promise<Unit>()
+
+    listOf(
+      suspend {
+        promiseA.get()
+        promiseC.complete(Unit).right()
+      },
+      suspend {
+        promiseB.get()
+        promiseA.complete(Unit).right()
+      },
+      suspend {
+        promiseB.complete(Unit)
+        promiseC.get().right()
+      }
+    ).parTraverseEither { it() }
+  }
+
+  "parTraverseEither results in the correct left" {
+    checkAll(
+      Arb.int(min = 10, max = 20),
+      Arb.int(min = 1, max = 9),
+      Arb.string()
+    ) { n, killOn, e ->
+      (0 until n).parTraverseEither { i ->
+        if (i == killOn) e.left() else Unit.right()
+      } shouldBe e.left()
+    }
+  }
+
+  "parTraverseEither identity is identity" {
+    checkAll(Arb.list(Arb.either(Arb.string(), Arb.int()))) { l ->
+      val containsError = l.any(Either<String, Int>::isLeft)
+      val res = l.parTraverseEither { it }
+
+      if (containsError) l.contains(res) shouldBe true
+      else res shouldBe l.sequence(Either.applicative())
+    }
+  }
+
+  "parTraverseEither results in the correct error" {
+    checkAll(
+      Arb.int(min = 10, max = 20),
+      Arb.int(min = 1, max = 9),
+      Arb.throwable()
+    ) { n, killOn, e ->
+      Either.catch {
+        (0 until n).parTraverseEither { i ->
+          if (i == killOn) throw e else Unit.right()
+        }
+      } should leftException(e)
+    }
+  }
+
+  "parTraverseEither stack-safe" {
+    val count = 20_000
+    val l = (0 until count).parTraverseEither { it.right() }
+    l shouldBe (0 until count).toList().right()
+  }
+
+  "parTraverseEither finishes on single thread " { // 100 is same default length as Arb.list
+    checkAll(Arb.int(min = Int.MIN_VALUE, max = 100)) { i ->
+      single.use { ctx ->
+        (0 until i).parTraverseEither(ctx) { Thread.currentThread().name.right() }
+      } shouldBe (0 until i).map { "single" }.right()
+    }
+  }
+})

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTraverseValidatedTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTraverseValidatedTest.kt
@@ -1,0 +1,98 @@
+package arrow.fx.coroutines
+
+import arrow.core.Either
+import arrow.core.NonEmptyList
+import arrow.core.Validated
+import arrow.core.extensions.list.traverse.sequence
+import arrow.core.extensions.nonemptylist.semigroup.semigroup
+import arrow.core.extensions.validated.applicative.applicative
+import arrow.core.extensions.validated.bifunctor.mapLeft
+import arrow.core.identity
+import arrow.core.invalidNel
+import arrow.core.validNel
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.string
+
+class ParTraverseValidatedTest : ArrowFxSpec(spec = {
+  "parTraverseValidated can traverse effect full computations" {
+    val ref = Atomic(0)
+    (0 until 100).parTraverseValidated(NonEmptyList.semigroup()) {
+      ref.update { it + 1 }.validNel()
+    }
+    ref.get() shouldBe 100
+  }
+
+  "parTraverseValidated runs in parallel" {
+    val promiseA = Promise<Unit>()
+    val promiseB = Promise<Unit>()
+    val promiseC = Promise<Unit>()
+
+    listOf(
+      suspend {
+        promiseA.get()
+        promiseC.complete(Unit).validNel()
+      },
+      suspend {
+        promiseB.get()
+        promiseA.complete(Unit).validNel()
+      },
+      suspend {
+        promiseB.complete(Unit)
+        promiseC.get().validNel()
+      }
+    ).parTraverseValidated(NonEmptyList.semigroup()) { it() }
+  }
+
+  "parTraverseValidated results in the correct left" {
+    checkAll(
+      Arb.int(min = 10, max = 20),
+      Arb.int(min = 1, max = 9),
+      Arb.string()
+    ) { n, killOn, e ->
+      (0 until n).parTraverseValidated(NonEmptyList.semigroup()) { i ->
+        if (i == killOn) e.invalidNel() else Unit.validNel()
+      } shouldBe e.invalidNel()
+    }
+  }
+
+  "parTraverseValidated identity is identity" {
+    checkAll(Arb.list(Arb.validatedNel(Arb.int(), Arb.int()))) { l ->
+      val res = l.parTraverseValidated(NonEmptyList.semigroup(), ::identity)
+      res shouldBe l.sequence(Validated.applicative(NonEmptyList.semigroup()))
+        // TODO Fix with Arrow Core Iterable<A>.traverseValidated
+        .mapLeft { NonEmptyList.fromListUnsafe(it.reversed()) }
+    }
+  }
+
+  "parTraverseValidated results in the correct error" {
+    checkAll(
+      Arb.int(min = 10, max = 20),
+      Arb.int(min = 1, max = 9),
+      Arb.throwable()
+    ) { n, killOn, e ->
+      Either.catch {
+        (0 until n).parTraverseValidated(NonEmptyList.semigroup()) { i ->
+          if (i == killOn) throw e else Unit.validNel()
+        }
+      } should leftException(e)
+    }
+  }
+
+  "parTraverseValidated stack-safe" {
+    val count = 20_000
+    val l = (0 until count).parTraverseValidated(NonEmptyList.semigroup()) { it.validNel() }
+    l shouldBe (0 until count).toList().validNel()
+  }
+
+  "parTraverseValidated finishes on single thread " { // 100 is same default length as Arb.list
+    checkAll(Arb.int(min = Int.MIN_VALUE, max = 100)) { i ->
+      single.use { ctx ->
+        (0 until i).parTraverseValidated(ctx, NonEmptyList.semigroup()) { Thread.currentThread().name.validNel() }
+      } shouldBe (0 until i).map { "single" }.validNel()
+    }
+  }
+})


### PR DESCRIPTION
## Status
**READY**

## Description
Completes the `parTraverse` operations for `Either` and `Validated`.

## Todos
- [x] Tests
- [x] Documentation
