### PR TITLE
Implement ParTupledN arity 4

### DIFF
--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTupledN.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/ParTupledN.kt
@@ -1,5 +1,6 @@
 package arrow.fx.coroutines
 
+import arrow.core.Tuple4
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.ContinuationInterceptor
@@ -137,3 +138,78 @@ suspend inline fun <A, B, C> parTupledN(
   crossinline fc: suspend () -> C
 ): Triple<A, B, C> =
   parMapN(ctx, fa, fb, fc, ::Triple)
+
+/**
+ * Runs [fa], [fb], [fc], [fd] in parallel on [Dispatchers.Default] and combines their results into [Tuple4].
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ *
+ * suspend fun main(): Unit {
+ *   //sampleStart
+ *   val (a, b, c, d) = parTupledN(
+ *     { "First one is on ${Thread.currentThread().name}" },
+ *     { "Second one is on ${Thread.currentThread().name}" },
+ *     { "Third one is on ${Thread.currentThread().name}" },
+ *     { "Fourth one is on ${Thread.currentThread().name}" }
+ *   )
+ *   //sampleEnd
+ *  println("$a\n$b\n$c\n$d")
+ * }
+ * ```
+ *
+ * @param fa value to parallel map
+ * @param fb value to parallel map
+ * @param fc value to parallel map
+ * @param fd value to parallel map
+ *
+ * @see parMapN for a function that can run on any [CoroutineContext].
+ */
+suspend inline fun <A, B, C, D> parTupledN(
+  crossinline fa: suspend () -> A,
+  crossinline fb: suspend () -> B,
+  crossinline fc: suspend () -> C,
+  crossinline fd: suspend () -> D,
+): Tuple4<A, B, C, D> =
+  parTupledN(Dispatchers.Default, fa, fb, fc, fd)
+
+/**
+ * Runs [fa], [fb], [fc], [fd] in parallel on [ctx] and combines their results using the provided function.
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [ctx] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor], this function will not run [fa], [fb], [fc] and [fd] in parallel.
+ *
+ * ```kotlin:ank:playground
+ * import arrow.fx.coroutines.*
+ * import kotlinx.coroutines.Dispatchers
+ *
+ * suspend fun main(): Unit {
+ *   //sampleStart
+ *   val (a, b, c, d) = parTupledN(
+ *     Dispatchers.IO,
+ *     { "First one is on ${Thread.currentThread().name}" },
+ *     { "Second one is on ${Thread.currentThread().name}" },
+ *     { "Third one is on ${Thread.currentThread().name}" },
+ *     { "Forth one is on ${Thread.currentThread().name}" }
+ *   )
+ *   //sampleEnd
+ *  println("$a\n$b\n$c\n$d")
+ * }
+ * ```
+ *
+ * @param fa value to parallel map
+ * @param fb value to parallel map
+ * @param fc value to parallel map
+ * @param fd value to parallel map
+ *
+ * @see parTupledN for a function that ensures operations run in parallel on the [Dispatchers.Default].
+ */
+suspend inline fun <A, B, C, D> parTupledN(
+  ctx: CoroutineContext = EmptyCoroutineContext,
+  crossinline fa: suspend () -> A,
+  crossinline fb: suspend () -> B,
+  crossinline fc: suspend () -> C,
+  crossinline fd: suspend () -> D,
+): Tuple4<A, B, C, D> =
+  parMapN(ctx, fa, fb, fc, fd, ::Tuple4)

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/parTupledN/ParTupled4Test.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/parTupledN/ParTupled4Test.kt
@@ -171,7 +171,7 @@ class ParTupled4Test : ArrowFxSpec(spec = {
       val pb = Promise<Pair<Int, ExitCase>>()
       val pc = Promise<Pair<Int, ExitCase>>()
 
-      val winner = suspend { s.acquire(); throw e }
+      val winner = suspend { s.acquireN(3); throw e }
       val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
       val loserB = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
       val loserC = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pc.complete(Pair(c, ex)) } }
