### PR TITLE
Fix breaking changes CircuitBreaker, and deprecate arrow.fx.coroutines.Duration

### DIFF
--- a/arrow-fx-coroutines-stream/build.gradle
+++ b/arrow-fx-coroutines-stream/build.gradle
@@ -19,15 +19,3 @@ dependencies {
     testImplementation "io.kotest:kotest-assertions-core-jvm:$KOTEST_VERSION" // for kotest core jvm assertions
     testImplementation "io.kotest:kotest-property-jvm:$KOTEST_VERSION" // for kotest property test
 }
-
-// usage of kotlin.time
-compileKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}

--- a/arrow-fx-coroutines-test/build.gradle
+++ b/arrow-fx-coroutines-test/build.gradle
@@ -17,15 +17,3 @@ dependencies {
     api "io.kotest:kotest-assertions-core-jvm:$KOTEST_VERSION" // for kotest core jvm assertions
     api "io.kotest:kotest-property-jvm:$KOTEST_VERSION" // for kotest property test
 }
-
-// usage of kotlin.time
-compileKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}

--- a/arrow-fx-coroutines/build.gradle
+++ b/arrow-fx-coroutines/build.gradle
@@ -19,15 +19,3 @@ dependencies {
   testImplementation "io.kotest:kotest-assertions-core-jvm:$KOTEST_VERSION" // for kotest core jvm assertions
   testImplementation "io.kotest:kotest-property-jvm:$KOTEST_VERSION" // for kotest property test
 }
-
-// usage of kotlin.time
-compileKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
@@ -6,16 +6,16 @@ import arrow.fx.coroutines.CircuitBreaker.State.Closed
 import arrow.fx.coroutines.CircuitBreaker.State.HalfOpen
 import arrow.fx.coroutines.CircuitBreaker.State.Open
 import kotlin.time.Duration
-import kotlin.time.milliseconds
-import kotlin.time.nanoseconds
+import kotlin.time.ExperimentalTime
+import arrow.fx.coroutines.Duration as FxDuration
 
 class CircuitBreaker
 private constructor(
   private val state: AtomicRefW<State>,
   private val maxFailures: Int,
-  private val resetTimeout: Duration,
+  private val resetTimeout: Double,
   private val exponentialBackoffFactor: Double,
-  private val maxResetTimeout: Duration,
+  private val maxResetTimeout: Double,
   private val onRejected: suspend () -> Unit,
   private val onClosed: suspend () -> Unit,
   private val onHalfOpen: suspend () -> Unit,
@@ -25,16 +25,16 @@ private constructor(
   @Deprecated(
     "$DeprecateDuration and please use the #of constructor instead",
     ReplaceWith(
-      "of(maxFailures, resetTimeout.millis.milliseconds, exponentialBackoffFactor, maxResetTimeout, onRejected, onClosed, onHalfOpen, onOpen)",
-      "arrow.fx.coroutines.CircuitBreaker.Companion.of"
+      "of(maxFailures, resetTimeout.nanoseconds.toDouble(), exponentialBackoffFactor, maxResetTimeout.nanoseconds.toDouble(), onRejected, onClosed, onHalfOpen, onOpen)",
+      "arrow.fx.coroutines.CircuitBreaker"
     )
   )
   constructor(
     state: AtomicRefW<State>,
     maxFailures: Int,
-    resetTimeout: arrow.fx.coroutines.Duration,
+    resetTimeout: FxDuration,
     exponentialBackoffFactor: Double,
-    maxResetTimeout: Duration,
+    maxResetTimeout: FxDuration,
     onRejected: suspend () -> Unit,
     onClosed: suspend () -> Unit,
     onHalfOpen: suspend () -> Unit,
@@ -42,9 +42,9 @@ private constructor(
   ) : this(
     state,
     maxFailures,
-    resetTimeout.millis.milliseconds,
+    resetTimeout.nanoseconds.toDouble(),
     exponentialBackoffFactor,
-    maxResetTimeout,
+    maxResetTimeout.nanoseconds.toDouble(),
     onRejected,
     onClosed,
     onHalfOpen,
@@ -106,7 +106,7 @@ private constructor(
         markOrResetFailures(attempt)
       }
       is Open -> {
-        val now = System.currentTimeMillis().milliseconds
+        val now = System.currentTimeMillis()
         if (now >= curr.expiresAt) {
           // The Open state has expired, so we are letting just one
           // task to execute, while transitioning into HalfOpen
@@ -189,7 +189,7 @@ private constructor(
    */
   private suspend fun <A> attemptReset(
     task: suspend () -> A,
-    resetTimeout: Duration,
+    resetTimeout: Double,
     awaitClose: Promise<Unit>,
     lastStartedAt: Long
   ): A =
@@ -213,8 +213,8 @@ private constructor(
           }
           is ExitCase.Failure -> {
             // Failed reset, which means we go back in the Open state with new expiry val nextTimeout
-            val value: Duration = (resetTimeout * exponentialBackoffFactor)
-            val nextTimeout: Duration =
+            val value: Double = (resetTimeout * exponentialBackoffFactor)
+            val nextTimeout: Double =
               if (maxResetTimeout.isFinite() && value > maxResetTimeout) maxResetTimeout
               else value
             val ts = System.currentTimeMillis()
@@ -383,22 +383,22 @@ private constructor(
      * @param awaitClose is a [Promise] that will get completed
      *        when the `CircuitBreaker` switches to the `Closed` state again
      */
-    class Open(val startedAt: Long, val resetTimeout: Duration, internal val awaitClose: Promise<Unit>) : State() {
+    class Open(val startedAt: Long, val resetTimeout: Double, internal val awaitClose: Promise<Unit>) : State() {
 
       @Deprecated(
         DeprecateDuration,
         ReplaceWith("(startedAt, resetTimeout.millis.milliseconds, awaitClose)", "kotlin.time.milliseconds")
       )
-      constructor(startedAt: Long, resetTimeout: arrow.fx.coroutines.Duration, awaitClose: Promise<Unit>) :
-        this(startedAt, resetTimeout.millis.milliseconds, awaitClose)
+      constructor(startedAt: Long, resetTimeout: FxDuration, awaitClose: Promise<Unit>) :
+        this(startedAt, resetTimeout.nanoseconds.toDouble(), awaitClose)
 
       /** The timestamp in milliseconds since the epoch, specifying
        * when the `Open` state is to transition to [HalfOpen].
        *
        * It is calculated as:
-       * `startedAt + resetTimeout.millis`
+       * `startedAt + (resetTimeout `
        */
-      val expiresAt: Duration = startedAt.milliseconds + resetTimeout
+      val expiresAt: Long = startedAt + (resetTimeout / 1_000_000).toLong()
 
       override fun equals(other: Any?): Boolean =
         if (other is Open) this.startedAt == startedAt &&
@@ -442,14 +442,14 @@ private constructor(
      * @param awaitClose is a [Promise] that will get completed
      *        when the `CircuitBreaker` switches to the `Closed` state again.
      */
-    class HalfOpen(val resetTimeout: Duration, internal val awaitClose: Promise<Unit>) : State() {
+    class HalfOpen(val resetTimeout: Double, internal val awaitClose: Promise<Unit>) : State() {
 
       @Deprecated(
         DeprecateDuration,
         ReplaceWith("(resetTimeout.millis.milliseconds, awaitClose)", "kotlin.time.milliseconds")
       )
-      constructor(resetTimeout: arrow.fx.coroutines.Duration, awaitClose: Promise<Unit>) :
-        this(resetTimeout.millis.milliseconds, awaitClose)
+      constructor(resetTimeout: FxDuration, awaitClose: Promise<Unit>) :
+        this(resetTimeout.nanoseconds.toDouble(), awaitClose)
 
       override fun hashCode(): Int =
         resetTimeout.hashCode()
@@ -497,17 +497,15 @@ private constructor(
      */
     suspend fun of(
       maxFailures: Int,
-      resetTimeout: Duration,
+      resetTimeout: Double,
       exponentialBackoffFactor: Double = 1.0,
-      maxResetTimeout: Duration = Duration.INFINITE,
+      maxResetTimeout: Double = Double.POSITIVE_INFINITY,
       onRejected: suspend () -> Unit = suspend { Unit },
       onClosed: suspend () -> Unit = suspend { Unit },
       onHalfOpen: suspend () -> Unit = suspend { Unit },
       onOpen: suspend () -> Unit = suspend { Unit }
     ): CircuitBreaker? =
-      if (maxFailures >= 0 && resetTimeout > 0.nanoseconds &&
-        exponentialBackoffFactor > 0 && maxResetTimeout > 0.nanoseconds
-      ) {
+      if (maxFailures >= 0 && resetTimeout > 0 && exponentialBackoffFactor > 0 && maxResetTimeout > 0) {
         CircuitBreaker(
           state = AtomicRefW(Closed(0)),
           maxFailures = maxFailures,
@@ -521,18 +519,41 @@ private constructor(
         )
       } else null
 
-    @Deprecated(
-      DeprecateDuration,
-      ReplaceWith(
-        "of(maxFailures, resetTimeout.millis.milliseconds, exponentialBackoffFactor, maxResetTimeout.millis.milliseconds, onRejected, onClosed, onHalfOpen, onOpen)",
-        "kotlin.time.milliseconds"
-      )
-    )
+    /**
+     * Attempts to create a [CircuitBreaker].
+     *
+     * @param maxFailures is the maximum count for failures before
+     *        opening the circuit breaker.
+     *
+     * @param resetTimeout is the timeout to wait in the `Open` state
+     *        before attempting a close of the circuit breaker (but without
+     *        the backoff factor applied).
+     *
+     * @param exponentialBackoffFactor is a factor to use for resetting
+     *        the `resetTimeout` when in the `HalfOpen` state, in case
+     *        the attempt to `Close` fails.
+     *
+     * @param maxResetTimeout is the maximum timeout the circuit breaker
+     *        is allowed to use when applying the `exponentialBackoffFactor`.
+     *
+     * @param onRejected is a callback for signaling rejected tasks, so
+     *         every time a task execution is attempted and rejected in
+     *         [CircuitBreaker.Open] or [CircuitBreaker.HalfOpen]
+     *         states.
+     *
+     * @param onClosed is a callback for signaling transitions to the [CircuitBreaker.State.Closed] state.
+     *
+     * @param onHalfOpen is a callback for signaling transitions to [CircuitBreaker.State.HalfOpen].
+     *
+     * @param onOpen is a callback for signaling transitions to [CircuitBreaker.State.Open].
+     *
+     */
+    @ExperimentalTime
     suspend fun of(
       maxFailures: Int,
-      resetTimeout: arrow.fx.coroutines.Duration,
+      resetTimeout: Duration,
       exponentialBackoffFactor: Double = 1.0,
-      maxResetTimeout: arrow.fx.coroutines.Duration = arrow.fx.coroutines.Duration.INFINITE,
+      maxResetTimeout: Duration = Duration.INFINITE,
       onRejected: suspend () -> Unit = suspend { Unit },
       onClosed: suspend () -> Unit = suspend { Unit },
       onHalfOpen: suspend () -> Unit = suspend { Unit },
@@ -540,9 +561,34 @@ private constructor(
     ): CircuitBreaker? =
       of(
         maxFailures,
-        resetTimeout.millis.milliseconds,
+        resetTimeout.inNanoseconds,
         exponentialBackoffFactor,
-        maxResetTimeout.millis.milliseconds,
+        maxResetTimeout.inNanoseconds,
+        onRejected,
+        onClosed,
+        onHalfOpen,
+        onOpen
+      )
+
+    @Deprecated(
+      DeprecateDuration,
+      ReplaceWith("of(maxFailures, resetTimeout.nanoseconds.toDouble(), exponentialBackoffFactor, maxResetTimeout.nanoseconds.toDouble(), onRejected, onClosed, onHalfOpen, onOpen)")
+    )
+    suspend fun of(
+      maxFailures: Int,
+      resetTimeout: FxDuration,
+      exponentialBackoffFactor: Double = 1.0,
+      maxResetTimeout: FxDuration = FxDuration.INFINITE,
+      onRejected: suspend () -> Unit = suspend { Unit },
+      onClosed: suspend () -> Unit = suspend { Unit },
+      onHalfOpen: suspend () -> Unit = suspend { Unit },
+      onOpen: suspend () -> Unit = suspend { Unit }
+    ): CircuitBreaker? =
+      of(
+        maxFailures,
+        resetTimeout.nanoseconds.toDouble(),
+        exponentialBackoffFactor,
+        maxResetTimeout.nanoseconds.toDouble(),
         onRejected,
         onClosed,
         onHalfOpen,

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/CircuitBreaker.kt
@@ -12,7 +12,6 @@ import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import arrow.fx.coroutines.Duration as FxDuration
 import arrow.fx.coroutines.nanoseconds as oldNanoseconds
-import arrow.fx.coroutines.milliseconds as oldMilliseconds
 
 class CircuitBreaker
 private constructor(
@@ -451,7 +450,7 @@ private constructor(
        *        the exponential backoff factor for the next transition to
        *        `Open`, in case the reset attempt fails.
        */
-      constructor(resetTimeoutNanos: Double): this(resetTimeoutNanos, CompletableDeferred())
+      constructor(resetTimeoutNanos: Double) : this(resetTimeoutNanos, CompletableDeferred())
 
       @Deprecated(
         DeprecateDuration,

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Schedule.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Schedule.kt
@@ -430,7 +430,7 @@ sealed class Schedule<Input, Output> {
   fun jittered(genRand: suspend () -> Double): Schedule<Input, Output> =
     modifyNanos { _, duration ->
       val n = genRand.invoke()
-      (duration.nanoseconds * n).inNanoseconds
+      (duration * n)
     }
 
   @JvmName("jitteredDuration")
@@ -493,7 +493,7 @@ sealed class Schedule<Input, Output> {
           val step = update(a, state)
           if (!step.cont) return Either.Right(step.finish.value())
           else {
-            delay(step.delayInNanos.nanoseconds)
+            delay(step.delayInNanos.toLong())
 
             // Set state before looping again
             last = { step.finish.value() }
@@ -1236,7 +1236,7 @@ suspend fun <A, B, C> Schedule<Throwable, B>.retryOrElseEither(
       dec = update(e, state)
       state = dec.state
 
-      if (dec.cont) delay(dec.delayInNanos.nanoseconds)
+      if (dec.cont) delay(dec.delayInNanos.toLong())
       else return Either.Left(orElse(e.nonFatalOrThrow(), dec.finish.value()))
     }
   }

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Schedule.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/Schedule.kt
@@ -493,7 +493,7 @@ sealed class Schedule<Input, Output> {
           val step = update(a, state)
           if (!step.cont) return Either.Right(step.finish.value())
           else {
-            delay(step.delayInNanos.toLong())
+            delay((step.delayInNanos / 1_000_000).toLong())
 
             // Set state before looping again
             last = { step.finish.value() }
@@ -1236,7 +1236,7 @@ suspend fun <A, B, C> Schedule<Throwable, B>.retryOrElseEither(
       dec = update(e, state)
       state = dec.state
 
-      if (dec.cont) delay(dec.delayInNanos.toLong())
+      if (dec.cont) delay((dec.delayInNanos / 1_000_000).toLong())
       else return Either.Left(orElse(e.nonFatalOrThrow(), dec.finish.value()))
     }
   }

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/flow.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/flow.kt
@@ -45,7 +45,7 @@ fun <A, B> Flow<A>.retry(schedule: Schedule<Throwable, B>): Flow<A> = flow {
     state = dec.state
 
     if (dec.cont) {
-      delay(dec.delayInNanos.toLong())
+      delay((dec.delayInNanos / 1_000_000).toLong())
       true
     } else {
       false

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/flow.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/flow.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.retryWhen
-import kotlin.time.nanoseconds
 
 /**
  * Retries collection of the given flow when an exception occurs in the upstream flow based on a decision by the [schedule].
@@ -46,7 +45,7 @@ fun <A, B> Flow<A>.retry(schedule: Schedule<Throwable, B>): Flow<A> = flow {
     state = dec.state
 
     if (dec.cont) {
-      delay(dec.delayInNanos.nanoseconds)
+      delay(dec.delayInNanos.toLong())
       true
     } else {
       false

--- a/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
+++ b/arrow-fx-coroutines/src/main/kotlin/arrow/fx/coroutines/stream/Stream.kt
@@ -8,6 +8,7 @@ import arrow.core.Option
 import arrow.core.Some
 import arrow.core.extensions.list.foldable.foldLeft
 import arrow.core.identity
+import arrow.fx.coroutines.Duration
 import arrow.fx.coroutines.ExitCase
 import arrow.fx.coroutines.Fiber
 import arrow.fx.coroutines.ForkAndForget
@@ -23,7 +24,6 @@ import kotlinx.coroutines.delay
 import java.util.concurrent.TimeoutException
 import kotlin.coroutines.CoroutineContext
 import kotlin.random.Random
-import kotlin.time.Duration
 
 class ForStream private constructor() {
   companion object
@@ -1448,7 +1448,7 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
    * Interrupts this stream after the specified duration has passed.
    */
   fun interruptAfter(duration: Duration): Stream<O> =
-    interruptWhen { Right(delay(duration)) }
+    interruptWhen { Right(delay(duration.millis)) }
 
   /**
    * Transforms this stream using the given `Pipe`.
@@ -1479,7 +1479,7 @@ inline fun <A> StreamOf<A>.fix(): Stream<A> =
      * A single-element `Stream` that waits for the duration `d` before emitting unit.
      */
     fun sleep(d: Duration): Stream<Unit> =
-      effect { delay(d) }
+      effect { delay(d.millis) }
 
     /**
      * Alias for `sleep(d).void`. Often used in conjunction with [append] (i.e., `sleep_(..).append { s }`) as a more

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancelBoundary.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancelBoundary.kt
@@ -3,8 +3,10 @@ package arrow.fx.coroutines
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.delay
+import kotlin.time.ExperimentalTime
 import kotlin.time.seconds
 
+@ExperimentalTime
 class CancelBoundary : StringSpec({
 
   suspend fun forever(): Unit {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CancellableF.kt
@@ -8,8 +8,10 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 
+@ExperimentalTime
 class CancellableF : ArrowFxSpec(spec = {
 
   "cancelable works for immediate values" {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
@@ -73,7 +73,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout.inNanoseconds
+        s.resetTimeoutNanos shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -100,7 +100,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout.inNanoseconds
+        s.resetTimeoutNanos shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -115,7 +115,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout.inNanoseconds
+        s.resetTimeoutNanos shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -136,7 +136,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.HalfOpen -> {
-        s.resetTimeout shouldBe resetTimeout.inNanoseconds
+        s.resetTimeoutNanos shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.HalfOpen but found $s")
     }
@@ -179,7 +179,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout.inNanoseconds
+        s.resetTimeoutNanos shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -194,7 +194,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout.inNanoseconds
+        s.resetTimeoutNanos shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -218,7 +218,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.HalfOpen -> {
-        s.resetTimeout shouldBe resetTimeout.inNanoseconds
+        s.resetTimeoutNanos shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.HalfOpen but found $s")
     }
@@ -235,7 +235,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
     // resetTimeout should've applied
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe (resetTimeout * exponentialBackoffFactor).inNanoseconds
+        s.resetTimeoutNanos shouldBe (resetTimeout * exponentialBackoffFactor).inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
@@ -7,9 +7,11 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 import kotlin.time.minutes
 
+@ExperimentalTime
 class CircuitBreakerTest : ArrowFxSpec(spec = {
 
   val dummy = RuntimeException("dummy")

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/CircuitBreakerTest.kt
@@ -73,7 +73,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout
+        s.resetTimeout shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -100,7 +100,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout
+        s.resetTimeout shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -115,7 +115,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout
+        s.resetTimeout shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -136,7 +136,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.HalfOpen -> {
-        s.resetTimeout shouldBe resetTimeout
+        s.resetTimeout shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.HalfOpen but found $s")
     }
@@ -179,7 +179,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout
+        s.resetTimeout shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -194,7 +194,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe resetTimeout
+        s.resetTimeout shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }
@@ -218,7 +218,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
 
     when (val s = cb.state()) {
       is CircuitBreaker.State.HalfOpen -> {
-        s.resetTimeout shouldBe resetTimeout
+        s.resetTimeout shouldBe resetTimeout.inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.HalfOpen but found $s")
     }
@@ -235,7 +235,7 @@ class CircuitBreakerTest : ArrowFxSpec(spec = {
     // resetTimeout should've applied
     when (val s = cb.state()) {
       is CircuitBreaker.State.Open -> {
-        s.resetTimeout shouldBe (resetTimeout * exponentialBackoffFactor)
+        s.resetTimeout shouldBe (resetTimeout * exponentialBackoffFactor).inNanoseconds
       }
       else -> fail("Invalid state: Expect CircuitBreaker.State.Open but found $s")
     }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ConcurrentVarTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ConcurrentVarTest.kt
@@ -5,8 +5,10 @@ import arrow.core.toT
 import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
+import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 
+@ExperimentalTime
 class ConcurrentVarTest : ArrowFxSpec(spec = {
 
   "empty; put; isNotEmpty; take; put; take" {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/EnvironmentTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/EnvironmentTest.kt
@@ -7,8 +7,10 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
 import kotlinx.coroutines.delay
+import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 
+@ExperimentalTime
 class EnvironmentTest : StringSpec({
 
   "unsafeRunSync can run immediate task" {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/FlowTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/FlowTest.kt
@@ -10,7 +10,6 @@ import io.kotest.property.arbitrary.positiveInts
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.reduce
-import kotlinx.coroutines.test.DelayController
 import kotlinx.coroutines.test.runBlockingTest
 import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/FlowTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/FlowTest.kt
@@ -48,12 +48,12 @@ class FlowTest : ArrowFxSpec(spec = {
   "Retry - schedule with delay" {
     runBlockingTest {
       checkAll(Arb.int(), Arb.int(100, 1000)) { a, delayMs ->
-        val start = currentTimeInMillis()
+        val start = currentTime
         val timestamps = mutableListOf<Long>()
         shouldThrow<RuntimeException> {
           flow {
             emit(a)
-            timestamps.add(currentTimeInMillis())
+            timestamps.add(currentTime)
             throw RuntimeException("Bang!")
           }
             .retry(Schedule.recurs<Throwable>(2) and Schedule.spaced(delayMs.milliseconds))
@@ -71,6 +71,3 @@ class FlowTest : ArrowFxSpec(spec = {
     }
   }
 })
-
-fun DelayController.currentTimeInMillis(): Long =
-  currentTime / 1_000_000

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTraverseTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ParTraverseTest.kt
@@ -10,8 +10,10 @@ import io.kotest.property.arbitrary.list
 import kotlinx.coroutines.Dispatchers
 import io.kotest.property.checkAll
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 
+@ExperimentalTime
 class ParTraverseTest : ArrowFxSpec(spec = {
 
   "parTraverse can traverse effect full computations" {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ScheduleTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/ScheduleTest.kt
@@ -7,10 +7,12 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.math.pow
+import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 import kotlin.time.nanoseconds
 import kotlin.time.seconds
 
+@ExperimentalTime
 class ScheduleTest : ArrowFxSpec(spec = {
 
   class MyException : Exception()
@@ -218,21 +220,25 @@ class ScheduleTest : ArrowFxSpec(spec = {
   }
 })
 
+@ExperimentalTime
 private fun fibs(one: kotlin.time.Duration): Sequence<kotlin.time.Duration> =
   generateSequence(Pair(0.0.nanoseconds, one)) { (a, b) ->
     Pair(b, (a + b))
   }.map { it.first }
 
+@ExperimentalTime
 private fun exp(base: kotlin.time.Duration): Sequence<kotlin.time.Duration> =
   generateSequence(Pair(base, 1.0)) { (_, n) ->
     Pair(base * 2.0.pow(n), n + 1)
   }.map { it.first }
 
+@ExperimentalTime
 private fun linear(base: kotlin.time.Duration): Sequence<kotlin.time.Duration> =
   generateSequence(Pair(base, 1.0)) { (_, n) ->
     Pair((base * n), (n + 1))
   }.map { it.first }
 
+@ExperimentalTime
 internal fun Sequence<kotlin.time.Duration>.sum(): kotlin.time.Duration {
   var sum: kotlin.time.Duration = 0.0.nanoseconds
   for (element in this) {
@@ -275,6 +281,7 @@ private suspend fun <B> checkRepeat(schedule: Schedule<Int, B>, expected: B): Un
   } shouldBe expected
 }
 
+@ExperimentalTime
 private infix fun <A> Schedule.Decision<Any?, A>.eqv(other: Schedule.Decision<Any?, A>): Unit {
   require(cont == other.cont) { "Decision#cont: ${this.cont} shouldBe ${other.cont}" }
   require(delayInNanos.nanoseconds == other.delayInNanos.nanoseconds) { "Decision#delay.nanoseconds: ${this.delayInNanos.nanoseconds} shouldBe ${other.delayInNanos.nanoseconds}" }

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/SemaphoreTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/SemaphoreTest.kt
@@ -10,8 +10,10 @@ import io.kotest.property.arbitrary.positiveInts
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 
+@ExperimentalTime
 class SemaphoreTest : ArrowFxSpec(spec = {
 
   "acquire n times synchronously" {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/BracketTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/BracketTest.kt
@@ -8,7 +8,7 @@ import arrow.fx.coroutines.ExitCase
 import arrow.fx.coroutines.ForkAndForget
 import arrow.fx.coroutines.Promise
 import arrow.fx.coroutines.leftException
-import kotlin.time.milliseconds
+import arrow.fx.coroutines.milliseconds as oldMilliseconds
 import arrow.fx.coroutines.parTupledN
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -19,7 +19,10 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.string
 import kotlinx.coroutines.delay
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
 
+@ExperimentalTime
 class BracketTest : StreamSpec(spec = {
 
   "bracket" - {
@@ -365,7 +368,7 @@ class BracketTest : StreamSpec(spec = {
         }.flatMap { s0.append { Stream.never() } }
 
         s
-          .interruptAfter(50.milliseconds)
+          .interruptAfter(50.oldMilliseconds)
           .drain()
 
         counter.count() shouldBe 0L

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/CallbackTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/CallbackTest.kt
@@ -18,7 +18,9 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.map
 import kotlinx.coroutines.delay
+import kotlin.time.ExperimentalTime
 
+@ExperimentalTime
 class CallbackTest : StreamSpec(iterations = 250, spec = {
 
   "should be lazy" {
@@ -203,6 +205,7 @@ class CallbackTest : StreamSpec(iterations = 250, spec = {
   }
 })
 
+@ExperimentalTime
 private suspend fun <A> countToCallback(
   iterations: Int,
   map: (Int) -> A,

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/InterruptionTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/InterruptionTest.kt
@@ -11,8 +11,8 @@ import arrow.fx.coroutines.guaranteeCase
 import arrow.fx.coroutines.guarantee
 import arrow.fx.coroutines.Semaphore
 import arrow.fx.coroutines.ExitCase
-import kotlin.time.milliseconds
 import arrow.fx.coroutines.never
+import arrow.fx.coroutines.milliseconds as oldMilliseconds
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -20,7 +20,10 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
 
+@ExperimentalTime
 class InterruptionTest : StreamSpec(spec = {
   "can cancel a hung effect" - {
     checkAll(Arb.stream(Arb.int())) { s ->
@@ -278,7 +281,7 @@ class InterruptionTest : StreamSpec(spec = {
 
     withTimeoutOrNull(500.milliseconds) {
       Stream.effect { guarantee({ latch.get() }) { latch.complete(Unit) } }
-        .interruptAfter(50.milliseconds)
+        .interruptAfter(50.oldMilliseconds)
         .drain()
 
       latch.get()
@@ -314,7 +317,7 @@ class InterruptionTest : StreamSpec(spec = {
   "nested-interrupt - interrupt in enclosing scope recovers" - {
     Stream.effect { never<Unit>() }
       .interruptWhen { never() }
-      .append { Stream(1).delayBy(20.milliseconds) }
+      .append { Stream(1).delayBy(20.oldMilliseconds) }
       .interruptWhen { Right(Unit) }
       .append { Stream(2) }
       .toList() shouldBe listOf(2)

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ParJoinTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/ParJoinTest.kt
@@ -15,7 +15,9 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.positiveInts
 import kotlinx.coroutines.delay
 import java.lang.RuntimeException
+import kotlin.time.ExperimentalTime
 
+@ExperimentalTime
 class ParJoinTest : StreamSpec(spec = {
   "no concurrency" - {
     checkAll(Arb.stream(Arb.int())) { s ->

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/StreamTest.kt
@@ -18,7 +18,9 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.math.absoluteValue
 import kotlin.math.max
 import kotlin.random.Random
+import kotlin.time.ExperimentalTime
 
+@ExperimentalTime
 class StreamTest : StreamSpec(spec = {
   "constructors" - {
     "empty() is empty" {

--- a/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
+++ b/arrow-fx-coroutines/src/test/kotlin/arrow/fx/coroutines/stream/concurrent/QueueTest.kt
@@ -4,9 +4,8 @@ import arrow.core.Option
 import arrow.fx.coroutines.ForkAndForget
 import arrow.fx.coroutines.ForkConnected
 import arrow.fx.coroutines.Promise
+import arrow.fx.coroutines.milliseconds as oldMilliseconds
 import arrow.fx.coroutines.stream.StreamSpec
-import kotlin.time.milliseconds
-import kotlin.time.seconds
 import arrow.fx.coroutines.stream.Stream
 import arrow.fx.coroutines.stream.append
 import arrow.fx.coroutines.stream.drain
@@ -23,7 +22,11 @@ import io.kotest.property.arbitrary.positiveInts
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.math.max
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
+import kotlin.time.milliseconds
 
+@ExperimentalTime
 class QueueTest : StreamSpec(spec = {
 
   "Queue with capacity can always take tryOffer1" {
@@ -177,7 +180,7 @@ class QueueTest : StreamSpec(spec = {
   "dequeue releases subscriber on " - {
     "interrupt" {
       val q = Queue.unbounded<Int>()
-      q.dequeue().interruptAfter(100.milliseconds).drain()
+      q.dequeue().interruptAfter(100.oldMilliseconds).drain()
       q.enqueue1(1)
       q.enqueue1(2)
       q.dequeue1() shouldBe 1

--- a/arrow-fx-kotlinx-coroutines/build.gradle
+++ b/arrow-fx-kotlinx-coroutines/build.gradle
@@ -15,15 +15,3 @@ dependencies {
     testImplementation project(':arrow-fx')
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$KOTLINX_COROUTINES_VERSION"
 }
-
-// usage of kotlin.time
-compileKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}

--- a/arrow-fx-stm/build.gradle
+++ b/arrow-fx-stm/build.gradle
@@ -17,15 +17,3 @@ dependencies {
     testImplementation "io.kotest:kotest-assertions-core-jvm:$KOTEST_VERSION" // for kotest core jvm assertions
     testImplementation "io.kotest:kotest-property-jvm:$KOTEST_VERSION" // for kotest property test
 }
-
-// usage of kotlin.time
-compileKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-}

--- a/arrow-fx-stm/src/test/kotlin/arrow/fx/stm/STMTest.kt
+++ b/arrow-fx-stm/src/test/kotlin/arrow/fx/stm/STMTest.kt
@@ -17,7 +17,9 @@ import io.kotest.property.arbitrary.bool
 import io.kotest.property.arbitrary.int
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.ExperimentalTime
 
+@ExperimentalTime
 class STMTest : ArrowFxSpec(spec = {
   "no-effects" {
     atomically { 10 } shouldBeExactly 10

--- a/arrow-fx-stm/src/test/kotlin/arrow/fx/stm/TVarTest.kt
+++ b/arrow-fx-stm/src/test/kotlin/arrow/fx/stm/TVarTest.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.ExperimentalTime
 
+@ExperimentalTime
 class TVarTest : ArrowFxSpec(spec = {
   "unsafeRead is consistent with atomically { read }" {
     val tv = TVar.new(10)

--- a/build.gradle
+++ b/build.gradle
@@ -61,16 +61,4 @@ configure(
 
   apply from: "$SUB_PROJECT"
   apply from: "$DOC_CREATION"
-
-  // usage of kotlin.time
-  compileKotlin {
-    kotlinOptions {
-      freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-  }
-  compileTestKotlin {
-    kotlinOptions {
-      freeCompilerArgs = ["-Xopt-in=kotlin.time.ExperimentalTime"]
-    }
-  }
 }


### PR DESCRIPTION
## Status
READY ~ON HOLD (blocked by #389)~

## Description
This PR removes all breaking changes from CircuitBreaker and adds deprecation from `arrow.fx.coroutines.Duration` to `kotlin. Double` and `kotlin.time.Duration`.
It also adds `@ExperimentalTime` on all APIs using `kotlin.time.Duration`.

It removes the gradle configuration to allow `kotlin.time.Duration` so that we get proper messages.

## Related PRs
* #389 