@@ -187,6 +187,14 @@ class ParTupled4Test : ArrowFxSpec(spec = {
 
       pa.get().let { (res, exit) ->
         res shouldBe a
+        exit.shouldBeInstanceOf<ExitCase.Cancelled>()
+      }
+      pb.get().let { (res, exit) ->
+        res shouldBe b
+        exit.shouldBeInstanceOf<ExitCase.Cancelled>()
+      }
+      pc.get().let { (res, exit) ->
+        res shouldBe c
         exit.shouldBeInstanceOf<ExitCase.Cancelled>()
       }
       r should leftException(e)

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/parTupledN/ParTupled4Test.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/parTupledN/ParTupled4Test.kt
@@ -1,0 +1,195 @@
+package arrow.fx.coroutines.parTupledN
+
+import arrow.core.Either
+import arrow.core.Tuple4
+import arrow.fx.coroutines.ArrowFxSpec
+import arrow.fx.coroutines.Atomic
+import arrow.fx.coroutines.ExitCase
+import arrow.fx.coroutines.ForkAndForget
+import arrow.fx.coroutines.NamedThreadFactory
+import arrow.fx.coroutines.Promise
+import arrow.fx.coroutines.Resource
+import arrow.fx.coroutines.Semaphore
+import arrow.fx.coroutines.guaranteeCase
+import arrow.fx.coroutines.leftException
+import arrow.fx.coroutines.never
+import arrow.fx.coroutines.parTupledN
+import arrow.fx.coroutines.single
+import arrow.fx.coroutines.singleThreadName
+import arrow.fx.coroutines.suspend
+import arrow.fx.coroutines.threadName
+import arrow.fx.coroutines.throwable
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.string
+import kotlinx.coroutines.withContext
+import java.util.concurrent.Executors
+
+class ParTupled4Test : ArrowFxSpec(spec = {
+
+  "parTupledN 4 returns to original context" {
+    val mapCtxName = "parTupled4"
+    val mapCtx = Resource.fromExecutor { Executors.newFixedThreadPool(4, NamedThreadFactory { mapCtxName }) }
+
+    checkAll {
+      single.zip(mapCtx).use { (single, mapCtx) ->
+        withContext(single) {
+          threadName() shouldBe singleThreadName
+
+          val (s1, s2, s3, s4) = parTupledN(mapCtx, threadName, threadName, threadName, threadName)
+
+          s1 shouldBe mapCtxName
+          s2 shouldBe mapCtxName
+          s3 shouldBe mapCtxName
+          s4 shouldBe mapCtxName
+          threadName() shouldBe singleThreadName
+        }
+      }
+    }
+  }
+
+  "parTupledN 4 returns to original context on failure" {
+    val mapCtxName = "parTupled4"
+    val mapCtx = Resource.fromExecutor { Executors.newFixedThreadPool(4, NamedThreadFactory { mapCtxName }) }
+
+    checkAll(Arb.int(1..4), Arb.throwable()) { choose, e ->
+      single.zip(mapCtx).use { (single, mapCtx) ->
+        withContext(single) {
+          threadName() shouldBe singleThreadName
+
+          Either.catch {
+            when (choose) {
+              1 -> parTupledN(mapCtx, { e.suspend() }, { never<Nothing>() }, { never<Nothing>() }, { never<Nothing>() })
+              2 -> parTupledN(mapCtx, { never<Nothing>() }, { e.suspend() }, { never<Nothing>() }, { never<Nothing>() })
+              3 -> parTupledN(mapCtx, { never<Nothing>() }, { never<Nothing>() }, { e.suspend() }, { never<Nothing>() })
+              else -> parTupledN(
+                mapCtx,
+                { never<Nothing>() },
+                { never<Nothing>() },
+                { never<Nothing>() },
+                { e.suspend() })
+            }
+          } should leftException(e)
+
+          threadName() shouldBe singleThreadName
+        }
+      }
+    }
+  }
+
+  "ParTupledN 4 runs in parallel" {
+    checkAll(Arb.int(), Arb.int(), Arb.int(), Arb.int()) { a, b, c, d ->
+      val r = Atomic("")
+      val modifyGate1 = Promise<Unit>()
+      val modifyGate2 = Promise<Unit>()
+      val modifyGate3 = Promise<Unit>()
+
+      parTupledN(
+        {
+          modifyGate3.get()
+          r.update { i -> "$i$a" }
+        },
+        {
+          modifyGate2.get()
+          r.update { i -> "$i$b" }
+          modifyGate3.complete(Unit)
+        },
+        {
+          modifyGate1.get()
+          r.update { i -> "$i$c" }
+          modifyGate2.complete(Unit)
+        },
+        {
+          r.set("$d")
+          modifyGate1.complete(Unit)
+        }
+      )
+
+      r.get() shouldBe "$d$c$b$a"
+    }
+  }
+
+  "ParTupledN 4 finishes on single thread" {
+    checkAll(Arb.string()) { name ->
+      single.use { ctx ->
+        parTupledN(ctx, threadName, threadName, threadName, threadName)
+      } shouldBe Tuple4("single", "single", "single", "single")
+    }
+  }
+
+  "Cancelling ParTupledN 4 cancels all participants" {
+    checkAll(Arb.int(), Arb.int(), Arb.int(), Arb.int()) { a, b, c, d ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+      val pb = Promise<Pair<Int, ExitCase>>()
+      val pc = Promise<Pair<Int, ExitCase>>()
+      val pd = Promise<Pair<Int, ExitCase>>()
+
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+      val loserB = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+      val loserC = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pc.complete(Pair(c, ex)) } }
+      val loserD = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pd.complete(Pair(d, ex)) } }
+
+      val f = ForkAndForget { parTupledN(loserA, loserB, loserC, loserD) }
+
+      s.acquireN(4) // Suspend until all racers started
+      f.cancel()
+
+      pa.get().let { (res, exit) ->
+        res shouldBe a
+        exit.shouldBeInstanceOf<ExitCase.Cancelled>()
+      }
+      pb.get().let { (res, exit) ->
+        res shouldBe b
+        exit.shouldBeInstanceOf<ExitCase.Cancelled>()
+      }
+      pc.get().let { (res, exit) ->
+        res shouldBe c
+        exit.shouldBeInstanceOf<ExitCase.Cancelled>()
+      }
+      pd.get().let { (res, exit) ->
+        res shouldBe d
+        exit.shouldBeInstanceOf<ExitCase.Cancelled>()
+      }
+    }
+  }
+
+  "ParTupledN 4 cancels losers if a failure occurs in one of the tasks" {
+    checkAll(
+      Arb.throwable(),
+      Arb.element(listOf(1, 2, 3, 4)),
+      Arb.int(),
+      Arb.int(),
+      Arb.int()
+    ) { e, leftWinner, a, b, c ->
+      val s = Semaphore(0L)
+      val pa = Promise<Pair<Int, ExitCase>>()
+      val pb = Promise<Pair<Int, ExitCase>>()
+      val pc = Promise<Pair<Int, ExitCase>>()
+
+      val winner = suspend { s.acquire(); throw e }
+      val loserA = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pa.complete(Pair(a, ex)) } }
+      val loserB = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pb.complete(Pair(b, ex)) } }
+      val loserC = suspend { guaranteeCase({ s.release(); never<Int>() }) { ex -> pc.complete(Pair(c, ex)) } }
+
+      val r = Either.catch {
+        when (leftWinner) {
+          1 -> parTupledN(winner, loserA, loserB, loserC)
+          2 -> parTupledN(loserA, winner, loserB, loserC)
+          3 -> parTupledN(loserA, loserB, winner, loserC)
+          else -> parTupledN(loserA, loserB, loserC, winner)
+        }
+      }
+
+      pa.get().let { (res, exit) ->
+        res shouldBe a
+        exit.shouldBeInstanceOf<ExitCase.Cancelled>()
+      }
+      r should leftException(e)
+    }
+  }
+})


### PR DESCRIPTION
## Issue
Fixes https://github.com/arrow-kt/arrow-fx/issues/347 (I hope, assuming the word `Par` is missing in the title cc @nomisRev )

## Status
**READY**

## Description

ParTupledN arity 4 based on the arity 3 impl
I took the liberty to create a `parTupledN` package in the tests (following the approach of `parMapN`) and created a separate spec just for Arity4
Also I am using `Tuple4` from arrow core since Kotlin doesn't have an equivalent AFIK

## Todos
- [x] Tests
- [x] Documentation

## Related PRs
* None
