### PR TITLE
CU-bcu7fc Deprecate all public functions, data types and generated code for IO

### DIFF
--- a/arrow-fx/build.gradle
+++ b/arrow-fx/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "org.jetbrains.kotlin.jvm"
-    id "org.jetbrains.kotlin.kapt"
     id "org.jlleitschuh.gradle.ktlint"
 }
 
@@ -14,8 +13,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$KOTLINX_COROUTINES_VERSION"
 
     compile "io.arrow-kt:arrow-core:$VERSION_NAME"
-    kapt "io.arrow-kt:arrow-meta:$VERSION_NAME"
-    kaptTest "io.arrow-kt:arrow-meta:$VERSION_NAME"
 
     testCompile "io.kotlintest:kotlintest-runner-junit5:$KOTLIN_TEST_VERSION", excludeArrow
     testCompile project(":arrow-fx-coroutines")

--- a/arrow-fx/src/main/kotlin/arrow/fx/Ref.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Ref.kt
@@ -206,6 +206,7 @@ interface Ref<F, A> {
  * }
  * ```
  */
+@Deprecated(IODeprecation)
 interface RefFactory<F> {
 
   /**

--- a/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Schedule.kt
@@ -901,6 +901,7 @@ sealed class Schedule<F, Input, Output> : ScheduleOf<F, Input, Output> {
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Returns the last output from the policy or raises an error if a repeat failed.
  */
+@Deprecated(IODeprecation)
 fun <F, A, B> Kind<F, A>.repeat(
   CF: Concurrent<F>,
   schedule: Schedule<F, A, B>
@@ -910,6 +911,7 @@ fun <F, A, B> Kind<F, A>.repeat(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Returns the last output from the policy or raises an error if a repeat failed.
  */
+@Deprecated(IODeprecation)
 fun <F, E, A, B> Kind<F, A>.repeat(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -920,6 +922,7 @@ fun <F, E, A, B> Kind<F, A>.repeat(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during repetition.
  */
+@Deprecated(IODeprecation)
 fun <F, A, B> Kind<F, A>.repeatOrElse(
   CF: Concurrent<F>,
   schedule: Schedule<F, A, B>,
@@ -930,6 +933,7 @@ fun <F, A, B> Kind<F, A>.repeatOrElse(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during repetition.
  */
+@Deprecated(IODeprecation)
 fun <F, E, A, B> Kind<F, A>.repeatOrElse(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -941,6 +945,7 @@ fun <F, E, A, B> Kind<F, A>.repeatOrElse(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during repetition.
  */
+@Deprecated(IODeprecation)
 fun <F, A, B, C> Kind<F, A>.repeatOrElseEither(
   CF: Concurrent<F>,
   schedule: Schedule<F, A, B>,
@@ -951,6 +956,7 @@ fun <F, A, B, C> Kind<F, A>.repeatOrElseEither(
  * Run this effect once and, if it succeeded, decide using the passed policy if the effect should be repeated and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during repetition.
  */
+@Deprecated(IODeprecation)
 fun <F, E, A, B, C> Kind<F, A>.repeatOrElseEither(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -976,6 +982,7 @@ fun <F, E, A, B, C> Kind<F, A>.repeatOrElseEither(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Returns the result of the effect if if it was successful or re-raises the last error encountered when the schedule ends.
  */
+@Deprecated(IODeprecation)
 fun <F, A, B> Kind<F, A>.retry(
   CF: Concurrent<F>,
   schedule: Schedule<F, Throwable, B>
@@ -985,6 +992,7 @@ fun <F, A, B> Kind<F, A>.retry(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Returns the result of the effect if if it was successful or re-raises the last error encountered when the schedule ends.
  */
+@Deprecated(IODeprecation)
 fun <F, E, A, B> Kind<F, A>.retry(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -995,6 +1003,7 @@ fun <F, E, A, B> Kind<F, A>.retry(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during retrial.
  */
+@Deprecated(IODeprecation)
 fun <F, A, B> Kind<F, A>.retryOrElse(
   CF: Concurrent<F>,
   schedule: Schedule<F, Throwable, B>,
@@ -1005,6 +1014,7 @@ fun <F, A, B> Kind<F, A>.retryOrElse(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during retrial.
  */
+@Deprecated(IODeprecation)
 fun <F, E, A, B> Kind<F, A>.retryOrElse(
   ME: MonadError<F, E>,
   T: Timer<F>,
@@ -1016,6 +1026,7 @@ fun <F, E, A, B> Kind<F, A>.retryOrElse(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during retrial.
  */
+@Deprecated(IODeprecation)
 fun <F, A, B, C> Kind<F, A>.retryOrElseEither(
   CF: Concurrent<F>,
   schedule: Schedule<F, Throwable, B>,
@@ -1026,6 +1037,7 @@ fun <F, A, B, C> Kind<F, A>.retryOrElseEither(
  * Run an effect and, if it fails, decide using the passed policy if the effect should be retried and if so, with how much delay.
  * Also offers a function to handle errors if they are encountered during retrial.
  */
+@Deprecated(IODeprecation)
 fun <F, E, A, B, C> Kind<F, A>.retryOrElseEither(
   ME: MonadError<F, E>,
   T: Timer<F>,

--- a/arrow-fx/src/main/kotlin/arrow/fx/Semaphore.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/Semaphore.kt
@@ -17,6 +17,7 @@ import arrow.typeclasses.ApplicativeError
  * A counting [Semaphore] is used to control access to a resource in a concurrent system.
  * It keeps track of the count of available resources.
  */
+@Deprecated(IODeprecation)
 interface Semaphore<F> {
 
   /**

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/ExitCaseEq.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/ExitCaseEq.kt
@@ -1,11 +1,9 @@
 package arrow.fx.extensions
 
-import arrow.extension
 import arrow.fx.IODeprecation
 import arrow.fx.typeclasses.ExitCase
 import arrow.typeclasses.Eq
 
-@extension
 @Deprecated(IODeprecation)
 interface ExitCaseEq<E> : Eq<ExitCase<E>> {
   fun EQE(): Eq<E>

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/QueueInvariant.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/QueueInvariant.kt
@@ -2,7 +2,6 @@ package arrow.fx.extensions
 
 import arrow.Kind
 import arrow.core.Option
-import arrow.extension
 import arrow.fx.IODeprecation
 import arrow.fx.Queue
 import arrow.fx.QueueOf
@@ -12,7 +11,6 @@ import arrow.typeclasses.Functor
 import arrow.typeclasses.Invariant
 import arrow.undocumented
 
-@extension
 @undocumented
 @Deprecated(IODeprecation)
 interface QueueInvariant<F> : Invariant<QueuePartialOf<F>> {

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration.kt
@@ -1,7 +1,6 @@
 package arrow.fx.extensions
 
 import arrow.core.Ordering
-import arrow.extension
 import arrow.fx.IODeprecation
 import arrow.fx.typeclasses.Duration
 import arrow.fx.typeclasses.seconds
@@ -11,32 +10,27 @@ import arrow.typeclasses.Monoid
 import arrow.typeclasses.Order
 import arrow.typeclasses.Semigroup
 
-@extension
 @Deprecated(IODeprecation)
 interface DurationEq : Eq<Duration> {
   override fun Duration.eqv(b: Duration): Boolean = compareTo(b) == 0
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface DurationHash : Hash<Duration> {
   override fun Duration.hash(): Int = hashCode()
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface DurationOrder : Order<Duration> {
   override fun Duration.compare(b: Duration): Ordering =
     Ordering.fromInt(this.compareTo(b))
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface DurationSemigroup : Semigroup<Duration> {
   override fun Duration.combine(b: Duration): Duration = this + b
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface DurationMonoid : Monoid<Duration>, DurationSemigroup {
   override fun empty(): Duration = 0.seconds

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/eq/DurationEq.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/eq/DurationEq.kt
@@ -1,0 +1,36 @@
+package arrow.fx.extensions.duration.eq
+
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.DurationEq
+import arrow.fx.typeclasses.Duration
+import arrow.fx.typeclasses.Duration.Companion
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val eq_singleton: DurationEq = object : arrow.fx.extensions.DurationEq {}
+
+@JvmName("neqv")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.neqv(arg1: Duration): Boolean = arrow.fx.typeclasses.Duration.eq().run {
+  this@neqv.neqv(arg1) as kotlin.Boolean
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.eq(): DurationEq = eq_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/hash/DurationHash.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/hash/DurationHash.kt
@@ -1,0 +1,36 @@
+package arrow.fx.extensions.duration.hash
+
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.DurationHash
+import arrow.fx.typeclasses.Duration
+import arrow.fx.typeclasses.Duration.Companion
+import kotlin.Deprecated
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val hash_singleton: DurationHash = object : arrow.fx.extensions.DurationHash {}
+
+@JvmName("hashWithSalt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.hashWithSalt(arg1: Int): Int = arrow.fx.typeclasses.Duration.hash().run {
+  this@hashWithSalt.hashWithSalt(arg1) as kotlin.Int
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.hash(): DurationHash = hash_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/monoid/DurationMonoid.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/monoid/DurationMonoid.kt
@@ -1,0 +1,49 @@
+package arrow.fx.extensions.duration.monoid
+
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.DurationMonoid
+import arrow.fx.typeclasses.Duration
+import arrow.fx.typeclasses.Duration.Companion
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.collections.Collection
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monoid_singleton: DurationMonoid = object : arrow.fx.extensions.DurationMonoid {}
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Collection<Duration>.combineAll(): Duration = arrow.fx.typeclasses.Duration.monoid().run {
+  this@combineAll.combineAll() as arrow.fx.typeclasses.Duration
+}
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun combineAll(arg0: List<Duration>): Duration = arrow.fx.typeclasses.Duration
+   .monoid()
+   .combineAll(arg0) as arrow.fx.typeclasses.Duration
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.monoid(): DurationMonoid = monoid_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/order/DurationOrder.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/order/DurationOrder.kt
@@ -1,0 +1,136 @@
+package arrow.fx.extensions.duration.order
+
+import arrow.core.Tuple2
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.DurationOrder
+import arrow.fx.typeclasses.Duration
+import arrow.fx.typeclasses.Duration.Companion
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val order_singleton: DurationOrder = object : arrow.fx.extensions.DurationOrder {}
+
+@JvmName("compareTo")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+operator fun Duration.compareTo(arg1: Duration): Int = arrow.fx.typeclasses.Duration.order().run {
+  this@compareTo.compareTo(arg1) as kotlin.Int
+}
+
+@JvmName("eqv")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.eqv(arg1: Duration): Boolean = arrow.fx.typeclasses.Duration.order().run {
+  this@eqv.eqv(arg1) as kotlin.Boolean
+}
+
+@JvmName("lt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.lt(arg1: Duration): Boolean = arrow.fx.typeclasses.Duration.order().run {
+  this@lt.lt(arg1) as kotlin.Boolean
+}
+
+@JvmName("lte")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.lte(arg1: Duration): Boolean = arrow.fx.typeclasses.Duration.order().run {
+  this@lte.lte(arg1) as kotlin.Boolean
+}
+
+@JvmName("gt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.gt(arg1: Duration): Boolean = arrow.fx.typeclasses.Duration.order().run {
+  this@gt.gt(arg1) as kotlin.Boolean
+}
+
+@JvmName("gte")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.gte(arg1: Duration): Boolean = arrow.fx.typeclasses.Duration.order().run {
+  this@gte.gte(arg1) as kotlin.Boolean
+}
+
+@JvmName("max")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.max(arg1: Duration): Duration = arrow.fx.typeclasses.Duration.order().run {
+  this@max.max(arg1) as arrow.fx.typeclasses.Duration
+}
+
+@JvmName("min")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.min(arg1: Duration): Duration = arrow.fx.typeclasses.Duration.order().run {
+  this@min.min(arg1) as arrow.fx.typeclasses.Duration
+}
+
+@JvmName("sort")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.sort(arg1: Duration): Tuple2<Duration, Duration> =
+    arrow.fx.typeclasses.Duration.order().run {
+  this@sort.sort(arg1) as arrow.core.Tuple2<arrow.fx.typeclasses.Duration,
+    arrow.fx.typeclasses.Duration>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.order(): DurationOrder = order_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/semigroup/DurationSemigroup.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/duration/semigroup/DurationSemigroup.kt
@@ -1,0 +1,50 @@
+package arrow.fx.extensions.duration.semigroup
+
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.DurationSemigroup
+import arrow.fx.typeclasses.Duration
+import arrow.fx.typeclasses.Duration.Companion
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val semigroup_singleton: DurationSemigroup = object : arrow.fx.extensions.DurationSemigroup
+    {}
+
+@JvmName("plus")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+operator fun Duration.plus(arg1: Duration): Duration =
+    arrow.fx.typeclasses.Duration.semigroup().run {
+  this@plus.plus(arg1) as arrow.fx.typeclasses.Duration
+}
+
+@JvmName("maybeCombine")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Duration.maybeCombine(arg1: Duration): Duration =
+    arrow.fx.typeclasses.Duration.semigroup().run {
+  this@maybeCombine.maybeCombine(arg1) as arrow.fx.typeclasses.Duration
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.semigroup(): DurationSemigroup = semigroup_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/eq/ExitCaseEq.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/eq/ExitCaseEq.kt
@@ -1,0 +1,32 @@
+package arrow.fx.extensions.eq
+
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.ExitCaseEq
+import arrow.fx.typeclasses.ExitCase
+import arrow.fx.typeclasses.ExitCase.Companion
+import arrow.typeclasses.Eq
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("neqv")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <E> ExitCase<E>.neqv(EQE: Eq<E>, arg1: ExitCase<E>): Boolean =
+    arrow.fx.typeclasses.ExitCase.eq<E>(EQE).run {
+  this@neqv.neqv(arg1) as kotlin.Boolean
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <E> Companion.eq(EQE: Eq<E>): ExitCaseEq<E> = object : arrow.fx.extensions.ExitCaseEq<E>
+    { override fun EQE(): arrow.typeclasses.Eq<E> = EQE }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/eq/ExitCaseEq.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/eq/ExitCaseEq.kt
@@ -1,4 +1,4 @@
-package arrow.fx.extensions.eq
+package arrow.fx.extensions.exitcase.eq
 
 import arrow.fx.IODeprecation
 import arrow.fx.extensions.ExitCaseEq

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/fiber.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/fiber.kt
@@ -2,6 +2,7 @@ package arrow.fx.extensions
 
 import arrow.Kind
 import arrow.core.Tuple2
+import arrow.fx.IODeprecation
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.ExitCase
 import arrow.fx.typeclasses.Fiber
@@ -15,6 +16,7 @@ import arrow.typeclasses.Functor
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Semigroup
 
+@Deprecated(IODeprecation)
 fun <F> Fiber.Companion.functor(C: Concurrent<F>): Functor<Kind<ForFiber, F>> =
   object : Functor<FiberPartialOf<F>> {
     override fun <A, B> FiberOf<F, A>.map(f: (A) -> B): Fiber<F, B> = C.run {
@@ -23,6 +25,7 @@ fun <F> Fiber.Companion.functor(C: Concurrent<F>): Functor<Kind<ForFiber, F>> =
     }
   }
 
+@Deprecated(IODeprecation)
 fun <F> Fiber.Companion.apply(C: Concurrent<F>): Apply<Kind<ForFiber, F>> =
   object : Apply<FiberPartialOf<F>>, Functor<FiberPartialOf<F>> by functor(C) {
     override fun <A, B> Kind<FiberPartialOf<F>, A>.ap(ff: Kind<FiberPartialOf<F>, (A) -> B>): Kind<FiberPartialOf<F>, B> = C.run {
@@ -50,12 +53,14 @@ fun <F> Fiber.Companion.apply(C: Concurrent<F>): Apply<Kind<ForFiber, F>> =
     }
   }
 
+@Deprecated(IODeprecation)
 fun <F> Fiber.Companion.applicative(C: Concurrent<F>): Applicative<Kind<ForFiber, F>> =
   object : Applicative<FiberPartialOf<F>>, Apply<FiberPartialOf<F>> by apply(C) {
     override fun <A> just(a: A): Kind<FiberPartialOf<F>, A> =
       Fiber(C.just(a), C.unit())
   }
 
+@Deprecated(IODeprecation)
 fun <F, A> Fiber.Companion.semigroup(C: Concurrent<F>, S: Semigroup<A>) =
   object : Semigroup<Fiber<F, A>> {
     override fun Fiber<F, A>.combine(b: Fiber<F, A>): Fiber<F, A> = apply(C).run {
@@ -65,6 +70,7 @@ fun <F, A> Fiber.Companion.semigroup(C: Concurrent<F>, S: Semigroup<A>) =
     }
   }
 
+@Deprecated(IODeprecation)
 fun <F, A> Fiber.Companion.monoid(C: Concurrent<F>, M: Monoid<A>): Monoid<Fiber<F, A>> =
   object : Monoid<Fiber<F, A>>, Semigroup<Fiber<F, A>> by semigroup(C, M) {
     override fun empty(): Fiber<F, A> =

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/invariant/QueueInvariant.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/invariant/QueueInvariant.kt
@@ -1,0 +1,37 @@
+package arrow.fx.extensions.invariant
+
+import arrow.Kind
+import arrow.fx.ForQueue
+import arrow.fx.IODeprecation
+import arrow.fx.Queue
+import arrow.fx.Queue.Companion
+import arrow.fx.extensions.QueueInvariant
+import arrow.typeclasses.Functor
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, A, B> Kind<Kind<ForQueue, F>, A>.imap(
+  FR: Functor<F>,
+  arg1: Function1<A, B>,
+  arg2: Function1<B, A>
+): Queue<F, B> = arrow.fx.Queue.invariant<F>(FR).run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.Queue<F, B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F> Companion.invariant(FR: Functor<F>): QueueInvariant<F> = object :
+    arrow.fx.extensions.QueueInvariant<F> { override fun FR(): arrow.typeclasses.Functor<F> = FR }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io.kt
@@ -6,7 +6,6 @@ import arrow.core.Eval
 import arrow.core.Tuple2
 import arrow.core.Tuple3
 import arrow.core.identity
-import arrow.extension
 import arrow.fx.ForIO
 import arrow.fx.IO
 import arrow.fx.IODeprecation
@@ -54,14 +53,12 @@ import kotlin.coroutines.CoroutineContext
 import arrow.fx.handleError as ioHandleError
 import arrow.fx.handleErrorWith as ioHandleErrorWith
 
-@extension
 @Deprecated(IODeprecation)
 interface IOFunctor : Functor<ForIO> {
   override fun <A, B> IOOf<A>.map(f: (A) -> B): IO<B> =
     fix().map(f)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOApply : Apply<ForIO> {
   override fun <A, B> IOOf<A>.map(f: (A) -> B): IO<B> =
@@ -74,7 +71,6 @@ interface IOApply : Apply<ForIO> {
     Eval.now(fix().ap(IO.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOApplicative : Applicative<ForIO> {
   override fun <A, B> IOOf<A>.map(f: (A) -> B): IO<B> =
@@ -90,7 +86,6 @@ interface IOApplicative : Applicative<ForIO> {
     Eval.now(fix().ap(IO.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOMonad : Monad<ForIO> {
   override fun <A, B> IOOf<A>.flatMap(f: (A) -> IOOf<B>): IO<B> =
@@ -109,7 +104,6 @@ interface IOMonad : Monad<ForIO> {
     Eval.now(fix().ap(IO.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOApplicativeError : ApplicativeError<ForIO, Throwable>, IOApplicative {
   override fun <A> IOOf<A>.attempt(): IO<Either<Throwable, A>> =
@@ -128,7 +122,6 @@ interface IOApplicativeError : ApplicativeError<ForIO, Throwable>, IOApplicative
     IO.raiseError(e)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOMonadError : MonadError<ForIO, Throwable>, IOApplicativeError, IOMonad {
 
@@ -156,11 +149,9 @@ interface IOMonadError : MonadError<ForIO, Throwable>, IOApplicativeError, IOMon
     Eval.now(fix().ap(IO.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOMonadThrow : MonadThrow<ForIO>, IOMonadError
 
-@extension
 @Deprecated(IODeprecation)
 interface IOBracket : Bracket<ForIO, Throwable>, IOMonadThrow {
   override fun <A, B> IOOf<A>.bracketCase(release: (A, ExitCase<Throwable>) -> IOOf<Unit>, use: (A) -> IOOf<B>): IO<B> =
@@ -176,7 +167,6 @@ interface IOBracket : Bracket<ForIO, Throwable>, IOMonadThrow {
     fix().guaranteeCase(finalizer)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOMonadDefer : MonadDefer<ForIO>, IOBracket {
   override fun <A> defer(fa: () -> IOOf<A>): IO<A> =
@@ -185,7 +175,6 @@ interface IOMonadDefer : MonadDefer<ForIO>, IOBracket {
   override fun lazy(): IO<Unit> = IO.lazy
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOAsync : Async<ForIO>, IOMonadDefer {
   override fun <A> async(fa: Proc<A>): IO<A> =
@@ -235,14 +224,15 @@ interface IOConcurrent : Concurrent<ForIO>, IOAsync {
     IO.raceN(this@raceN, fa, fb, fc)
 }
 
+@Deprecated(IODeprecation)
 fun IO.Companion.concurrent(dispatchers: Dispatchers<ForIO>): Concurrent<ForIO> = object : IOConcurrent {
   override fun dispatchers(): Dispatchers<ForIO> = dispatchers
 }
 
+@Deprecated(IODeprecation)
 fun IO.Companion.timer(CF: Concurrent<ForIO>): Timer<ForIO> =
   Timer(CF)
 
-@extension
 @Deprecated(IODeprecation)
 interface IOEffect : Effect<ForIO>, IOAsync {
   override fun <A> IOOf<A>.runAsync(cb: (Either<Throwable, A>) -> IOOf<Unit>): IO<Unit> =
@@ -261,7 +251,6 @@ fun IO.Companion.concurrentEffect(dispatchers: Dispatchers<ForIO>): ConcurrentEf
   override fun dispatchers(): Dispatchers<ForIO> = dispatchers
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOSemigroup<A> : Semigroup<IO<A>> {
 
@@ -271,7 +260,6 @@ interface IOSemigroup<A> : Semigroup<IO<A>> {
     flatMap { a1: A -> b.map { a2: A -> SG().run { a1.combine(a2) } } }
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOMonoid<A> : Monoid<IO<A>>, IOSemigroup<A> {
   override fun SG(): Monoid<A>
@@ -279,13 +267,11 @@ interface IOMonoid<A> : Monoid<IO<A>>, IOSemigroup<A> {
   override fun empty(): IO<A> = IO.just(SG().empty())
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOMonadIO : MonadIO<ForIO>, IOMonad {
   override fun <A> IO<A>.liftIO(): Kind<ForIO, A> = this
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOUnsafeRun : UnsafeRun<ForIO> {
 
@@ -295,7 +281,6 @@ interface IOUnsafeRun : UnsafeRun<ForIO> {
     fa().fix().unsafeRunAsync(cb)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOUnsafeCancellableRun : UnsafeCancellableRun<ForIO> {
   override suspend fun <A> unsafe.runBlocking(fa: () -> Kind<ForIO, A>): A = fa().fix().unsafeRunSync()
@@ -307,7 +292,6 @@ interface IOUnsafeCancellableRun : UnsafeCancellableRun<ForIO> {
     fa().fix().unsafeRunAsyncCancellable(onCancel, cb)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IODispatchers : Dispatchers<ForIO> {
   override fun default(): CoroutineContext =
@@ -317,7 +301,6 @@ interface IODispatchers : Dispatchers<ForIO> {
     IODispatchers.IOPool
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IOEnvironment : Environment<ForIO> {
   override fun dispatchers(): Dispatchers<ForIO> =
@@ -327,7 +310,6 @@ interface IOEnvironment : Environment<ForIO> {
     IO { println("Found uncaught async exception!"); e.printStackTrace() }
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface IODefaultConcurrent : Concurrent<ForIO>, IOConcurrent {
 
@@ -335,12 +317,13 @@ interface IODefaultConcurrent : Concurrent<ForIO>, IOConcurrent {
     IO.dispatchers()
 }
 
+@Deprecated(IODeprecation)
 fun IO.Companion.timer(): Timer<ForIO> = Timer(IO.concurrent())
 
-@extension
 @Deprecated(IODeprecation)
 interface IODefaultConcurrentEffect : ConcurrentEffect<ForIO>, IOConcurrentEffect, IODefaultConcurrent
 
+@Deprecated(IODeprecation)
 fun <A> IO.Companion.fx(c: suspend ConcurrentSyntax<ForIO>.() -> A): IO<A> =
   IO.concurrent().fx.concurrent(c).fix()
 
@@ -348,6 +331,7 @@ fun <A> IO.Companion.fx(c: suspend ConcurrentSyntax<ForIO>.() -> A): IO<A> =
  * converts this Either to an IO. The resulting IO will evaluate to this Eithers
  * Right value or alternatively to the result of applying the specified function to this Left value.
  */
+@Deprecated(IODeprecation)
 fun <E, A> Either<E, A>.toIO(f: (E) -> Throwable): IO<A> =
   fold({ IO.raiseError(f(it)) }, { IO.just(it) })
 
@@ -355,10 +339,10 @@ fun <E, A> Either<E, A>.toIO(f: (E) -> Throwable): IO<A> =
  * converts this Either to an IO. The resulting IO will evaluate to this Eithers
  * Right value or Left exception.
  */
+@Deprecated(IODeprecation)
 fun <A> Either<Throwable, A>.toIO(): IO<A> =
   toIO(::identity)
 
-@extension
 @Deprecated(IODeprecation)
 interface IOSemigroupK : SemigroupK<ForIO> {
   override fun <A> Kind<ForIO, A>.combineK(y: Kind<ForIO, A>): Kind<ForIO, A> =

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/applicative/IOApplicative.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/applicative/IOApplicative.kt
@@ -1,0 +1,91 @@
+package arrow.fx.extensions.io.applicative
+
+import arrow.Kind
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOApplicative
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicative_singleton: IOApplicative = object : arrow.fx.extensions.IOApplicative {}
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> A.just(): IO<A> = arrow.fx.IO.applicative().run {
+  this@just.just<A>() as arrow.fx.IO<A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun unit(): IO<Unit> = arrow.fx.IO
+   .applicative()
+   .unit() as arrow.fx.IO<kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.map(arg1: Function1<A, B>): IO<B> = arrow.fx.IO.applicative().run {
+  this@map.map<A, B>(arg1) as arrow.fx.IO<B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.replicate(arg1: Int): IO<List<A>> = arrow.fx.IO.applicative().run {
+  this@replicate.replicate<A>(arg1) as arrow.fx.IO<kotlin.collections.List<A>>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.replicate(arg1: Int, arg2: Monoid<A>): IO<A> =
+    arrow.fx.IO.applicative().run {
+  this@replicate.replicate<A>(arg1, arg2) as arrow.fx.IO<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.applicative(): IOApplicative = applicative_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/applicativeError/IOApplicativeError.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/applicativeError/IOApplicativeError.kt
@@ -1,0 +1,172 @@
+package arrow.fx.extensions.io.applicativeError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.ForOption
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOApplicativeError
+import arrow.typeclasses.ApplicativeError
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicativeError_singleton: IOApplicativeError = object :
+    arrow.fx.extensions.IOApplicativeError {}
+
+@JvmName("handleErrorWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.handleErrorWith(arg1: Function1<Throwable, Kind<ForIO, A>>): IO<A> =
+    arrow.fx.IO.applicativeError().run {
+  this@handleErrorWith.handleErrorWith<A>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("raiseError1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Throwable.raiseError(): IO<A> = arrow.fx.IO.applicativeError().run {
+  this@raiseError.raiseError<A>() as arrow.fx.IO<A>
+}
+
+@JvmName("fromOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForOption, A>.fromOption(arg1: Function0<Throwable>): IO<A> =
+    arrow.fx.IO.applicativeError().run {
+  this@fromOption.fromOption<A>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("fromEither")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, Throwable>): IO<A> =
+    arrow.fx.IO.applicativeError().run {
+  this@fromEither.fromEither<A, EE>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("handleError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.handleError(arg1: Function1<Throwable, A>): IO<A> =
+    arrow.fx.IO.applicativeError().run {
+  this@handleError.handleError<A>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("redeem")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.redeem(arg1: Function1<Throwable, B>, arg2: Function1<A, B>): IO<B> =
+    arrow.fx.IO.applicativeError().run {
+  this@redeem.redeem<A, B>(arg1, arg2) as arrow.fx.IO<B>
+}
+
+@JvmName("attempt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.attempt(): IO<Either<Throwable, A>> = arrow.fx.IO.applicativeError().run {
+  this@attempt.attempt<A>() as arrow.fx.IO<arrow.core.Either<kotlin.Throwable, A>>
+}
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> catch(arg0: Function1<Throwable, Throwable>, arg1: Function0<A>): IO<A> = arrow.fx.IO
+   .applicativeError()
+   .catch<A>(arg0, arg1) as arrow.fx.IO<A>
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> ApplicativeError<ForIO, Throwable>.catch(arg1: Function0<A>): IO<A> =
+    arrow.fx.IO.applicativeError().run {
+  this@catch.catch<A>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+suspend fun <A> effectCatch(arg0: Function1<Throwable, Throwable>, arg1: suspend () -> A): IO<A> =
+    arrow.fx.IO
+   .applicativeError()
+   .effectCatch<A>(arg0, arg1) as arrow.fx.IO<A>
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+suspend fun <F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend () -> A): Kind<F, A> =
+    arrow.fx.IO.applicativeError().run {
+  this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.applicativeError(): IOApplicativeError = applicativeError_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/apply/IOApply.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/apply/IOApply.kt
@@ -1,0 +1,952 @@
+package arrow.fx.extensions.io.apply
+
+import arrow.Kind
+import arrow.core.Eval
+import arrow.core.Tuple10
+import arrow.core.Tuple2
+import arrow.core.Tuple3
+import arrow.core.Tuple4
+import arrow.core.Tuple5
+import arrow.core.Tuple6
+import arrow.core.Tuple7
+import arrow.core.Tuple8
+import arrow.core.Tuple9
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOApply
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val apply_singleton: IOApply = object : arrow.fx.extensions.IOApply {}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.ap(arg1: Kind<ForIO, Function1<A, B>>): IO<B> = arrow.fx.IO.apply().run {
+  this@ap.ap<A, B>(arg1) as arrow.fx.IO<B>
+}
+
+@JvmName("apEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.apEval(arg1: Eval<Kind<ForIO, Function1<A, B>>>): Eval<Kind<ForIO, B>> =
+    arrow.fx.IO.apply().run {
+  this@apEval.apEval<A, B>(arg1) as arrow.core.Eval<arrow.Kind<arrow.fx.ForIO, B>>
+}
+
+@JvmName("map2Eval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, Z> Kind<ForIO, A>.map2Eval(arg1: Eval<Kind<ForIO, B>>, arg2: Function1<Tuple2<A, B>, Z>):
+    Eval<Kind<ForIO, Z>> = arrow.fx.IO.apply().run {
+  this@map2Eval.map2Eval<A, B, Z>(arg1, arg2) as arrow.core.Eval<arrow.Kind<arrow.fx.ForIO, Z>>
+}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, Z> map(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .map<A, B, Z>(arg0, arg1, arg2) as arrow.fx.IO<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, Z> mapN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .mapN<A, B, Z>(arg0, arg1, arg2) as arrow.fx.IO<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, Z> map(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Function1<Tuple3<A, B, C>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .map<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.fx.IO<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, Z> mapN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Function1<Tuple3<A, B, C>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .mapN<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.fx.IO<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, Z> map(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Function1<Tuple4<A, B, C, D>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .map<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.fx.IO<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, Z> mapN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Function1<Tuple4<A, B, C, D>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .mapN<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.fx.IO<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, Z> map(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Function1<Tuple5<A, B, C, D, E>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .map<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.fx.IO<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, Z> mapN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Function1<Tuple5<A, B, C, D, E>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .mapN<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.fx.IO<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, Z> map(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .map<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.fx.IO<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, Z> mapN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .mapN<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.fx.IO<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, Z> map(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .map<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as arrow.fx.IO<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, Z> mapN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .mapN<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as arrow.fx.IO<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, Z> map(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .map<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+    arrow.fx.IO<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, Z> mapN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .mapN<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+    arrow.fx.IO<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, I, Z> map(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Kind<ForIO, I>,
+  arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .map<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    as arrow.fx.IO<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, I, Z> mapN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Kind<ForIO, I>,
+  arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .mapN<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+    as arrow.fx.IO<Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, I, J, Z> map(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Kind<ForIO, I>,
+  arg9: Kind<ForIO, J>,
+  arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .map<A, B, C, D, E, FF, G, H, I, J,
+    Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.fx.IO<Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, I, J, Z> mapN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Kind<ForIO, I>,
+  arg9: Kind<ForIO, J>,
+  arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
+): IO<Z> = arrow.fx.IO
+   .apply()
+   .mapN<A, B, C, D, E, FF, G, H, I, J,
+    Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.fx.IO<Z>
+
+@JvmName("map2")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, Z> Kind<ForIO, A>.map2(arg1: Kind<ForIO, B>, arg2: Function1<Tuple2<A, B>, Z>): IO<Z> =
+    arrow.fx.IO.apply().run {
+  this@map2.map2<A, B, Z>(arg1, arg2) as arrow.fx.IO<Z>
+}
+
+@JvmName("product")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.product(arg1: Kind<ForIO, B>): IO<Tuple2<A, B>> =
+    arrow.fx.IO.apply().run {
+  this@product.product<A, B>(arg1) as arrow.fx.IO<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("product1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, Z> Kind<ForIO, Tuple2<A, B>>.product(arg1: Kind<ForIO, Z>): IO<Tuple3<A, B, Z>> =
+    arrow.fx.IO.apply().run {
+  this@product.product<A, B, Z>(arg1) as arrow.fx.IO<arrow.core.Tuple3<A, B, Z>>
+}
+
+@JvmName("product2")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, Z> Kind<ForIO, Tuple3<A, B, C>>.product(arg1: Kind<ForIO, Z>): IO<Tuple4<A, B, C, Z>> =
+    arrow.fx.IO.apply().run {
+  this@product.product<A, B, C, Z>(arg1) as arrow.fx.IO<arrow.core.Tuple4<A, B, C, Z>>
+}
+
+@JvmName("product3")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, Z> Kind<ForIO, Tuple4<A, B, C, D>>.product(arg1: Kind<ForIO, Z>): IO<Tuple5<A, B,
+    C, D, Z>> = arrow.fx.IO.apply().run {
+  this@product.product<A, B, C, D, Z>(arg1) as arrow.fx.IO<arrow.core.Tuple5<A, B, C, D, Z>>
+}
+
+@JvmName("product4")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, Z> Kind<ForIO, Tuple5<A, B, C, D, E>>.product(arg1: Kind<ForIO, Z>):
+    IO<Tuple6<A, B, C, D, E, Z>> = arrow.fx.IO.apply().run {
+  this@product.product<A, B, C, D, E, Z>(arg1) as arrow.fx.IO<arrow.core.Tuple6<A, B, C, D, E, Z>>
+}
+
+@JvmName("product5")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, Z> Kind<ForIO, Tuple6<A, B, C, D, E, FF>>.product(arg1: Kind<ForIO, Z>):
+    IO<Tuple7<A, B, C, D, E, FF, Z>> = arrow.fx.IO.apply().run {
+  this@product.product<A, B, C, D, E, FF, Z>(arg1) as arrow.fx.IO<arrow.core.Tuple7<A, B, C, D, E,
+    FF, Z>>
+}
+
+@JvmName("product6")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, Z> Kind<ForIO, Tuple7<A, B, C, D, E, FF, G>>.product(
+  arg1: Kind<ForIO,
+Z>
+): IO<Tuple8<A, B, C, D, E, FF, G, Z>> = arrow.fx.IO.apply().run {
+  this@product.product<A, B, C, D, E, FF, G, Z>(arg1) as arrow.fx.IO<arrow.core.Tuple8<A, B, C, D,
+    E, FF, G, Z>>
+}
+
+@JvmName("product7")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, Z> Kind<ForIO, Tuple8<A, B, C, D, E, FF, G,
+    H>>.product(arg1: Kind<ForIO, Z>): IO<Tuple9<A, B, C, D, E, FF, G, H, Z>> =
+    arrow.fx.IO.apply().run {
+  this@product.product<A, B, C, D, E, FF, G, H, Z>(arg1) as arrow.fx.IO<arrow.core.Tuple9<A, B, C,
+    D, E, FF, G, H, Z>>
+}
+
+@JvmName("product8")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, I, Z> Kind<ForIO, Tuple9<A, B, C, D, E, FF, G, H,
+    I>>.product(arg1: Kind<ForIO, Z>): IO<Tuple10<A, B, C, D, E, FF, G, H, I, Z>> =
+    arrow.fx.IO.apply().run {
+  this@product.product<A, B, C, D, E, FF, G, H, I, Z>(arg1) as arrow.fx.IO<arrow.core.Tuple10<A, B,
+    C, D, E, FF, G, H, I, Z>>
+}
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> tupled(arg0: Kind<ForIO, A>, arg1: Kind<ForIO, B>): IO<Tuple2<A, B>> = arrow.fx.IO
+   .apply()
+   .tupled<A, B>(arg0, arg1) as arrow.fx.IO<arrow.core.Tuple2<A, B>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> tupledN(arg0: Kind<ForIO, A>, arg1: Kind<ForIO, B>): IO<Tuple2<A, B>> = arrow.fx.IO
+   .apply()
+   .tupledN<A, B>(arg0, arg1) as arrow.fx.IO<arrow.core.Tuple2<A, B>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C> tupled(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>
+): IO<Tuple3<A, B, C>> = arrow.fx.IO
+   .apply()
+   .tupled<A, B, C>(arg0, arg1, arg2) as arrow.fx.IO<arrow.core.Tuple3<A, B, C>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C> tupledN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>
+): IO<Tuple3<A, B, C>> = arrow.fx.IO
+   .apply()
+   .tupledN<A, B, C>(arg0, arg1, arg2) as arrow.fx.IO<arrow.core.Tuple3<A, B, C>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D> tupled(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>
+): IO<Tuple4<A, B, C, D>> = arrow.fx.IO
+   .apply()
+   .tupled<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.fx.IO<arrow.core.Tuple4<A, B, C, D>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D> tupledN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>
+): IO<Tuple4<A, B, C, D>> = arrow.fx.IO
+   .apply()
+   .tupledN<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.fx.IO<arrow.core.Tuple4<A, B, C, D>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E> tupled(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>
+): IO<Tuple5<A, B, C, D, E>> = arrow.fx.IO
+   .apply()
+   .tupled<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.fx.IO<arrow.core.Tuple5<A, B, C, D,
+    E>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E> tupledN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>
+): IO<Tuple5<A, B, C, D, E>> = arrow.fx.IO
+   .apply()
+   .tupledN<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.fx.IO<arrow.core.Tuple5<A, B, C,
+    D, E>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF> tupled(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>
+): IO<Tuple6<A, B, C, D, E, FF>> = arrow.fx.IO
+   .apply()
+   .tupled<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as
+    arrow.fx.IO<arrow.core.Tuple6<A, B, C, D, E, FF>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF> tupledN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>
+): IO<Tuple6<A, B, C, D, E, FF>> = arrow.fx.IO
+   .apply()
+   .tupledN<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as
+    arrow.fx.IO<arrow.core.Tuple6<A, B, C, D, E, FF>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G> tupled(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>
+): IO<Tuple7<A, B, C, D, E, FF, G>> = arrow.fx.IO
+   .apply()
+   .tupled<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as
+    arrow.fx.IO<arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G> tupledN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>
+): IO<Tuple7<A, B, C, D, E, FF, G>> = arrow.fx.IO
+   .apply()
+   .tupledN<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as
+    arrow.fx.IO<arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H> tupled(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>
+): IO<Tuple8<A, B, C, D, E, FF, G, H>> = arrow.fx.IO
+   .apply()
+   .tupled<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+    arrow.fx.IO<arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H> tupledN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>
+): IO<Tuple8<A, B, C, D, E, FF, G, H>> = arrow.fx.IO
+   .apply()
+   .tupledN<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+    arrow.fx.IO<arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, I> tupled(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Kind<ForIO, I>
+): IO<Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.fx.IO
+   .apply()
+   .tupled<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+    arrow.fx.IO<arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, I> tupledN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Kind<ForIO, I>
+): IO<Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.fx.IO
+   .apply()
+   .tupledN<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+    arrow.fx.IO<arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, I, J> tupled(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Kind<ForIO, I>,
+  arg9: Kind<ForIO, J>
+): IO<Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.fx.IO
+   .apply()
+   .tupled<A, B, C, D, E, FF, G, H, I,
+    J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as
+    arrow.fx.IO<arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, FF, G, H, I, J> tupledN(
+  arg0: Kind<ForIO, A>,
+  arg1: Kind<ForIO, B>,
+  arg2: Kind<ForIO, C>,
+  arg3: Kind<ForIO, D>,
+  arg4: Kind<ForIO, E>,
+  arg5: Kind<ForIO, FF>,
+  arg6: Kind<ForIO, G>,
+  arg7: Kind<ForIO, H>,
+  arg8: Kind<ForIO, I>,
+  arg9: Kind<ForIO, J>
+): IO<Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.fx.IO
+   .apply()
+   .tupledN<A, B, C, D, E, FF, G, H, I,
+    J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as
+    arrow.fx.IO<arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.followedBy(arg1: Kind<ForIO, B>): IO<B> = arrow.fx.IO.apply().run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.fx.IO<B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.apTap(arg1: Kind<ForIO, B>): IO<A> = arrow.fx.IO.apply().run {
+  this@apTap.apTap<A, B>(arg1) as arrow.fx.IO<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.apply(): IOApply = apply_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/async/IOAsync.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/async/IOAsync.kt
@@ -1,0 +1,313 @@
+package arrow.fx.extensions.io.async
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOAsync
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val async_singleton: IOAsync = object : arrow.fx.extensions.IOAsync {}
+
+/**
+ *  [async] variant that can suspend side effects in the provided registration function.
+ *
+ *  The passed in function is injected with a side-effectful callback for signaling the final result of an asynchronous process.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.*
+ * import arrow.fx.extensions.io.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.*
+ *  import arrow.fx.typeclasses.Async
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.makeCompleteAndGetPromiseInAsync() =
+ *     asyncF<String> { cb: (Either<Throwable, String>) -> Unit ->
+ *       Promise.uncancellable<F, String>(this).flatMap { promise ->
+ *         promise.complete("Hello World!").flatMap {
+ *           promise.get().map { str -> cb(Right(str)) }
+ *         }
+ *       }
+ *     }
+ *
+ *   val result = IO.async().makeCompleteAndGetPromiseInAsync()
+ *  //sampleEnd
+ *  println(result)
+ *  }
+ *  ```
+ *
+ *  @see async for a simpler, non suspending version.
+ */
+@JvmName("asyncF")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> asyncF(k: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForIO, Unit>>): IO<A> =
+    arrow.fx.IO
+   .async()
+   .asyncF<A>(k) as arrow.fx.IO<A>
+
+/**
+ *  Continue the evaluation on provided [CoroutineContext]
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.*
+ * import arrow.fx.extensions.io.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.runOnDefaultDispatcher(): Kind<F, String> =
+ *     just(Unit).continueOn(Dispatchers.Default).flatMap {
+ *       later({ Thread.currentThread().name })
+ *     }
+ *
+ *   val result = IO.async().runOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("continueOn")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.continueOn(ctx: CoroutineContext): IO<A> = arrow.fx.IO.async().run {
+  this@continueOn.continueOn<A>(ctx) as arrow.fx.IO<A>
+}
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.*
+ * import arrow.fx.extensions.io.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     later(Dispatchers.Default, { Thread.currentThread().name })
+ *
+ *   val result = IO.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> later(ctx: CoroutineContext, f: Function0<A>): IO<A> = arrow.fx.IO
+   .async()
+   .later<A>(ctx, f) as arrow.fx.IO<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.*
+ * import arrow.fx.extensions.io.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     defer(Dispatchers.Default, { effect { Thread.currentThread().name } })
+ *
+ *   val result = IO.async().invokeOnDefaultDispatcher().fix().unsafeRunSync()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> defer(ctx: CoroutineContext, f: Function0<Kind<ForIO, A>>): IO<A> = arrow.fx.IO
+   .async()
+   .defer<A>(ctx, f) as arrow.fx.IO<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ */
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> laterOrRaise(ctx: CoroutineContext, f: Function0<Either<Throwable, A>>): IO<A> = arrow.fx.IO
+   .async()
+   .laterOrRaise<A>(ctx, f) as arrow.fx.IO<A>
+
+/**
+ *  Shift evaluation to provided [CoroutineContext].
+ *
+ *  @receiver [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.*
+ * import arrow.fx.extensions.io.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   IO.async().run {
+ *     val result = Dispatchers.Default.shift().map {
+ *       Thread.currentThread().name
+ *     }
+ *
+ *     println(result)
+ *   }
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("shift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun CoroutineContext.shift(): IO<Unit> = arrow.fx.IO.async().run {
+  this@shift.shift() as arrow.fx.IO<kotlin.Unit>
+}
+
+/**
+ *  Task that never finishes evaluating.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.*
+ * import arrow.fx.extensions.io.async.*
+ * import arrow.core.*
+ *
+ *
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val i = IO.async().never<Int>()
+ *
+ *   println(i)
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("never")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> never(): IO<A> = arrow.fx.IO
+   .async()
+   .never<A>() as arrow.fx.IO<A>
+
+/**
+ *  Helper function that provides an easy way to construct a suspend effect
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.*
+ * import arrow.fx.extensions.io.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun logAndIncrease(s: String): Int {
+ *      println(s)
+ *      return s.toInt() + 1
+ *   }
+ *
+ *   val result = IO.async().effect(Dispatchers.Default) { Thread.currentThread().name }.effectMap { s: String -> logAndIncrease(s) }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effectMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.effectMap(f: suspend (A) -> B): IO<B> = arrow.fx.IO.async().run {
+  this@effectMap.effectMap<A, B>(f) as arrow.fx.IO<B>
+}
+
+/**
+ *  [Async] models how a data type runs an asynchronous computation that may fail.
+ *  Defined by the [Proc] signature, which is the consumption of a callback.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.async(): IOAsync = async_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/bracket/IOBracket.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/bracket/IOBracket.kt
@@ -1,0 +1,258 @@
+package arrow.fx.extensions.io.bracket
+
+import arrow.Kind
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOBracket
+import arrow.fx.typeclasses.ExitCase
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bracket_singleton: IOBracket = object : arrow.fx.extensions.IOBracket {}
+
+/**
+ *  A way to safely acquire a resource and release in the face of errors and cancellation.
+ *  It uses [ExitCase] to distinguish between different exit cases when releasing the acquired resource.
+ *
+ *  @param use is the action to consume the resource and produce an [F] with the result.
+ *  Once the resulting [F] terminates, either successfully, error or cancelled.
+ *
+ *  @param release the allocated resource after the resulting [F] of [use] is terminates.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.*
+ * import arrow.fx.extensions.io.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.extensions.io.monadDefer.defer
+ * import arrow.fx.extensions.io.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val release: (File, ExitCase<Throwable>) -> Kind<F, Unit> = { file, exitCase ->
+ *       when (exitCase) {
+ * do something * / }
+ * do something * / }
+ * do something * / }
+ *       }
+ *       closeFile(file)
+ *   }
+ *
+ *   val use: (File) -> Kind<F, String> = { file: File -> fileToString(file) }
+ *
+ *   val safeComputation = openFile("data.json").bracketCase(release, use)
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracketCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.bracketCase(
+  release: Function2<A, ExitCase<Throwable>, Kind<ForIO, Unit>>,
+  use: Function1<A, Kind<ForIO, B>>
+): IO<B> = arrow.fx.IO.bracket().run {
+  this@bracketCase.bracketCase<A, B>(release, use) as arrow.fx.IO<B>
+}
+
+/**
+ *  Meant for specifying tasks with safe resource acquisition and release in the face of errors and interruption.
+ *  It would be the the equivalent of `try/catch/finally` statements in mainstream imperative languages for resource
+ *  acquisition and release.
+ *
+ *  @param release is the action that's supposed to release the allocated resource after `use` is done, irregardless
+ *  of its exit condition.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.*
+ * import arrow.fx.extensions.io.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.extensions.io.monadDefer.defer
+ * import arrow.fx.extensions.io.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val safeComputation = openFile("data.json").bracket({ file: File -> closeFile(file) }, { file -> fileToString(file) })
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracket")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.bracket(
+  release: Function1<A, Kind<ForIO, Unit>>,
+  use: Function1<A,
+    Kind<ForIO, B>>
+): IO<B> = arrow.fx.IO.bracket().run {
+  this@bracket.bracket<A, B>(release, use) as arrow.fx.IO<B>
+}
+
+/**
+ *  Meant for ensuring a given task continues execution even when interrupted.
+ */
+@JvmName("uncancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.uncancellable(): IO<A> = arrow.fx.IO.bracket().run {
+  this@uncancellable.uncancellable<A>() as arrow.fx.IO<A>
+}
+
+@JvmName("uncancelable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.uncancelable(): IO<A> = arrow.fx.IO.bracket().run {
+  this@uncancelable.uncancelable<A>() as arrow.fx.IO<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracket] for the acquisition and release of resources.
+ *
+ *  @see [guaranteeCase] for the version that can discriminate between termination conditions
+ *
+ *  @see [bracket] for the more general operation
+ */
+@JvmName("guarantee")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.guarantee(finalizer: Kind<ForIO, Unit>): IO<A> = arrow.fx.IO.bracket().run {
+  this@guarantee.guarantee<A>(finalizer) as arrow.fx.IO<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled, allowing
+ *  for differentiating between exit conditions. That's thanks to the [ExitCase] argument of the finalizer.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracketCase] for the acquisition and release of resources.
+ *
+ *  @see [guarantee] for the simpler version
+ *
+ *  @see [bracketCase] for the more general operation
+ */
+@JvmName("guaranteeCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.guaranteeCase(finalizer: Function1<ExitCase<Throwable>, Kind<ForIO, Unit>>):
+  IO<A> = arrow.fx.IO.bracket().run {
+  this@guaranteeCase.guaranteeCase<A>(finalizer) as arrow.fx.IO<A>
+}
+
+/**
+ *  Executes the given [finalizer] when the source is cancelled, allowing registering a cancellation token.
+ *
+ *  Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
+ */
+@JvmName("onCancel")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.onCancel(finalizer: Kind<ForIO, Unit>): IO<A> = arrow.fx.IO.bracket().run {
+  this@onCancel.onCancel<A>(finalizer) as arrow.fx.IO<A>
+}
+
+/**
+ *  Executes the given `finalizer` with the given error when the source is finished in error.
+ */
+@JvmName("onError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.onError(finalizer: Function1<Throwable, Kind<ForIO, Unit>>): IO<A> =
+  arrow.fx.IO.bracket().run {
+    this@onError.onError<A>(finalizer) as arrow.fx.IO<A>
+  }
+
+/**
+ *  Extension of MonadError exposing the [bracket] operation, a generalized abstracted pattern of safe resource
+ *  acquisition and release in the face of errors or interruption.
+ *
+ *  @define The functions receiver here (Kind<F, A>) would stand for the "acquireParam", and stands for an action that
+ *  "acquires" some expensive resource, that needs to be used and then discarded.
+ *
+ *  @define use is the action that uses the newly allocated resource and that will provide the final result.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.bracket(): IOBracket = bracket_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/concurrent/IODefaultConcurrent.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/concurrent/IODefaultConcurrent.kt
@@ -1,0 +1,1055 @@
+package arrow.fx.extensions.io.concurrent
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Tuple2
+import arrow.core.Tuple3
+import arrow.core.Tuple4
+import arrow.core.Tuple5
+import arrow.core.Tuple6
+import arrow.core.Tuple7
+import arrow.core.Tuple8
+import arrow.core.Tuple9
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.MVar
+import arrow.fx.Promise
+import arrow.fx.Race3
+import arrow.fx.Race4
+import arrow.fx.Race5
+import arrow.fx.Race6
+import arrow.fx.Race7
+import arrow.fx.Race8
+import arrow.fx.Race9
+import arrow.fx.RacePair
+import arrow.fx.RaceTriple
+import arrow.fx.Semaphore
+import arrow.fx.Timer
+import arrow.fx.extensions.IODefaultConcurrent
+import arrow.fx.typeclasses.Concurrent
+import arrow.fx.typeclasses.ConcurrentContinuation
+import arrow.fx.typeclasses.Dispatchers
+import arrow.fx.typeclasses.Duration
+import arrow.fx.typeclasses.Fiber
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Traverse
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.Function3
+import kotlin.Function4
+import kotlin.Function5
+import kotlin.Function6
+import kotlin.Function7
+import kotlin.Function8
+import kotlin.Function9
+import kotlin.Long
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.collections.Iterable
+import kotlin.collections.List
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val concurrent_singleton: IODefaultConcurrent = object :
+    arrow.fx.extensions.IODefaultConcurrent {}
+
+@JvmName("timer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun timer(): Timer<ForIO> = arrow.fx.IO
+   .concurrent()
+   .timer() as arrow.fx.Timer<arrow.fx.ForIO>
+
+@JvmName("parApplicative")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun parApplicative(): Applicative<ForIO> = arrow.fx.IO
+   .concurrent()
+   .parApplicative() as arrow.typeclasses.Applicative<arrow.fx.ForIO>
+
+@JvmName("parApplicative")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun parApplicative(ctx: CoroutineContext): Applicative<ForIO> = arrow.fx.IO
+   .concurrent()
+   .parApplicative(ctx) as arrow.typeclasses.Applicative<arrow.fx.ForIO>
+
+@JvmName("fork")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.fork(ctx: CoroutineContext): IO<Fiber<ForIO, A>> =
+    arrow.fx.IO.concurrent().run {
+  this@fork.fork<A>(ctx) as arrow.fx.IO<arrow.fx.typeclasses.Fiber<arrow.fx.ForIO, A>>
+}
+
+@JvmName("fork")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.fork(): IO<Fiber<ForIO, A>> = arrow.fx.IO.concurrent().run {
+  this@fork.fork<A>() as arrow.fx.IO<arrow.fx.typeclasses.Fiber<arrow.fx.ForIO, A>>
+}
+
+@JvmName("racePair")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> CoroutineContext.racePair(fa: Kind<ForIO, A>, fb: Kind<ForIO, B>): IO<RacePair<ForIO, A,
+    B>> = arrow.fx.IO.concurrent().run {
+  this@racePair.racePair<A, B>(fa, fb) as arrow.fx.IO<arrow.fx.RacePair<arrow.fx.ForIO, A, B>>
+}
+
+@JvmName("raceTriple")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C> CoroutineContext.raceTriple(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>
+): IO<RaceTriple<ForIO, A, B, C>> = arrow.fx.IO.concurrent().run {
+  this@raceTriple.raceTriple<A, B, C>(fa, fb, fc) as arrow.fx.IO<arrow.fx.RaceTriple<arrow.fx.ForIO,
+    A, B, C>>
+}
+
+@JvmName("cancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> cancellable(k: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForIO, Unit>>): IO<A> =
+    arrow.fx.IO
+   .concurrent()
+   .cancellable<A>(k) as arrow.fx.IO<A>
+
+@JvmName("cancelable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> cancelable(k: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForIO, Unit>>): IO<A> =
+    arrow.fx.IO
+   .concurrent()
+   .cancelable<A>(k) as arrow.fx.IO<A>
+
+@JvmName("cancellableF")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> cancellableF(
+  k: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForIO, Kind<ForIO,
+Unit>>>
+): IO<A> = arrow.fx.IO
+   .concurrent()
+   .cancellableF<A>(k) as arrow.fx.IO<A>
+
+@JvmName("cancelableF")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> cancelableF(
+  k: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForIO, Kind<ForIO,
+Unit>>>
+): IO<A> = arrow.fx.IO
+   .concurrent()
+   .cancelableF<A>(k) as arrow.fx.IO<A>
+
+@JvmName("parTraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <G, A, B> Kind<G, A>.parTraverse(
+  ctx: CoroutineContext,
+  TG: Traverse<G>,
+  f: Function1<A, Kind<ForIO, B>>
+): IO<Kind<G, B>> = arrow.fx.IO.concurrent().run {
+  this@parTraverse.parTraverse<G, A, B>(ctx, TG, f) as arrow.fx.IO<arrow.Kind<G, B>>
+}
+
+@JvmName("parTraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <G, A, B> Kind<G, A>.parTraverse(TG: Traverse<G>, f: Function1<A, Kind<ForIO, B>>): IO<Kind<G,
+    B>> = arrow.fx.IO.concurrent().run {
+  this@parTraverse.parTraverse<G, A, B>(TG, f) as arrow.fx.IO<arrow.Kind<G, B>>
+}
+
+@JvmName("parTraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Iterable<A>.parTraverse(ctx: CoroutineContext, f: Function1<A, Kind<ForIO, B>>):
+    IO<List<B>> = arrow.fx.IO.concurrent().run {
+  this@parTraverse.parTraverse<A, B>(ctx, f) as arrow.fx.IO<kotlin.collections.List<B>>
+}
+
+@JvmName("parTraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Iterable<A>.parTraverse(f: Function1<A, Kind<ForIO, B>>): IO<List<B>> =
+    arrow.fx.IO.concurrent().run {
+  this@parTraverse.parTraverse<A, B>(f) as arrow.fx.IO<kotlin.collections.List<B>>
+}
+
+@JvmName("parSequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <G, A> Kind<G, Kind<ForIO, A>>.parSequence(TG: Traverse<G>, ctx: CoroutineContext): IO<Kind<G,
+    A>> = arrow.fx.IO.concurrent().run {
+  this@parSequence.parSequence<G, A>(TG, ctx) as arrow.fx.IO<arrow.Kind<G, A>>
+}
+
+@JvmName("parSequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <G, A> Kind<G, Kind<ForIO, A>>.parSequence(TG: Traverse<G>): IO<Kind<G, A>> =
+    arrow.fx.IO.concurrent().run {
+  this@parSequence.parSequence<G, A>(TG) as arrow.fx.IO<arrow.Kind<G, A>>
+}
+
+@JvmName("parSequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Iterable<Kind<ForIO, A>>.parSequence(ctx: CoroutineContext): IO<List<A>> =
+    arrow.fx.IO.concurrent().run {
+  this@parSequence.parSequence<A>(ctx) as arrow.fx.IO<kotlin.collections.List<A>>
+}
+
+@JvmName("parSequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Iterable<Kind<ForIO, A>>.parSequence(): IO<List<A>> = arrow.fx.IO.concurrent().run {
+  this@parSequence.parSequence<A>() as arrow.fx.IO<kotlin.collections.List<A>>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C> parMapN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  f: Function1<Tuple2<A, B>, C>
+): IO<C> = arrow.fx.IO
+   .concurrent()
+   .parMapN<A, B, C>(ctx, fa, fb, f) as arrow.fx.IO<C>
+
+@JvmName("parTupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> parTupledN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>
+): IO<Tuple2<A, B>> = arrow.fx.IO
+   .concurrent()
+   .parTupledN<A, B>(ctx, fa, fb) as arrow.fx.IO<arrow.core.Tuple2<A, B>>
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C> CoroutineContext.parMapN(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  f: Function2<A, B, C>
+): IO<C> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<A, B, C>(fa, fb, f) as arrow.fx.IO<C>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D> parMapN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  f: Function1<Tuple3<A, B, C>, D>
+): IO<D> = arrow.fx.IO
+   .concurrent()
+   .parMapN<A, B, C, D>(ctx, fa, fb, fc, f) as arrow.fx.IO<D>
+
+@JvmName("parTupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C> parTupledN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>
+): IO<Tuple3<A, B, C>> = arrow.fx.IO
+   .concurrent()
+   .parTupledN<A, B, C>(ctx, fa, fb, fc) as arrow.fx.IO<arrow.core.Tuple3<A, B, C>>
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D> CoroutineContext.parMapN(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  f: Function3<A, B, C, D>
+): IO<D> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<A, B, C, D>(fa, fb, fc, f) as arrow.fx.IO<D>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E> parMapN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  f: Function1<Tuple4<A, B, C, D>, E>
+): IO<E> = arrow.fx.IO
+   .concurrent()
+   .parMapN<A, B, C, D, E>(ctx, fa, fb, fc, fd, f) as arrow.fx.IO<E>
+
+@JvmName("parTupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D> parTupledN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>
+): IO<Tuple4<A, B, C, D>> = arrow.fx.IO
+   .concurrent()
+   .parTupledN<A, B, C, D>(ctx, fa, fb, fc, fd) as arrow.fx.IO<arrow.core.Tuple4<A, B, C, D>>
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E> CoroutineContext.parMapN(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  f: Function4<A, B, C, D, E>
+): IO<E> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<A, B, C, D, E>(fa, fb, fc, fd, f) as arrow.fx.IO<E>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G> parMapN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  f: Function1<Tuple5<A, B, C, D, E>, G>
+): IO<G> = arrow.fx.IO
+   .concurrent()
+   .parMapN<A, B, C, D, E, G>(ctx, fa, fb, fc, fd, fe, f) as arrow.fx.IO<G>
+
+@JvmName("parTupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E> Concurrent<ForIO>.parTupledN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>
+): IO<Tuple5<A, B, C, D, E>> = arrow.fx.IO.concurrent().run {
+  this@parTupledN.parTupledN<A, B, C, D, E>(ctx, fa, fb, fc, fd, fe) as
+    arrow.fx.IO<arrow.core.Tuple5<A, B, C, D, E>>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G> CoroutineContext.parMapN(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  f: Function5<A, B, C, D, E, G>
+): IO<G> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<A, B, C, D, E, G>(fa, fb, fc, fd, fe, f) as arrow.fx.IO<G>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H> Concurrent<ForIO>.parMapN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  f: Function1<Tuple6<A, B, C, D, E, G>, H>
+): IO<H> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<A, B, C, D, E, G, H>(ctx, fa, fb, fc, fd, fe, fg, f) as arrow.fx.IO<H>
+}
+
+@JvmName("parTupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G> Concurrent<ForIO>.parTupledN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>
+): IO<Tuple6<A, B, C, D, E, G>> = arrow.fx.IO.concurrent().run {
+  this@parTupledN.parTupledN<A, B, C, D, E, G>(ctx, fa, fb, fc, fd, fe, fg) as
+    arrow.fx.IO<arrow.core.Tuple6<A, B, C, D, E, G>>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H> CoroutineContext.parMapN(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  f: Function6<A, B, C, D, E, G, H>
+): IO<H> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<A, B, C, D, E, G, H>(fa, fb, fc, fd, fe, fg, f) as arrow.fx.IO<H>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, A, B, C, D, E, G, H, I> Concurrent<F>.parMapN(
+  ctx: CoroutineContext,
+  fa: Kind<F, A>,
+  fb: Kind<F, B>,
+  fc: Kind<F, C>,
+  fd: Kind<F, D>,
+  fe: Kind<F, E>,
+  fg: Kind<F, G>,
+  fh: Kind<F, H>,
+  f: Function1<Tuple7<A, B, C, D, E, G, H>, I>
+): Kind<F, I> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<F, A, B, C, D, E, G, H, I>(ctx, fa, fb, fc, fd, fe, fg, fh, f) as
+    arrow.Kind<F, I>
+}
+
+@JvmName("parTupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H> parTupledN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  fh: Kind<ForIO, H>
+): IO<Tuple7<A, B, C, D, E, G, H>> = arrow.fx.IO
+   .concurrent()
+   .parTupledN<A, B, C, D, E, G, H>(ctx, fa, fb, fc, fd, fe, fg, fh) as
+    arrow.fx.IO<arrow.core.Tuple7<A, B, C, D, E, G, H>>
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H, I> CoroutineContext.parMapN(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  fh: Kind<ForIO, H>,
+  f: Function7<A, B, C, D, E, G, H, I>
+): IO<I> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<A, B, C, D, E, G, H, I>(fa, fb, fc, fd, fe, fg, fh, f) as arrow.fx.IO<I>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H, I, J> parMapN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  fh: Kind<ForIO, H>,
+  fi: Kind<ForIO, I>,
+  f: Function1<Tuple8<A, B, C, D, E, G, H, I>, J>
+): IO<J> = arrow.fx.IO
+   .concurrent()
+   .parMapN<A, B, C, D, E, G, H, I, J>(ctx, fa, fb, fc, fd, fe, fg, fh, fi, f) as arrow.fx.IO<J>
+
+@JvmName("parTupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H, I> parTupledN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  fh: Kind<ForIO, H>,
+  fi: Kind<ForIO, I>
+): IO<Tuple8<A, B, C, D, E, G, H, I>> = arrow.fx.IO
+   .concurrent()
+   .parTupledN<A, B, C, D, E, G, H, I>(ctx, fa, fb, fc, fd, fe, fg, fh, fi) as
+    arrow.fx.IO<arrow.core.Tuple8<A, B, C, D, E, G, H, I>>
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H, I, J> CoroutineContext.parMapN(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  fh: Kind<ForIO, H>,
+  fi: Kind<ForIO, I>,
+  f: Function8<A, B, C, D, E, G, H, I, J>
+): IO<J> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<A, B, C, D, E, G, H, I, J>(fa, fb, fc, fd, fe, fg, fh, fi, f) as
+    arrow.fx.IO<J>
+}
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H, I, J, K> parMapN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  fh: Kind<ForIO, H>,
+  fi: Kind<ForIO, I>,
+  fj: Kind<ForIO, J>,
+  f: Function1<Tuple9<A, B, C, D, E, G, H, I, J>, K>
+): IO<K> = arrow.fx.IO
+   .concurrent()
+   .parMapN<A, B, C, D, E, G, H, I, J, K>(ctx, fa, fb, fc, fd, fe, fg, fh, fi, fj, f) as
+    arrow.fx.IO<K>
+
+@JvmName("parTupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H, I, J> parTupledN(
+  ctx: CoroutineContext,
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  fh: Kind<ForIO, H>,
+  fi: Kind<ForIO, I>,
+  fj: Kind<ForIO, J>
+): IO<Tuple9<A, B, C, D, E, G, H, I, J>> = arrow.fx.IO
+   .concurrent()
+   .parTupledN<A, B, C, D, E, G, H, I, J>(ctx, fa, fb, fc, fd, fe, fg, fh, fi, fj) as
+    arrow.fx.IO<arrow.core.Tuple9<A, B, C, D, E, G, H, I, J>>
+
+@JvmName("parMapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H, I, J, K> CoroutineContext.parMapN(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>,
+  fd: Kind<ForIO, D>,
+  fe: Kind<ForIO, E>,
+  fg: Kind<ForIO, G>,
+  fh: Kind<ForIO, H>,
+  fi: Kind<ForIO, I>,
+  fj: Kind<ForIO, J>,
+  f: Function9<A, B, C, D, E, G, H, I, J, K>
+): IO<K> = arrow.fx.IO.concurrent().run {
+  this@parMapN.parMapN<A, B, C, D, E, G, H, I, J, K>(fa, fb, fc, fd, fe, fg, fh, fi, fj, f) as
+    arrow.fx.IO<K>
+}
+
+@JvmName("raceN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> CoroutineContext.raceN(fa: Kind<ForIO, A>, fb: Kind<ForIO, B>): IO<Either<A, B>> =
+    arrow.fx.IO.concurrent().run {
+  this@raceN.raceN<A, B>(fa, fb) as arrow.fx.IO<arrow.core.Either<A, B>>
+}
+
+@JvmName("raceN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C> CoroutineContext.raceN(
+  fa: Kind<ForIO, A>,
+  fb: Kind<ForIO, B>,
+  fc: Kind<ForIO, C>
+): IO<Race3<A, B, C>> = arrow.fx.IO.concurrent().run {
+  this@raceN.raceN<A, B, C>(fa, fb, fc) as arrow.fx.IO<arrow.fx.Race3<A, B, C>>
+}
+
+@JvmName("raceN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D> CoroutineContext.raceN(
+  a: Kind<ForIO, A>,
+  b: Kind<ForIO, B>,
+  c: Kind<ForIO, C>,
+  d: Kind<ForIO, D>
+): IO<Race4<A, B, C, D>> = arrow.fx.IO.concurrent().run {
+  this@raceN.raceN<A, B, C, D>(a, b, c, d) as arrow.fx.IO<arrow.fx.Race4<A, B, C, D>>
+}
+
+@JvmName("raceN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E> CoroutineContext.raceN(
+  a: Kind<ForIO, A>,
+  b: Kind<ForIO, B>,
+  c: Kind<ForIO, C>,
+  d: Kind<ForIO, D>,
+  e: Kind<ForIO, E>
+): IO<Race5<A, B, C, D, E>> = arrow.fx.IO.concurrent().run {
+  this@raceN.raceN<A, B, C, D, E>(a, b, c, d, e) as arrow.fx.IO<arrow.fx.Race5<A, B, C, D, E>>
+}
+
+@JvmName("raceN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G> CoroutineContext.raceN(
+  a: Kind<ForIO, A>,
+  b: Kind<ForIO, B>,
+  c: Kind<ForIO, C>,
+  d: Kind<ForIO, D>,
+  e: Kind<ForIO, E>,
+  g: Kind<ForIO, G>
+): IO<Race6<A, B, C, D, E, G>> = arrow.fx.IO.concurrent().run {
+  this@raceN.raceN<A, B, C, D, E, G>(a, b, c, d, e, g) as arrow.fx.IO<arrow.fx.Race6<A, B, C, D, E,
+    G>>
+}
+
+@JvmName("raceN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H> CoroutineContext.raceN(
+  a: Kind<ForIO, A>,
+  b: Kind<ForIO, B>,
+  c: Kind<ForIO, C>,
+  d: Kind<ForIO, D>,
+  e: Kind<ForIO, E>,
+  g: Kind<ForIO, G>,
+  h: Kind<ForIO, H>
+): IO<Race7<A, B, C, D, E, G, H>> = arrow.fx.IO.concurrent().run {
+  this@raceN.raceN<A, B, C, D, E, G, H>(a, b, c, d, e, g, h) as arrow.fx.IO<arrow.fx.Race7<A, B, C,
+    D, E, G, H>>
+}
+
+@JvmName("raceN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H, I> CoroutineContext.raceN(
+  a: Kind<ForIO, A>,
+  b: Kind<ForIO, B>,
+  c: Kind<ForIO, C>,
+  d: Kind<ForIO, D>,
+  e: Kind<ForIO, E>,
+  g: Kind<ForIO, G>,
+  h: Kind<ForIO, H>,
+  i: Kind<ForIO, I>
+): IO<Race8<A, B, C, D, E, G, H, I>> = arrow.fx.IO.concurrent().run {
+  this@raceN.raceN<A, B, C, D, E, G, H, I>(a, b, c, d, e, g, h, i) as arrow.fx.IO<arrow.fx.Race8<A,
+    B, C, D, E, G, H, I>>
+}
+
+@JvmName("raceN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B, C, D, E, G, H, I, J> CoroutineContext.raceN(
+  a: Kind<ForIO, A>,
+  b: Kind<ForIO, B>,
+  c: Kind<ForIO, C>,
+  d: Kind<ForIO, D>,
+  e: Kind<ForIO, E>,
+  g: Kind<ForIO, G>,
+  h: Kind<ForIO, H>,
+  i: Kind<ForIO, I>,
+  j: Kind<ForIO, J>
+): IO<Race9<A, B, C, D, E, G, H, I, J>> = arrow.fx.IO.concurrent().run {
+  this@raceN.raceN<A, B, C, D, E, G, H, I, J>(a, b, c, d, e, g, h, i, j) as
+    arrow.fx.IO<arrow.fx.Race9<A, B, C, D, E, G, H, I, J>>
+}
+
+@JvmName("Promise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Promise(): IO<Promise<ForIO, A>> = arrow.fx.IO
+   .concurrent()
+   .Promise<A>() as arrow.fx.IO<arrow.fx.Promise<arrow.fx.ForIO, A>>
+
+@JvmName("Semaphore")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun Semaphore(n: Long): IO<Semaphore<ForIO>> = arrow.fx.IO
+   .concurrent()
+   .Semaphore(n) as arrow.fx.IO<arrow.fx.Semaphore<arrow.fx.ForIO>>
+
+@JvmName("MVar")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> MVar(a: A): IO<MVar<ForIO, A>> = arrow.fx.IO
+   .concurrent()
+   .MVar<A>(a) as arrow.fx.IO<arrow.fx.MVar<arrow.fx.ForIO, A>>
+
+@JvmName("bindingConcurrent")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <B> bindingConcurrent(c: suspend ConcurrentContinuation<ForIO, *>.() -> B): IO<B> = arrow.fx.IO
+   .concurrent()
+   .bindingConcurrent<B>(c) as arrow.fx.IO<B>
+
+@JvmName("sleep")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun sleep(duration: Duration): IO<Unit> = arrow.fx.IO
+   .concurrent()
+   .sleep(duration) as arrow.fx.IO<kotlin.Unit>
+
+@JvmName("waitFor")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.waitFor(duration: Duration, p2_772401952: Kind<ForIO, A>): IO<A> =
+    arrow.fx.IO.concurrent().run {
+  this@waitFor.waitFor<A>(duration, p2_772401952) as arrow.fx.IO<A>
+}
+
+@JvmName("waitFor")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.waitFor(duration: Duration): IO<A> = arrow.fx.IO.concurrent().run {
+  this@waitFor.waitFor<A>(duration) as arrow.fx.IO<A>
+}
+
+@JvmName("dispatchers")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun dispatchers(): Dispatchers<ForIO> = arrow.fx.IO
+   .concurrent()
+   .dispatchers() as arrow.fx.typeclasses.Dispatchers<arrow.fx.ForIO>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.concurrent(): IODefaultConcurrent = concurrent_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/concurrentEffect/IODefaultConcurrentEffect.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/concurrentEffect/IODefaultConcurrentEffect.kt
@@ -1,0 +1,44 @@
+package arrow.fx.extensions.io.concurrentEffect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IODefaultConcurrentEffect
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val concurrentEffect_singleton: IODefaultConcurrentEffect = object :
+    arrow.fx.extensions.IODefaultConcurrentEffect {}
+
+@JvmName("runAsyncCancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.runAsyncCancellable(cb: Function1<Either<Throwable, A>, Kind<ForIO, Unit>>):
+    IO<Function0<Unit>> = arrow.fx.IO.concurrentEffect().run {
+  this@runAsyncCancellable.runAsyncCancellable<A>(cb) as arrow.fx.IO<kotlin.Function0<kotlin.Unit>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.concurrentEffect(): IODefaultConcurrentEffect = concurrentEffect_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/dispatchers/IODispatchers.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/dispatchers/IODispatchers.kt
@@ -1,0 +1,35 @@
+package arrow.fx.extensions.io.dispatchers
+
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IODispatchers
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val dispatchers_singleton: IODispatchers = object : arrow.fx.extensions.IODispatchers {}
+
+@JvmName("io")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun io(): CoroutineContext = arrow.fx.IO
+   .dispatchers()
+   .io() as kotlin.coroutines.CoroutineContext
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.dispatchers(): IODispatchers = dispatchers_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/effect/IOEffect.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/effect/IOEffect.kt
@@ -1,0 +1,42 @@
+package arrow.fx.extensions.io.effect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOEffect
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val effect_singleton: IOEffect = object : arrow.fx.extensions.IOEffect {}
+
+@JvmName("runAsync")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.runAsync(cb: Function1<Either<Throwable, A>, Kind<ForIO, Unit>>): IO<Unit> =
+    arrow.fx.IO.effect().run {
+  this@runAsync.runAsync<A>(cb) as arrow.fx.IO<kotlin.Unit>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.effect(): IOEffect = effect_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/environment/IOEnvironment.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/environment/IOEnvironment.kt
@@ -1,0 +1,36 @@
+package arrow.fx.extensions.io.environment
+
+import arrow.fx.ForIO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOEnvironment
+import arrow.fx.typeclasses.Dispatchers
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val environment_singleton: IOEnvironment = object : arrow.fx.extensions.IOEnvironment {}
+
+@JvmName("dispatchers")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun dispatchers(): Dispatchers<ForIO> = arrow.fx.IO
+   .environment()
+   .dispatchers() as arrow.fx.typeclasses.Dispatchers<arrow.fx.ForIO>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.environment(): IOEnvironment = environment_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/functor/IOFunctor.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/functor/IOFunctor.kt
@@ -1,0 +1,151 @@
+package arrow.fx.extensions.io.functor
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOFunctor
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: IOFunctor = object : arrow.fx.extensions.IOFunctor {}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.map(arg1: Function1<A, B>): IO<B> = arrow.fx.IO.functor().run {
+  this@map.map<A, B>(arg1) as arrow.fx.IO<B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): IO<B> =
+    arrow.fx.IO.functor().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.IO<B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForIO, A>, Kind<ForIO, B>> = arrow.fx.IO
+   .functor()
+   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.fx.ForIO, A>, arrow.Kind<arrow.fx.ForIO,
+    B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.void(): IO<Unit> = arrow.fx.IO.functor().run {
+  this@void.void<A>() as arrow.fx.IO<kotlin.Unit>
+}
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.fproduct(arg1: Function1<A, B>): IO<Tuple2<A, B>> =
+    arrow.fx.IO.functor().run {
+  this@fproduct.fproduct<A, B>(arg1) as arrow.fx.IO<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.mapConst(arg1: B): IO<B> = arrow.fx.IO.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.IO<B>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> A.mapConst(arg1: Kind<ForIO, B>): IO<A> = arrow.fx.IO.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.tupleLeft(arg1: B): IO<Tuple2<B, A>> = arrow.fx.IO.functor().run {
+  this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.fx.IO<arrow.core.Tuple2<B, A>>
+}
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.tupleRight(arg1: B): IO<Tuple2<A, B>> = arrow.fx.IO.functor().run {
+  this@tupleRight.tupleRight<A, B>(arg1) as arrow.fx.IO<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <B, A : B> Kind<ForIO, A>.widen(): IO<B> = arrow.fx.IO.functor().run {
+  this@widen.widen<B, A>() as arrow.fx.IO<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.functor(): IOFunctor = functor_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monad/IOMonad.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monad/IOMonad.kt
@@ -1,0 +1,257 @@
+package arrow.fx.extensions.io.monad
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.Tuple2
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOMonad
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monad_singleton: IOMonad = object : arrow.fx.extensions.IOMonad {}
+
+@JvmName("flatMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.flatMap(arg1: Function1<A, Kind<ForIO, B>>): IO<B> =
+  arrow.fx.IO.monad().run {
+    this@flatMap.flatMap<A, B>(arg1) as arrow.fx.IO<B>
+  }
+
+@JvmName("tailRecM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForIO, Either<A, B>>>): IO<B> = arrow.fx.IO
+  .monad()
+  .tailRecM<A, B>(arg0, arg1) as arrow.fx.IO<B>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.map(arg1: Function1<A, B>): IO<B> = arrow.fx.IO.monad().run {
+  this@map.map<A, B>(arg1) as arrow.fx.IO<B>
+}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.ap(arg1: Kind<ForIO, Function1<A, B>>): IO<B> = arrow.fx.IO.monad().run {
+  this@ap.ap<A, B>(arg1) as arrow.fx.IO<B>
+}
+
+@JvmName("flatten")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, Kind<ForIO, A>>.flatten(): IO<A> = arrow.fx.IO.monad().run {
+  this@flatten.flatten<A>() as arrow.fx.IO<A>
+}
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.followedBy(arg1: Kind<ForIO, B>): IO<B> = arrow.fx.IO.monad().run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.fx.IO<B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.apTap(arg1: Kind<ForIO, B>): IO<A> = arrow.fx.IO.monad().run {
+  this@apTap.apTap<A, B>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("followedByEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.followedByEval(arg1: Eval<Kind<ForIO, B>>): IO<B> =
+  arrow.fx.IO.monad().run {
+    this@followedByEval.followedByEval<A, B>(arg1) as arrow.fx.IO<B>
+  }
+
+@JvmName("effectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.effectM(arg1: Function1<A, Kind<ForIO, B>>): IO<A> =
+  arrow.fx.IO.monad().run {
+    this@effectM.effectM<A, B>(arg1) as arrow.fx.IO<A>
+  }
+
+@JvmName("flatTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.flatTap(arg1: Function1<A, Kind<ForIO, B>>): IO<A> =
+  arrow.fx.IO.monad().run {
+    this@flatTap.flatTap<A, B>(arg1) as arrow.fx.IO<A>
+  }
+
+@JvmName("productL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.productL(arg1: Kind<ForIO, B>): IO<A> = arrow.fx.IO.monad().run {
+  this@productL.productL<A, B>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("forEffect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.forEffect(arg1: Kind<ForIO, B>): IO<A> = arrow.fx.IO.monad().run {
+  this@forEffect.forEffect<A, B>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("productLEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.productLEval(arg1: Eval<Kind<ForIO, B>>): IO<A> =
+  arrow.fx.IO.monad().run {
+    this@productLEval.productLEval<A, B>(arg1) as arrow.fx.IO<A>
+  }
+
+@JvmName("forEffectEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.forEffectEval(arg1: Eval<Kind<ForIO, B>>): IO<A> =
+  arrow.fx.IO.monad().run {
+    this@forEffectEval.forEffectEval<A, B>(arg1) as arrow.fx.IO<A>
+  }
+
+@JvmName("mproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.mproduct(arg1: Function1<A, Kind<ForIO, B>>): IO<Tuple2<A, B>> =
+  arrow.fx.IO.monad().run {
+    this@mproduct.mproduct<A, B>(arg1) as arrow.fx.IO<arrow.core.Tuple2<A, B>>
+  }
+
+@JvmName("ifM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <B> Kind<ForIO, Boolean>.ifM(arg1: Function0<Kind<ForIO, B>>, arg2: Function0<Kind<ForIO, B>>):
+  IO<B> = arrow.fx.IO.monad().run {
+  this@ifM.ifM<B>(arg1, arg2) as arrow.fx.IO<B>
+}
+
+@JvmName("selectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, Either<A, B>>.selectM(arg1: Kind<ForIO, Function1<A, B>>): IO<B> =
+  arrow.fx.IO.monad().run {
+    this@selectM.selectM<A, B>(arg1) as arrow.fx.IO<B>
+  }
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, Either<A, B>>.select(arg1: Kind<ForIO, Function1<A, B>>): IO<B> =
+  arrow.fx.IO.monad().run {
+    this@select.select<A, B>(arg1) as arrow.fx.IO<B>
+  }
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.monad(): IOMonad = monad_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadDefer/IOMonadDefer.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadDefer/IOMonadDefer.kt
@@ -1,0 +1,89 @@
+package arrow.fx.extensions.io.monadDefer
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.Ref
+import arrow.fx.extensions.IOMonadDefer
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadDefer_singleton: IOMonadDefer = object : arrow.fx.extensions.IOMonadDefer {}
+
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> defer(fa: Function0<Kind<ForIO, A>>): IO<A> = arrow.fx.IO
+   .monadDefer()
+   .defer<A>(fa) as arrow.fx.IO<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> later(f: Function0<A>): IO<A> = arrow.fx.IO
+   .monadDefer()
+   .later<A>(f) as arrow.fx.IO<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> later(fa: Kind<ForIO, A>): IO<A> = arrow.fx.IO
+   .monadDefer()
+   .later<A>(fa) as arrow.fx.IO<A>
+
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> laterOrRaise(f: Function0<Either<Throwable, A>>): IO<A> = arrow.fx.IO
+   .monadDefer()
+   .laterOrRaise<A>(f) as arrow.fx.IO<A>
+
+@JvmName("Ref")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Ref(a: A): IO<Ref<ForIO, A>> = arrow.fx.IO
+   .monadDefer()
+   .Ref<A>(a) as arrow.fx.IO<arrow.fx.Ref<arrow.fx.ForIO, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.monadDefer(): IOMonadDefer = monadDefer_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadError/IOMonadError.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadError/IOMonadError.kt
@@ -1,0 +1,71 @@
+package arrow.fx.extensions.io.monadError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOMonadError
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadError_singleton: IOMonadError = object : arrow.fx.extensions.IOMonadError {}
+
+@JvmName("ensure")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.ensure(arg1: Function0<Throwable>, arg2: Function1<A, Boolean>): IO<A> =
+  arrow.fx.IO.monadError().run {
+    this@ensure.ensure<A>(arg1, arg2) as arrow.fx.IO<A>
+  }
+
+@JvmName("redeemWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A, B> Kind<ForIO, A>.redeemWith(
+  arg1: Function1<Throwable, Kind<ForIO, B>>,
+  arg2: Function1<A,
+    Kind<ForIO, B>>
+): IO<B> = arrow.fx.IO.monadError().run {
+  this@redeemWith.redeemWith<A, B>(arg1, arg2) as arrow.fx.IO<B>
+}
+
+@JvmName("rethrow")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, Either<Throwable, A>>.rethrow(): IO<A> = arrow.fx.IO.monadError().run {
+  this@rethrow.rethrow<A>() as arrow.fx.IO<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.monadError(): IOMonadError = monadError_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadIO/IOMonadIO.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadIO/IOMonadIO.kt
@@ -1,0 +1,35 @@
+package arrow.fx.extensions.io.monadIO
+
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOMonadIO
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadIO_singleton: IOMonadIO = object : arrow.fx.extensions.IOMonadIO {}
+
+@JvmName("liftIO")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> IO<A>.liftIO(): IO<A> = arrow.fx.IO.monadIO().run {
+  this@liftIO.liftIO<A>() as arrow.fx.IO<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.monadIO(): IOMonadIO = monadIO_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadThrow/IOMonadThrow.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monadThrow/IOMonadThrow.kt
@@ -1,0 +1,36 @@
+package arrow.fx.extensions.io.monadThrow
+
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOMonadThrow
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadThrow_singleton: IOMonadThrow = object : arrow.fx.extensions.IOMonadThrow {}
+
+@JvmName("raiseNonFatal")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Throwable.raiseNonFatal(): IO<A> = arrow.fx.IO.monadThrow().run {
+  this@raiseNonFatal.raiseNonFatal<A>() as arrow.fx.IO<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.monadThrow(): IOMonadThrow = monadThrow_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monoid/IOMonoid.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/monoid/IOMonoid.kt
@@ -1,0 +1,44 @@
+package arrow.fx.extensions.io.monoid
+
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOMonoid
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Suppress
+import kotlin.collections.Collection
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Collection<IO<A>>.combineAll(SG: Monoid<A>): IO<A> = arrow.fx.IO.monoid<A>(SG).run {
+  this@combineAll.combineAll() as arrow.fx.IO<A>
+}
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> combineAll(SG: Monoid<A>, arg0: List<IO<A>>): IO<A> = arrow.fx.IO
+   .monoid<A>(SG)
+   .combineAll(arg0) as arrow.fx.IO<A>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <A> Companion.monoid(SG: Monoid<A>): IOMonoid<A> = object :
+    arrow.fx.extensions.IOMonoid<A> { override fun SG(): arrow.typeclasses.Monoid<A> = SG }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/semigroup/IOSemigroup.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/semigroup/IOSemigroup.kt
@@ -1,0 +1,43 @@
+package arrow.fx.extensions.io.semigroup
+
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOSemigroup
+import arrow.typeclasses.Semigroup
+import kotlin.Deprecated
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("plus")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> IO<A>.plus(SG: Semigroup<A>, arg1: IO<A>): IO<A> = arrow.fx.IO.semigroup<A>(SG).run {
+  this@plus.plus(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("maybeCombine")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> IO<A>.maybeCombine(SG: Semigroup<A>, arg1: IO<A>): IO<A> =
+    arrow.fx.IO.semigroup<A>(SG).run {
+  this@maybeCombine.maybeCombine(arg1) as arrow.fx.IO<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <A> Companion.semigroup(SG: Semigroup<A>): IOSemigroup<A> = object :
+    arrow.fx.extensions.IOSemigroup<A> { override fun SG(): arrow.typeclasses.Semigroup<A> = SG }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/semigroupK/IOSemigroupK.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/semigroupK/IOSemigroupK.kt
@@ -1,0 +1,50 @@
+package arrow.fx.extensions.io.semigroupK
+
+import arrow.Kind
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOSemigroupK
+import arrow.typeclasses.Semigroup
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val semigroupK_singleton: IOSemigroupK = object : arrow.fx.extensions.IOSemigroupK {}
+
+@JvmName("combineK")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> Kind<ForIO, A>.combineK(arg1: Kind<ForIO, A>): IO<A> = arrow.fx.IO.semigroupK().run {
+  this@combineK.combineK<A>(arg1) as arrow.fx.IO<A>
+}
+
+@JvmName("algebra")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <A> algebra(): Semigroup<Kind<ForIO, A>> = arrow.fx.IO
+   .semigroupK()
+   .algebra<A>() as arrow.typeclasses.Semigroup<arrow.Kind<arrow.fx.ForIO, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.semigroupK(): IOSemigroupK = semigroupK_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/unsafeCancellableRun/IOUnsafeCancellableRun.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/unsafeCancellableRun/IOUnsafeCancellableRun.kt
@@ -1,0 +1,49 @@
+package arrow.fx.extensions.io.unsafeCancellableRun
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.ForIO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.OnCancel
+import arrow.fx.extensions.IOUnsafeCancellableRun
+import arrow.unsafe
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val unsafeCancellableRun_singleton: IOUnsafeCancellableRun = object :
+    arrow.fx.extensions.IOUnsafeCancellableRun {}
+
+@JvmName("runNonBlockingCancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+suspend fun <A> unsafe.runNonBlockingCancellable(
+  onCancel: OnCancel,
+  fa: Function0<Kind<ForIO, A>>,
+  cb: Function1<Either<Throwable, A>, Unit>
+): Function0<Unit> = arrow.fx.IO.unsafeCancellableRun().run {
+  this@runNonBlockingCancellable.runNonBlockingCancellable<A>(onCancel, fa, cb) as
+    kotlin.Function0<kotlin.Unit>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.unsafeCancellableRun(): IOUnsafeCancellableRun = unsafeCancellableRun_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/unsafeRun/IOUnsafeRun.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/io/unsafeRun/IOUnsafeRun.kt
@@ -1,0 +1,58 @@
+package arrow.fx.extensions.io.unsafeRun
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.ForIO
+import arrow.fx.IO.Companion
+import arrow.fx.IODeprecation
+import arrow.fx.extensions.IOUnsafeRun
+import arrow.unsafe
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val unsafeRun_singleton: IOUnsafeRun = object : arrow.fx.extensions.IOUnsafeRun {}
+
+@JvmName("runBlocking")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+suspend fun <A> unsafe.runBlocking(fa: Function0<Kind<ForIO, A>>): A = arrow.fx.IO.unsafeRun().run {
+  this@runBlocking.runBlocking<A>(fa) as A
+}
+
+@JvmName("runNonBlocking")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+suspend fun <A> unsafe.runNonBlocking(
+  fa: Function0<Kind<ForIO, A>>,
+  cb: Function1<Either<Throwable,
+    A>, Unit>
+): Unit = arrow.fx.IO.unsafeRun().run {
+  this@runNonBlocking.runNonBlocking<A>(fa, cb) as kotlin.Unit
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun Companion.unsafeRun(): IOUnsafeRun = unsafeRun_singleton

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource.kt
@@ -7,7 +7,6 @@ import arrow.fx.ResourceOf
 import arrow.fx.ResourcePartialOf
 import arrow.fx.fix
 import arrow.fx.typeclasses.Bracket
-import arrow.extension
 import arrow.fx.IO
 import arrow.fx.IODeprecation
 import arrow.fx.typeclasses.MonadIO
@@ -19,7 +18,6 @@ import arrow.typeclasses.Selective
 import arrow.typeclasses.Semigroup
 import arrow.undocumented
 
-@extension
 @undocumented
 @Deprecated(IODeprecation)
 interface ResourceFunctor<F, E> : Functor<ResourcePartialOf<F, E>> {
@@ -28,7 +26,6 @@ interface ResourceFunctor<F, E> : Functor<ResourcePartialOf<F, E>> {
     fix().map(BR(), f)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ResourceApplicative<F, E> : Applicative<ResourcePartialOf<F, E>>, ResourceFunctor<F, E> {
   override fun BR(): Bracket<F, E>
@@ -41,7 +38,6 @@ interface ResourceApplicative<F, E> : Applicative<ResourcePartialOf<F, E>>, Reso
     fix().map(BR(), f)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ResourceSelective<F, E> : Selective<ResourcePartialOf<F, E>>, ResourceApplicative<F, E> {
   override fun BR(): Bracket<F, E>
@@ -49,7 +45,6 @@ interface ResourceSelective<F, E> : Selective<ResourcePartialOf<F, E>>, Resource
     fix().flatMap { it.fold({ a -> Resource.just(a, BR()).ap(BR(), f.fix()) }, { b -> Resource.just(b, BR()) }) }
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ResourceMonad<F, E> : Monad<ResourcePartialOf<F, E>>, ResourceSelective<F, E> {
   override fun BR(): Bracket<F, E>
@@ -69,7 +64,6 @@ interface ResourceMonad<F, E> : Monad<ResourcePartialOf<F, E>>, ResourceSelectiv
     fix().flatMap { it.fold({ a -> Resource.just(a, BR()).ap(BR(), f.fix()) }, { b -> Resource.just(b, BR()) }) }
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ResourceSemigroup<F, E, A> : Semigroup<Resource<F, E, A>> {
   fun SR(): Semigroup<A>
@@ -77,7 +71,6 @@ interface ResourceSemigroup<F, E, A> : Semigroup<Resource<F, E, A>> {
   override fun Resource<F, E, A>.combine(b: Resource<F, E, A>): Resource<F, E, A> = combine(b, SR(), BR())
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ResourceMonoid<F, E, A> : Monoid<Resource<F, E, A>>, ResourceSemigroup<F, E, A> {
   fun MR(): Monoid<A>
@@ -86,7 +79,6 @@ interface ResourceMonoid<F, E, A> : Monoid<Resource<F, E, A>>, ResourceSemigroup
   override fun empty(): Resource<F, E, A> = Resource.empty(MR(), BR())
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ResourceMonadIO<F, E> : MonadIO<ResourcePartialOf<F, E>>, ResourceMonad<F, E> {
   fun FIO(): MonadIO<F>

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/applicative/ResourceApplicative.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/applicative/ResourceApplicative.kt
@@ -1,0 +1,98 @@
+package arrow.fx.extensions.resource.applicative
+
+import arrow.Kind
+import arrow.fx.ForResource
+import arrow.fx.IODeprecation
+import arrow.fx.Resource
+import arrow.fx.Resource.Companion
+import arrow.fx.extensions.ResourceApplicative
+import arrow.fx.typeclasses.Bracket
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Int
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> A.just(BR: Bracket<F, E>): Resource<F, E, A> = arrow.fx.Resource.applicative<F,
+  E>(BR).run {
+  this@just.just<A>() as arrow.fx.Resource<F, E, A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E> unit(BR: Bracket<F, E>): Resource<F, E, Unit> = arrow.fx.Resource
+  .applicative<F, E>(BR)
+  .unit() as arrow.fx.Resource<F, E, kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.map(
+  BR: Bracket<F, E>,
+  arg1: Function1<A,
+    B>
+): Resource<F, E, B> = arrow.fx.Resource.applicative<F, E>(BR).run {
+  this@map.map<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Kind<Kind<Kind<ForResource, F>, E>, A>.replicate(BR: Bracket<F, E>, arg1: Int):
+  Resource<F, E, List<A>> = arrow.fx.Resource.applicative<F, E>(BR).run {
+  this@replicate.replicate<A>(arg1) as arrow.fx.Resource<F, E, kotlin.collections.List<A>>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Kind<Kind<Kind<ForResource, F>, E>, A>.replicate(
+  BR: Bracket<F, E>,
+  arg1: Int,
+  arg2: Monoid<A>
+): Resource<F, E, A> = arrow.fx.Resource.applicative<F, E>(BR).run {
+  this@replicate.replicate<A>(arg1, arg2) as arrow.fx.Resource<F, E, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, E> Companion.applicative(BR: Bracket<F, E>): ResourceApplicative<F, E> = object :
+  arrow.fx.extensions.ResourceApplicative<F, E> {
+  override fun BR():
+    arrow.fx.typeclasses.Bracket<F, E> = BR
+}

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/functor/ResourceFunctor.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/functor/ResourceFunctor.kt
@@ -1,0 +1,166 @@
+package arrow.fx.extensions.resource.functor
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.fx.ForResource
+import arrow.fx.IODeprecation
+import arrow.fx.Resource
+import arrow.fx.Resource.Companion
+import arrow.fx.extensions.ResourceFunctor
+import arrow.fx.typeclasses.Bracket
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.map(
+  BR: Bracket<F, E>,
+  arg1: Function1<A,
+    B>
+): Resource<F, E, B> = arrow.fx.Resource.functor<F, E>(BR).run {
+  this@map.map<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.imap(
+  BR: Bracket<F, E>,
+  arg1: Function1<A, B>,
+  arg2: Function1<B, A>
+): Resource<F, E, B> = arrow.fx.Resource.functor<F, E>(BR).run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.Resource<F, E, B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> lift(BR: Bracket<F, E>, arg0: Function1<A, B>):
+  Function1<Kind<Kind<Kind<ForResource, F>, E>, A>, Kind<Kind<Kind<ForResource, F>, E>, B>> =
+  arrow.fx.Resource
+    .functor<F, E>(BR)
+    .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.Kind<arrow.fx.ForResource, F>,
+    E>, A>, arrow.Kind<arrow.Kind<arrow.Kind<arrow.fx.ForResource, F>, E>, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Kind<Kind<Kind<ForResource, F>, E>, A>.void(BR: Bracket<F, E>): Resource<F, E, Unit> =
+  arrow.fx.Resource.functor<F, E>(BR).run {
+    this@void.void<A>() as arrow.fx.Resource<F, E, kotlin.Unit>
+  }
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.fproduct(
+  BR: Bracket<F, E>,
+  arg1: Function1<A, B>
+): Resource<F, E, Tuple2<A, B>> = arrow.fx.Resource.functor<F, E>(BR).run {
+  this@fproduct.fproduct<A, B>(arg1) as arrow.fx.Resource<F, E, arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.mapConst(BR: Bracket<F, E>, arg1: B):
+  Resource<F, E, B> = arrow.fx.Resource.functor<F, E>(BR).run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> A.mapConst(BR: Bracket<F, E>, arg1: Kind<Kind<Kind<ForResource, F>, E>, B>):
+  Resource<F, E, A> = arrow.fx.Resource.functor<F, E>(BR).run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.Resource<F, E, A>
+}
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.tupleLeft(BR: Bracket<F, E>, arg1: B):
+  Resource<F, E, Tuple2<B, A>> = arrow.fx.Resource.functor<F, E>(BR).run {
+  this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.fx.Resource<F, E, arrow.core.Tuple2<B, A>>
+}
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.tupleRight(BR: Bracket<F, E>, arg1: B):
+  Resource<F, E, Tuple2<A, B>> = arrow.fx.Resource.functor<F, E>(BR).run {
+  this@tupleRight.tupleRight<A, B>(arg1) as arrow.fx.Resource<F, E, arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, B, A : B> Kind<Kind<Kind<ForResource, F>, E>, A>.widen(BR: Bracket<F, E>): Resource<F, E,
+  B> = arrow.fx.Resource.functor<F, E>(BR).run {
+  this@widen.widen<B, A>() as arrow.fx.Resource<F, E, B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, E> Companion.functor(BR: Bracket<F, E>): ResourceFunctor<F, E> = object :
+  arrow.fx.extensions.ResourceFunctor<F, E> {
+  override fun BR(): arrow.fx.typeclasses.Bracket<F,
+    E> = BR
+}

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/monad/ResourceMonad.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/monad/ResourceMonad.kt
@@ -1,0 +1,314 @@
+package arrow.fx.extensions.resource.monad
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.Tuple2
+import arrow.fx.ForResource
+import arrow.fx.IODeprecation
+import arrow.fx.Resource
+import arrow.fx.Resource.Companion
+import arrow.fx.extensions.ResourceMonad
+import arrow.fx.typeclasses.Bracket
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("flatMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.flatMap(
+  BR: Bracket<F, E>,
+  arg1: Function1<A, Kind<Kind<Kind<ForResource, F>, E>, B>>
+): Resource<F, E, B> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@flatMap.flatMap<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+  }
+
+@JvmName("tailRecM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> tailRecM(
+  BR: Bracket<F, E>,
+  arg0: A,
+  arg1: Function1<A, Kind<Kind<Kind<ForResource, F>, E>, Either<A, B>>>
+): Resource<F, E, B> = arrow.fx.Resource
+  .monad<F, E>(BR)
+  .tailRecM<A, B>(arg0, arg1) as arrow.fx.Resource<F, E, B>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.map(
+  BR: Bracket<F, E>,
+  arg1: Function1<A,
+    B>
+): Resource<F, E, B> = arrow.fx.Resource.monad<F, E>(BR).run {
+  this@map.map<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.ap(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, Function1<A, B>>
+): Resource<F, E, B> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@ap.ap<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+  }
+
+@JvmName("flatten")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Kind<Kind<Kind<ForResource, F>, E>, Kind<Kind<Kind<ForResource, F>, E>,
+  A>>.flatten(BR: Bracket<F, E>): Resource<F, E, A> = arrow.fx.Resource.monad<F, E>(BR).run {
+  this@flatten.flatten<A>() as arrow.fx.Resource<F, E, A>
+}
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.followedBy(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, B>
+): Resource<F, E, B> = arrow.fx.Resource.monad<F,
+  E>(BR).run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.apTap(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, B>
+): Resource<F, E, A> = arrow.fx.Resource.monad<F,
+  E>(BR).run {
+  this@apTap.apTap<A, B>(arg1) as arrow.fx.Resource<F, E, A>
+}
+
+@JvmName("followedByEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.followedByEval(
+  BR: Bracket<F, E>,
+  arg1: Eval<Kind<Kind<Kind<ForResource, F>, E>, B>>
+): Resource<F, E, B> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@followedByEval.followedByEval<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+  }
+
+@JvmName("effectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.effectM(
+  BR: Bracket<F, E>,
+  arg1: Function1<A, Kind<Kind<Kind<ForResource, F>, E>, B>>
+): Resource<F, E, A> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@effectM.effectM<A, B>(arg1) as arrow.fx.Resource<F, E, A>
+  }
+
+@JvmName("flatTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.flatTap(
+  BR: Bracket<F, E>,
+  arg1: Function1<A, Kind<Kind<Kind<ForResource, F>, E>, B>>
+): Resource<F, E, A> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@flatTap.flatTap<A, B>(arg1) as arrow.fx.Resource<F, E, A>
+  }
+
+@JvmName("productL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.productL(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, B>
+): Resource<F, E, A> = arrow.fx.Resource.monad<F,
+  E>(BR).run {
+  this@productL.productL<A, B>(arg1) as arrow.fx.Resource<F, E, A>
+}
+
+@JvmName("forEffect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.forEffect(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, B>
+): Resource<F, E, A> = arrow.fx.Resource.monad<F,
+  E>(BR).run {
+  this@forEffect.forEffect<A, B>(arg1) as arrow.fx.Resource<F, E, A>
+}
+
+@JvmName("productLEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.productLEval(
+  BR: Bracket<F, E>,
+  arg1: Eval<Kind<Kind<Kind<ForResource, F>, E>, B>>
+): Resource<F, E, A> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@productLEval.productLEval<A, B>(arg1) as arrow.fx.Resource<F, E, A>
+  }
+
+@JvmName("forEffectEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.forEffectEval(
+  BR: Bracket<F, E>,
+  arg1: Eval<Kind<Kind<Kind<ForResource, F>, E>, B>>
+): Resource<F, E, A> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@forEffectEval.forEffectEval<A, B>(arg1) as arrow.fx.Resource<F, E, A>
+  }
+
+@JvmName("mproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, A>.mproduct(
+  BR: Bracket<F, E>,
+  arg1: Function1<A, Kind<Kind<Kind<ForResource, F>, E>, B>>
+): Resource<F, E, Tuple2<A, B>> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@mproduct.mproduct<A, B>(arg1) as arrow.fx.Resource<F, E, arrow.core.Tuple2<A, B>>
+  }
+
+@JvmName("ifM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, B> Kind<Kind<Kind<ForResource, F>, E>, Boolean>.ifM(
+  BR: Bracket<F, E>,
+  arg1: Function0<Kind<Kind<Kind<ForResource, F>, E>, B>>,
+  arg2: Function0<Kind<Kind<Kind<ForResource, F>, E>, B>>
+): Resource<F, E, B> = arrow.fx.Resource.monad<F, E>(BR).run {
+  this@ifM.ifM<B>(arg1, arg2) as arrow.fx.Resource<F, E, B>
+}
+
+@JvmName("selectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, Either<A, B>>.selectM(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, Function1<A, B>>
+): Resource<F, E, B> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@selectM.selectM<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+  }
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, Either<A, B>>.select(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, Function1<A, B>>
+): Resource<F, E, B> =
+  arrow.fx.Resource.monad<F, E>(BR).run {
+    this@select.select<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+  }
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, E> Companion.monad(BR: Bracket<F, E>): ResourceMonad<F, E> = object :
+  arrow.fx.extensions.ResourceMonad<F, E> {
+  override fun BR(): arrow.fx.typeclasses.Bracket<F, E> =
+    BR
+}

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/monadIO/ResourceMonadIO.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/monadIO/ResourceMonadIO.kt
@@ -1,0 +1,36 @@
+package arrow.fx.extensions.resource.monadIO
+
+import arrow.fx.IO
+import arrow.fx.IODeprecation
+import arrow.fx.Resource
+import arrow.fx.Resource.Companion
+import arrow.fx.extensions.ResourceMonadIO
+import arrow.fx.typeclasses.Bracket
+import arrow.fx.typeclasses.MonadIO
+import kotlin.Deprecated
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("liftIO")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> IO<A>.liftIO(FIO: MonadIO<F>, BR: Bracket<F, E>): Resource<F, E, A> =
+    arrow.fx.Resource.monadIO<F, E>(FIO, BR).run {
+  this@liftIO.liftIO<A>() as arrow.fx.Resource<F, E, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, E> Companion.monadIO(FIO: MonadIO<F>, BR: Bracket<F, E>): ResourceMonadIO<F, E> =
+    object : arrow.fx.extensions.ResourceMonadIO<F, E> { override fun FIO():
+    arrow.fx.typeclasses.MonadIO<F> = FIO
+
+  override fun BR(): arrow.fx.typeclasses.Bracket<F, E> = BR }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/monoid/ResourceMonoid.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/monoid/ResourceMonoid.kt
@@ -1,0 +1,53 @@
+package arrow.fx.extensions.resource.monoid
+
+import arrow.fx.IODeprecation
+import arrow.fx.Resource
+import arrow.fx.Resource.Companion
+import arrow.fx.extensions.ResourceMonoid
+import arrow.fx.typeclasses.Bracket
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Suppress
+import kotlin.collections.Collection
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Collection<Resource<F, E, A>>.combineAll(MR: Monoid<A>, BR: Bracket<F, E>):
+    Resource<F, E, A> = arrow.fx.Resource.monoid<F, E, A>(MR, BR).run {
+  this@combineAll.combineAll() as arrow.fx.Resource<F, E, A>
+}
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> combineAll(
+  MR: Monoid<A>,
+  BR: Bracket<F, E>,
+  arg0: List<Resource<F, E, A>>
+): Resource<F, E, A> = arrow.fx.Resource
+   .monoid<F, E, A>(MR, BR)
+   .combineAll(arg0) as arrow.fx.Resource<F, E, A>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, E, A> Companion.monoid(MR: Monoid<A>, BR: Bracket<F, E>): ResourceMonoid<F, E, A> =
+    object : arrow.fx.extensions.ResourceMonoid<F, E, A> { override fun MR():
+    arrow.typeclasses.Monoid<A> = MR
+
+  override fun BR(): arrow.fx.typeclasses.Bracket<F, E> = BR }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/selective/ResourceSelective.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/selective/ResourceSelective.kt
@@ -1,0 +1,122 @@
+package arrow.fx.extensions.resource.selective
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.ForResource
+import arrow.fx.IODeprecation
+import arrow.fx.Resource
+import arrow.fx.Resource.Companion
+import arrow.fx.extensions.ResourceSelective
+import arrow.fx.typeclasses.Bracket
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B> Kind<Kind<Kind<ForResource, F>, E>, Either<A, B>>.select(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, Function1<A, B>>
+): Resource<F, E, B> =
+    arrow.fx.Resource.selective<F, E>(BR).run {
+  this@select.select<A, B>(arg1) as arrow.fx.Resource<F, E, B>
+}
+
+@JvmName("branch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A, B, C> Kind<Kind<Kind<ForResource, F>, E>, Either<A, B>>.branch(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, Function1<A, C>>,
+  arg2: Kind<Kind<Kind<ForResource, F>, E>, Function1<B, C>>
+): Resource<F, E, C> = arrow.fx.Resource.selective<F, E>(BR).run {
+  this@branch.branch<A, B, C>(arg1, arg2) as arrow.fx.Resource<F, E, C>
+}
+
+@JvmName("whenS")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Kind<Kind<Kind<ForResource, F>, E>, Boolean>.whenS(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, Function0<Unit>>
+): Resource<F, E, Unit> =
+    arrow.fx.Resource.selective<F, E>(BR).run {
+  this@whenS.whenS<A>(arg1) as arrow.fx.Resource<F, E, kotlin.Unit>
+}
+
+@JvmName("ifS")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Kind<Kind<Kind<ForResource, F>, E>, Boolean>.ifS(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, A>,
+  arg2: Kind<Kind<Kind<ForResource, F>, E>, A>
+): Resource<F, E, A> = arrow.fx.Resource.selective<F, E>(BR).run {
+  this@ifS.ifS<A>(arg1, arg2) as arrow.fx.Resource<F, E, A>
+}
+
+@JvmName("orS")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Kind<Kind<Kind<ForResource, F>, E>, Boolean>.orS(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, Boolean>
+): Resource<F, E, Boolean> =
+    arrow.fx.Resource.selective<F, E>(BR).run {
+  this@orS.orS<A>(arg1) as arrow.fx.Resource<F, E, kotlin.Boolean>
+}
+
+@JvmName("andS")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Kind<Kind<Kind<ForResource, F>, E>, Boolean>.andS(
+  BR: Bracket<F, E>,
+  arg1: Kind<Kind<Kind<ForResource, F>, E>, Boolean>
+): Resource<F, E, Boolean> =
+    arrow.fx.Resource.selective<F, E>(BR).run {
+  this@andS.andS<A>(arg1) as arrow.fx.Resource<F, E, kotlin.Boolean>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, E> Companion.selective(BR: Bracket<F, E>): ResourceSelective<F, E> = object :
+    arrow.fx.extensions.ResourceSelective<F, E> { override fun BR(): arrow.fx.typeclasses.Bracket<F,
+    E> = BR }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/semigroup/ResourceSemigroup.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/resource/semigroup/ResourceSemigroup.kt
@@ -1,0 +1,56 @@
+package arrow.fx.extensions.resource.semigroup
+
+import arrow.fx.IODeprecation
+import arrow.fx.Resource
+import arrow.fx.Resource.Companion
+import arrow.fx.extensions.ResourceSemigroup
+import arrow.fx.typeclasses.Bracket
+import arrow.typeclasses.Semigroup
+import kotlin.Deprecated
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("plus")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Resource<F, E, A>.plus(
+  SR: Semigroup<A>,
+  BR: Bracket<F, E>,
+  arg1: Resource<F, E, A>
+): Resource<F, E, A> = arrow.fx.Resource.semigroup<F, E, A>(SR, BR).run {
+  this@plus.plus(arg1) as arrow.fx.Resource<F, E, A>
+}
+
+@JvmName("maybeCombine")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, E, A> Resource<F, E, A>.maybeCombine(
+  SR: Semigroup<A>,
+  BR: Bracket<F, E>,
+  arg1: Resource<F, E, A>
+): Resource<F, E, A> = arrow.fx.Resource.semigroup<F, E, A>(SR, BR).run {
+  this@maybeCombine.maybeCombine(arg1) as arrow.fx.Resource<F, E, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, E, A> Companion.semigroup(SR: Semigroup<A>, BR: Bracket<F, E>): ResourceSemigroup<F,
+  E, A> = object : arrow.fx.extensions.ResourceSemigroup<F, E, A> {
+  override fun SR():
+    arrow.typeclasses.Semigroup<A> = SR
+
+  override fun BR(): arrow.fx.typeclasses.Bracket<F, E> = BR
+}

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule.kt
@@ -3,7 +3,6 @@ package arrow.fx.extensions
 import arrow.Kind
 import arrow.Kind2
 import arrow.core.identity
-import arrow.extension
 import arrow.fx.ForSchedule
 import arrow.fx.IODeprecation
 import arrow.fx.Schedule
@@ -23,21 +22,18 @@ import arrow.typeclasses.SemigroupK
 import arrow.typeclasses.conest
 import arrow.typeclasses.counnest
 
-@extension
 @Deprecated(IODeprecation)
 interface ScheduleFunctor<F, Input> : Functor<SchedulePartialOf<F, Input>> {
   override fun <A, B> Kind<SchedulePartialOf<F, Input>, A>.map(f: (A) -> B): Kind<SchedulePartialOf<F, Input>, B> =
     fix().map(f)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ScheduleAppy<F, Input> : Apply<SchedulePartialOf<F, Input>>, ScheduleFunctor<F, Input> {
   override fun <A, B> Kind<SchedulePartialOf<F, Input>, A>.ap(ff: Kind<SchedulePartialOf<F, Input>, (A) -> B>): Kind<SchedulePartialOf<F, Input>, B> =
     fix().and(ff.fix()).map { (a, f) -> f(a) }
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ScheduleApplicative<F, Input> : Applicative<SchedulePartialOf<F, Input>>, ScheduleAppy<F, Input> {
 
@@ -50,7 +46,6 @@ interface ScheduleApplicative<F, Input> : Applicative<SchedulePartialOf<F, Input
     fix().map(f)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ScheduleSemigroup<F, Input, Output> : Semigroup<Schedule<F, Input, Output>> {
   fun OI(): Semigroup<Output>
@@ -59,7 +54,6 @@ interface ScheduleSemigroup<F, Input, Output> : Semigroup<Schedule<F, Input, Out
     and(b).map { (a, b) -> OI().run { a + b } }
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ScheduleMonoid<F, Input, Output> : Monoid<Schedule<F, Input, Output>>, ScheduleSemigroup<F, Input, Output> {
   override fun OI(): Monoid<Output>
@@ -69,14 +63,12 @@ interface ScheduleMonoid<F, Input, Output> : Monoid<Schedule<F, Input, Output>>,
     Schedule.forever<F, Input>(MF()).const(OI().empty())
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ScheduleSemigroupK<F, Input> : SemigroupK<SchedulePartialOf<F, Input>> {
   override fun <A> Kind<SchedulePartialOf<F, Input>, A>.combineK(y: Kind<SchedulePartialOf<F, Input>, A>): Kind<SchedulePartialOf<F, Input>, A> =
     fix().andThen(y.fix()).map { it.fold(::identity, ::identity) }
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ScheduleContravariant<F, Output> : Contravariant<Conested<Kind<ForSchedule, F>, Output>> {
   override fun <A, B> Kind<Conested<Kind<ForSchedule, F>, Output>, A>.contramap(f: (B) -> A): Kind<Conested<Kind<ForSchedule, F>, Output>, B> =
@@ -86,14 +78,12 @@ interface ScheduleContravariant<F, Output> : Contravariant<Conested<Kind<ForSche
     fix().contramap(f)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ScheduleProfunctor<F> : Profunctor<Kind<ForSchedule, F>> {
   override fun <A, B, C, D> Kind2<Kind<ForSchedule, F>, A, B>.dimap(fl: (C) -> A, fr: (B) -> D): Kind2<Kind<ForSchedule, F>, C, D> =
     fix().dimap(fl, fr)
 }
 
-@extension
 @Deprecated(IODeprecation)
 interface ScheduleCategory<F> : Category<Kind<ForSchedule, F>> {
   fun MM(): Monad<F>

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/applicative/ScheduleApplicative.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/applicative/ScheduleApplicative.kt
@@ -1,0 +1,110 @@
+package arrow.fx.extensions.schedule.applicative
+
+import arrow.Kind
+import arrow.fx.ForSchedule
+import arrow.fx.IODeprecation
+import arrow.fx.Schedule
+import arrow.fx.Schedule.Companion
+import arrow.fx.extensions.ScheduleApplicative
+import arrow.typeclasses.Monad
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Int
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A> A.just(MF: Monad<F>): Schedule<F, Input, A> = arrow.fx.Schedule.applicative<F,
+  Input>(MF).run {
+  this@just.just<A>() as arrow.fx.Schedule<F, Input, A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input> unit(MF: Monad<F>): Schedule<F, Input, Unit> = arrow.fx.Schedule
+  .applicative<F, Input>(MF)
+  .unit() as arrow.fx.Schedule<F, Input, kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.map(
+  MF: Monad<F>,
+  arg1: Function1<A,
+    B>
+): Schedule<F, Input, B> = arrow.fx.Schedule.applicative<F, Input>(MF).run {
+  this@map.map<A, B>(arg1) as arrow.fx.Schedule<F, Input, B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.replicate(MF: Monad<F>, arg1: Int):
+  Schedule<F, Input, List<A>> = arrow.fx.Schedule.applicative<F, Input>(MF).run {
+  this@replicate.replicate<A>(arg1) as arrow.fx.Schedule<F, Input, kotlin.collections.List<A>>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.replicate(
+  MF: Monad<F>,
+  arg1: Int,
+  arg2: Monoid<A>
+): Schedule<F, Input, A> = arrow.fx.Schedule.applicative<F, Input>(MF).run {
+  this@replicate.replicate<A>(arg1, arg2) as arrow.fx.Schedule<F, Input, A>
+}
+
+@JvmName("just")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A> just(MF: Monad<F>, a: A): Schedule<F, Input, A> = arrow.fx.Schedule
+  .applicative<F, Input>(MF)
+  .just<A>(a) as arrow.fx.Schedule<F, Input, A>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, Input> Companion.applicative(MF: Monad<F>): ScheduleApplicative<F, Input> = object :
+  arrow.fx.extensions.ScheduleApplicative<F, Input> {
+  override fun MF():
+    arrow.typeclasses.Monad<F> = MF
+}

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/apply/ScheduleAppy.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/apply/ScheduleAppy.kt
@@ -1,0 +1,993 @@
+package arrow.fx.extensions.schedule.apply
+
+import arrow.Kind
+import arrow.core.Eval
+import arrow.core.Tuple10
+import arrow.core.Tuple2
+import arrow.core.Tuple3
+import arrow.core.Tuple4
+import arrow.core.Tuple5
+import arrow.core.Tuple6
+import arrow.core.Tuple7
+import arrow.core.Tuple8
+import arrow.core.Tuple9
+import arrow.fx.ForSchedule
+import arrow.fx.IODeprecation
+import arrow.fx.Schedule
+import arrow.fx.Schedule.Companion
+import arrow.fx.extensions.ScheduleAppy
+import kotlin.Any
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val apply_singleton: ScheduleAppy<Any?, Any?> = object : ScheduleAppy<Any?, Any?> {}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.ap(
+  arg1: Kind<Kind<Kind<ForSchedule,
+    F>, Input>, Function1<A, B>>
+): Schedule<F, Input, B> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@ap.ap<A, B>(arg1) as arrow.fx.Schedule<F, Input, B>
+}
+
+@JvmName("apEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>,
+  A>.apEval(arg1: Eval<Kind<Kind<Kind<ForSchedule, F>, Input>, Function1<A, B>>>):
+  Eval<Kind<Kind<Kind<ForSchedule, F>, Input>, B>> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@apEval.apEval<A, B>(arg1) as
+    arrow.core.Eval<arrow.Kind<arrow.Kind<arrow.Kind<arrow.fx.ForSchedule, F>, Input>, B>>
+}
+
+@JvmName("map2Eval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, Z> Kind<Kind<Kind<ForSchedule, F>, Input>,
+  A>.map2Eval(
+    arg1: Eval<Kind<Kind<Kind<ForSchedule, F>, Input>, B>>,
+    arg2: Function1<Tuple2<A, B>, Z>
+  ): Eval<Kind<Kind<Kind<ForSchedule, F>, Input>, Z>> = arrow.fx.Schedule.apply<F,
+  Input>().run {
+  this@map2Eval.map2Eval<A, B, Z>(arg1, arg2) as
+    arrow.core.Eval<arrow.Kind<arrow.Kind<arrow.Kind<arrow.fx.ForSchedule, F>, Input>, Z>>
+}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, Z> map(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .map<A, B, Z>(arg0, arg1, arg2) as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, Z> mapN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Function1<Tuple2<A, B>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .mapN<A, B, Z>(arg0, arg1, arg2) as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, Z> map(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Function1<Tuple3<A, B, C>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .map<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, Z> mapN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Function1<Tuple3<A, B, C>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .mapN<A, B, C, Z>(arg0, arg1, arg2, arg3) as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, Z> map(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Function1<Tuple4<A, B, C, D>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .map<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, Z> mapN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Function1<Tuple4<A, B, C, D>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .mapN<A, B, C, D, Z>(arg0, arg1, arg2, arg3, arg4) as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, Z> map(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Function1<Tuple5<A, B, C, D, E>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .map<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, Z> mapN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Function1<Tuple5<A, B, C, D, E>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .mapN<A, B, C, D, E, Z>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, Z> map(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .map<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.fx.Schedule<F,
+  Input, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, Z> mapN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Function1<Tuple6<A, B, C, D, E, FF>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .mapN<A, B, C, D, E, FF, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.fx.Schedule<F,
+  Input, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, Z> map(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .map<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, Z> mapN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Function1<Tuple7<A, B, C, D, E, FF, G>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .mapN<A, B, C, D, E, FF, G, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, Z> map(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .map<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, Z> mapN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Function1<Tuple8<A, B, C, D, E, FF, G, H>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .mapN<A, B, C, D, E, FF, G, H, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, I, Z> map(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Kind<Kind<Kind<ForSchedule, F>, Input>, I>,
+  arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .map<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+  as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, I, Z> mapN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Kind<Kind<Kind<ForSchedule, F>, Input>, I>,
+  arg9: Function1<Tuple9<A, B, C, D, E, FF, G, H, I>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .mapN<A, B, C, D, E, FF, G, H, I, Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+  as arrow.fx.Schedule<F, Input, Z>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, I, J, Z> map(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Kind<Kind<Kind<ForSchedule, F>, Input>, I>,
+  arg9: Kind<Kind<Kind<ForSchedule, F>, Input>, J>,
+  arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .map<A, B, C, D, E, FF, G, H, I, J,
+    Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.fx.Schedule<F,
+  Input, Z>
+
+@JvmName("mapN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, I, J, Z> mapN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Kind<Kind<Kind<ForSchedule, F>, Input>, I>,
+  arg9: Kind<Kind<Kind<ForSchedule, F>, Input>, J>,
+  arg10: Function1<Tuple10<A, B, C, D, E, FF, G, H, I, J>, Z>
+): Schedule<F, Input, Z> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .mapN<A, B, C, D, E, FF, G, H, I, J,
+    Z>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) as arrow.fx.Schedule<F,
+  Input, Z>
+
+@JvmName("map2")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, Z> Kind<Kind<Kind<ForSchedule, F>, Input>,
+  A>.map2(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>, arg2: Function1<Tuple2<A, B>, Z>):
+  Schedule<F, Input, Z> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@map2.map2<A, B, Z>(arg1, arg2) as arrow.fx.Schedule<F, Input, Z>
+}
+
+@JvmName("product")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>,
+  A>.product(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>): Schedule<F, Input, Tuple2<A, B>> =
+  arrow.fx.Schedule.apply<F, Input>().run {
+    this@product.product<A, B>(arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple2<A, B>>
+  }
+
+@JvmName("product1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, Z> Kind<Kind<Kind<ForSchedule, F>, Input>, Tuple2<A,
+  B>>.product(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, Z>): Schedule<F, Input, Tuple3<A, B,
+  Z>> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@product.product<A, B, Z>(arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple3<A, B, Z>>
+}
+
+@JvmName("product2")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, Z> Kind<Kind<Kind<ForSchedule, F>, Input>, Tuple3<A, B,
+  C>>.product(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, Z>): Schedule<F, Input, Tuple4<A, B,
+  C, Z>> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@product.product<A, B, C, Z>(arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple4<A, B, C,
+    Z>>
+}
+
+@JvmName("product3")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, Z> Kind<Kind<Kind<ForSchedule, F>, Input>, Tuple4<A, B, C,
+  D>>.product(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, Z>): Schedule<F, Input, Tuple5<A, B,
+  C, D, Z>> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@product.product<A, B, C, D, Z>(arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple5<A, B,
+    C, D, Z>>
+}
+
+@JvmName("product4")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, Z> Kind<Kind<Kind<ForSchedule, F>, Input>, Tuple5<A, B, C, D,
+  E>>.product(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, Z>): Schedule<F, Input, Tuple6<A, B,
+  C, D, E, Z>> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@product.product<A, B, C, D, E, Z>(arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple6<A,
+    B, C, D, E, Z>>
+}
+
+@JvmName("product5")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, Z> Kind<Kind<Kind<ForSchedule, F>, Input>, Tuple6<A, B, C, D, E,
+  FF>>.product(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, Z>): Schedule<F, Input, Tuple7<A, B,
+  C, D, E, FF, Z>> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@product.product<A, B, C, D, E, FF, Z>(arg1) as arrow.fx.Schedule<F, Input,
+    arrow.core.Tuple7<A, B, C, D, E, FF, Z>>
+}
+
+@JvmName("product6")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, Z> Kind<Kind<Kind<ForSchedule, F>, Input>, Tuple7<A, B, C, D,
+  E, FF, G>>.product(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, Z>): Schedule<F, Input,
+  Tuple8<A, B, C, D, E, FF, G, Z>> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@product.product<A, B, C, D, E, FF, G, Z>(arg1) as arrow.fx.Schedule<F, Input,
+    arrow.core.Tuple8<A, B, C, D, E, FF, G, Z>>
+}
+
+@JvmName("product7")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, Z> Kind<Kind<Kind<ForSchedule, F>, Input>, Tuple8<A, B, C,
+  D, E, FF, G, H>>.product(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, Z>): Schedule<F, Input,
+  Tuple9<A, B, C, D, E, FF, G, H, Z>> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@product.product<A, B, C, D, E, FF, G, H, Z>(arg1) as arrow.fx.Schedule<F, Input,
+    arrow.core.Tuple9<A, B, C, D, E, FF, G, H, Z>>
+}
+
+@JvmName("product8")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, I, Z> Kind<Kind<Kind<ForSchedule, F>, Input>, Tuple9<A, B,
+  C, D, E, FF, G, H, I>>.product(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, Z>): Schedule<F,
+  Input, Tuple10<A, B, C, D, E, FF, G, H, I, Z>> = arrow.fx.Schedule.apply<F, Input>().run {
+  this@product.product<A, B, C, D, E, FF, G, H, I, Z>(arg1) as arrow.fx.Schedule<F, Input,
+    arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, Z>>
+}
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> tupled(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>
+): Schedule<F, Input, Tuple2<A, B>> =
+  arrow.fx.Schedule
+    .apply<F, Input>()
+    .tupled<A, B>(arg0, arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple2<A, B>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> tupledN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>
+): Schedule<F, Input, Tuple2<A, B>> =
+  arrow.fx.Schedule
+    .apply<F, Input>()
+    .tupledN<A, B>(arg0, arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple2<A, B>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C> tupled(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>
+): Schedule<F, Input, Tuple3<A, B, C>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupled<A, B, C>(arg0, arg1, arg2) as arrow.fx.Schedule<F, Input, arrow.core.Tuple3<A, B, C>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C> tupledN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>
+): Schedule<F, Input, Tuple3<A, B, C>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupledN<A, B, C>(arg0, arg1, arg2) as arrow.fx.Schedule<F, Input, arrow.core.Tuple3<A, B, C>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D> tupled(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>
+): Schedule<F, Input, Tuple4<A, B, C, D>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupled<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.fx.Schedule<F, Input, arrow.core.Tuple4<A,
+  B, C, D>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D> tupledN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>
+): Schedule<F, Input, Tuple4<A, B, C, D>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupledN<A, B, C, D>(arg0, arg1, arg2, arg3) as arrow.fx.Schedule<F, Input, arrow.core.Tuple4<A,
+  B, C, D>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E> tupled(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>
+): Schedule<F, Input, Tuple5<A, B, C, D, E>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupled<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.fx.Schedule<F, Input,
+  arrow.core.Tuple5<A, B, C, D, E>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E> tupledN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>
+): Schedule<F, Input, Tuple5<A, B, C, D, E>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupledN<A, B, C, D, E>(arg0, arg1, arg2, arg3, arg4) as arrow.fx.Schedule<F, Input,
+  arrow.core.Tuple5<A, B, C, D, E>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF> tupled(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>
+): Schedule<F, Input, Tuple6<A, B, C, D, E, FF>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupled<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.fx.Schedule<F, Input,
+  arrow.core.Tuple6<A, B, C, D, E, FF>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF> tupledN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>
+): Schedule<F, Input, Tuple6<A, B, C, D, E, FF>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupledN<A, B, C, D, E, FF>(arg0, arg1, arg2, arg3, arg4, arg5) as arrow.fx.Schedule<F, Input,
+  arrow.core.Tuple6<A, B, C, D, E, FF>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G> tupled(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>
+): Schedule<F, Input, Tuple7<A, B, C, D, E, FF, G>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupled<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.fx.Schedule<F,
+  Input, arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G> tupledN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>
+): Schedule<F, Input, Tuple7<A, B, C, D, E, FF, G>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupledN<A, B, C, D, E, FF, G>(arg0, arg1, arg2, arg3, arg4, arg5, arg6) as arrow.fx.Schedule<F,
+  Input, arrow.core.Tuple7<A, B, C, D, E, FF, G>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H> tupled(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>
+): Schedule<F, Input, Tuple8<A, B, C, D, E, FF, G, H>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupled<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.fx.Schedule<F, Input, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H> tupledN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>
+): Schedule<F, Input, Tuple8<A, B, C, D, E, FF, G, H>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupledN<A, B, C, D, E, FF, G, H>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7) as
+  arrow.fx.Schedule<F, Input, arrow.core.Tuple8<A, B, C, D, E, FF, G, H>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, I> tupled(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Kind<Kind<Kind<ForSchedule, F>, Input>, I>
+): Schedule<F, Input, Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupled<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.fx.Schedule<F, Input, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, I> tupledN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Kind<Kind<Kind<ForSchedule, F>, Input>, I>
+): Schedule<F, Input, Tuple9<A, B, C, D, E, FF, G, H, I>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupledN<A, B, C, D, E, FF, G, H, I>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) as
+  arrow.fx.Schedule<F, Input, arrow.core.Tuple9<A, B, C, D, E, FF, G, H, I>>
+
+@JvmName("tupled")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, I, J> tupled(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Kind<Kind<Kind<ForSchedule, F>, Input>, I>,
+  arg9: Kind<Kind<Kind<ForSchedule, F>, Input>, J>
+): Schedule<F, Input, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupled<A, B, C, D, E, FF, G, H, I,
+    J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.fx.Schedule<F, Input,
+  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+
+@JvmName("tupledN")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B, C, D, E, FF, G, H, I, J> tupledN(
+  arg0: Kind<Kind<Kind<ForSchedule, F>, Input>, A>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>,
+  arg2: Kind<Kind<Kind<ForSchedule, F>, Input>, C>,
+  arg3: Kind<Kind<Kind<ForSchedule, F>, Input>, D>,
+  arg4: Kind<Kind<Kind<ForSchedule, F>, Input>, E>,
+  arg5: Kind<Kind<Kind<ForSchedule, F>, Input>, FF>,
+  arg6: Kind<Kind<Kind<ForSchedule, F>, Input>, G>,
+  arg7: Kind<Kind<Kind<ForSchedule, F>, Input>, H>,
+  arg8: Kind<Kind<Kind<ForSchedule, F>, Input>, I>,
+  arg9: Kind<Kind<Kind<ForSchedule, F>, Input>, J>
+): Schedule<F, Input, Tuple10<A, B, C, D, E, FF, G, H, I, J>> = arrow.fx.Schedule
+  .apply<F, Input>()
+  .tupledN<A, B, C, D, E, FF, G, H, I,
+    J>(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) as arrow.fx.Schedule<F, Input,
+  arrow.core.Tuple10<A, B, C, D, E, FF, G, H, I, J>>
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>,
+  A>.followedBy(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>): Schedule<F, Input, B> =
+  arrow.fx.Schedule.apply<F, Input>().run {
+    this@followedBy.followedBy<A, B>(arg1) as arrow.fx.Schedule<F, Input, B>
+  }
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>,
+  A>.apTap(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>): Schedule<F, Input, A> =
+  arrow.fx.Schedule.apply<F, Input>().run {
+    this@apTap.apTap<A, B>(arg1) as arrow.fx.Schedule<F, Input, A>
+  }
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, Input> Companion.apply(): ScheduleAppy<F, Input> = apply_singleton as
+  arrow.fx.extensions.ScheduleAppy<F, Input>

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/category/ScheduleCategory.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/category/ScheduleCategory.kt
@@ -1,0 +1,64 @@
+package arrow.fx.extensions.schedule.category
+
+import arrow.Kind
+import arrow.fx.ForSchedule
+import arrow.fx.IODeprecation
+import arrow.fx.Schedule
+import arrow.fx.Schedule.Companion
+import arrow.fx.extensions.ScheduleCategory
+import arrow.typeclasses.Monad
+import kotlin.Deprecated
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("compose")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, A, B, C> Kind<Kind<Kind<ForSchedule, F>, B>, C>.compose(
+  MM: Monad<F>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, A>, B>
+): Schedule<F, A, C> =
+    arrow.fx.Schedule.category<F>(MM).run {
+  this@compose.compose<A, B, C>(arg1) as arrow.fx.Schedule<F, A, C>
+}
+
+@JvmName("andThen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, A, B, C> Kind<Kind<Kind<ForSchedule, F>, A>, B>.andThen(
+  MM: Monad<F>,
+  arg1: Kind<Kind<Kind<ForSchedule, F>, B>, C>
+): Schedule<F, A, C> =
+    arrow.fx.Schedule.category<F>(MM).run {
+  this@andThen.andThen<A, B, C>(arg1) as arrow.fx.Schedule<F, A, C>
+}
+
+@JvmName("id")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, A> id(MM: Monad<F>): Schedule<F, A, A> = arrow.fx.Schedule
+   .category<F>(MM)
+   .id<A>() as arrow.fx.Schedule<F, A, A>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F> Companion.category(MM: Monad<F>): ScheduleCategory<F> = object :
+    arrow.fx.extensions.ScheduleCategory<F> { override fun MM(): arrow.typeclasses.Monad<F> = MM }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/contravariant/ScheduleContravariant.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/contravariant/ScheduleContravariant.kt
@@ -1,0 +1,94 @@
+package arrow.fx.extensions.schedule.contravariant
+
+import arrow.Kind
+import arrow.fx.ForSchedule
+import arrow.fx.IODeprecation
+import arrow.fx.Schedule.Companion
+import arrow.fx.extensions.ScheduleContravariant
+import arrow.typeclasses.Conested
+import kotlin.Any
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val contravariant_singleton: ScheduleContravariant<Any?, Any?> = object :
+    ScheduleContravariant<Any?, Any?> {}
+
+@JvmName("contramap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Output, A, B> Kind<Conested<Kind<ForSchedule, F>, Output>, A>.contramap(
+  arg1: Function1<B,
+A>
+): Kind<Conested<Kind<ForSchedule, F>, Output>, B> = arrow.fx.Schedule.contravariant<F,
+    Output>().run {
+  this@contramap.contramap<A, B>(arg1) as
+    arrow.Kind<arrow.typeclasses.Conested<arrow.Kind<arrow.fx.ForSchedule, F>, Output>, B>
+}
+
+@JvmName("lift1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Output, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Conested<Kind<ForSchedule, F>,
+    Output>, B>, Kind<Conested<Kind<ForSchedule, F>, Output>, A>> = arrow.fx.Schedule
+   .contravariant<F, Output>()
+   .lift<A, B>(arg0) as
+    kotlin.Function1<arrow.Kind<arrow.typeclasses.Conested<arrow.Kind<arrow.fx.ForSchedule, F>,
+    Output>, B>, arrow.Kind<arrow.typeclasses.Conested<arrow.Kind<arrow.fx.ForSchedule, F>, Output>,
+    A>>
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Output, A, B> Kind<Conested<Kind<ForSchedule, F>, Output>, A>.imap(
+  arg1: Function1<A, B>,
+  arg2: Function1<B, A>
+): Kind<Conested<Kind<ForSchedule, F>, Output>, B> =
+    arrow.fx.Schedule.contravariant<F, Output>().run {
+  this@imap.imap<A, B>(arg1, arg2) as
+    arrow.Kind<arrow.typeclasses.Conested<arrow.Kind<arrow.fx.ForSchedule, F>, Output>, B>
+}
+
+@JvmName("narrow")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Output, A, B : A> Kind<Conested<Kind<ForSchedule, F>, Output>, A>.narrow():
+    Kind<Conested<Kind<ForSchedule, F>, Output>, B> = arrow.fx.Schedule.contravariant<F,
+    Output>().run {
+  this@narrow.narrow<A, B>() as
+    arrow.Kind<arrow.typeclasses.Conested<arrow.Kind<arrow.fx.ForSchedule, F>, Output>, B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, Output> Companion.contravariant(): ScheduleContravariant<F, Output> =
+    contravariant_singleton as arrow.fx.extensions.ScheduleContravariant<F, Output>

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/functor/ScheduleFunctor.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/functor/ScheduleFunctor.kt
@@ -1,0 +1,164 @@
+package arrow.fx.extensions.schedule.functor
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.fx.ForSchedule
+import arrow.fx.IODeprecation
+import arrow.fx.Schedule
+import arrow.fx.Schedule.Companion
+import arrow.fx.extensions.ScheduleFunctor
+import kotlin.Any
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: ScheduleFunctor<Any?, Any?> = object : ScheduleFunctor<Any?, Any?>
+    {}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.map(arg1: Function1<A, B>):
+    Schedule<F, Input, B> = arrow.fx.Schedule.functor<F, Input>().run {
+  this@map.map<A, B>(arg1) as arrow.fx.Schedule<F, Input, B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.imap(
+  arg1: Function1<A, B>,
+  arg2: Function1<B, A>
+): Schedule<F, Input, B> = arrow.fx.Schedule.functor<F, Input>().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.Schedule<F, Input, B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> lift(arg0: Function1<A, B>): Function1<Kind<Kind<Kind<ForSchedule, F>, Input>,
+    A>, Kind<Kind<Kind<ForSchedule, F>, Input>, B>> = arrow.fx.Schedule
+   .functor<F, Input>()
+   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.Kind<arrow.Kind<arrow.fx.ForSchedule, F>,
+    Input>, A>, arrow.Kind<arrow.Kind<arrow.Kind<arrow.fx.ForSchedule, F>, Input>, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.void(): Schedule<F, Input, Unit> =
+    arrow.fx.Schedule.functor<F, Input>().run {
+  this@void.void<A>() as arrow.fx.Schedule<F, Input, kotlin.Unit>
+}
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.fproduct(arg1: Function1<A, B>):
+    Schedule<F, Input, Tuple2<A, B>> = arrow.fx.Schedule.functor<F, Input>().run {
+  this@fproduct.fproduct<A, B>(arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.mapConst(arg1: B): Schedule<F,
+    Input, B> = arrow.fx.Schedule.functor<F, Input>().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.Schedule<F, Input, B>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> A.mapConst(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, B>): Schedule<F,
+    Input, A> = arrow.fx.Schedule.functor<F, Input>().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.Schedule<F, Input, A>
+}
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.tupleLeft(arg1: B): Schedule<F,
+    Input, Tuple2<B, A>> = arrow.fx.Schedule.functor<F, Input>().run {
+  this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple2<B, A>>
+}
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A, B> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.tupleRight(arg1: B): Schedule<F,
+    Input, Tuple2<A, B>> = arrow.fx.Schedule.functor<F, Input>().run {
+  this@tupleRight.tupleRight<A, B>(arg1) as arrow.fx.Schedule<F, Input, arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, B, A : B> Kind<Kind<Kind<ForSchedule, F>, Input>, A>.widen(): Schedule<F, Input, B> =
+    arrow.fx.Schedule.functor<F, Input>().run {
+  this@widen.widen<B, A>() as arrow.fx.Schedule<F, Input, B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, Input> Companion.functor(): ScheduleFunctor<F, Input> = functor_singleton as
+    arrow.fx.extensions.ScheduleFunctor<F, Input>

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/monoid/ScheduleMonoid.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/monoid/ScheduleMonoid.kt
@@ -1,0 +1,56 @@
+package arrow.fx.extensions.schedule.monoid
+
+import arrow.fx.IODeprecation
+import arrow.fx.Schedule
+import arrow.fx.Schedule.Companion
+import arrow.fx.extensions.ScheduleMonoid
+import arrow.typeclasses.Monad
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Suppress
+import kotlin.collections.Collection
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, Output> Collection<Schedule<F, Input, Output>>.combineAll(
+  OI: Monoid<Output>,
+  MF: Monad<F>
+): Schedule<F, Input, Output> = arrow.fx.Schedule.monoid<F, Input,
+    Output>(OI, MF).run {
+  this@combineAll.combineAll() as arrow.fx.Schedule<F, Input, Output>
+}
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, Output> combineAll(
+  OI: Monoid<Output>,
+  MF: Monad<F>,
+  arg0: List<Schedule<F, Input, Output>>
+): Schedule<F, Input, Output> = arrow.fx.Schedule
+   .monoid<F, Input, Output>(OI, MF)
+   .combineAll(arg0) as arrow.fx.Schedule<F, Input, Output>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, Input, Output> Companion.monoid(OI: Monoid<Output>, MF: Monad<F>): ScheduleMonoid<F,
+    Input, Output> = object : arrow.fx.extensions.ScheduleMonoid<F, Input, Output> { override fun
+    OI(): arrow.typeclasses.Monoid<Output> = OI
+
+  override fun MF(): arrow.typeclasses.Monad<F> = MF }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/profunctor/ScheduleProfunctor.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/profunctor/ScheduleProfunctor.kt
@@ -1,0 +1,69 @@
+package arrow.fx.extensions.schedule.profunctor
+
+import arrow.Kind
+import arrow.fx.ForSchedule
+import arrow.fx.IODeprecation
+import arrow.fx.Schedule
+import arrow.fx.Schedule.Companion
+import arrow.fx.extensions.ScheduleProfunctor
+import kotlin.Any
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val profunctor_singleton: ScheduleProfunctor<Any?> = object : ScheduleProfunctor<Any?> {}
+
+@JvmName("dimap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, A, B, C, D> Kind<Kind<Kind<ForSchedule, F>, A>, B>.dimap(
+  arg1: Function1<C, A>,
+  arg2: Function1<B, D>
+): Schedule<F, C, D> = arrow.fx.Schedule.profunctor<F>().run {
+  this@dimap.dimap<A, B, C, D>(arg1, arg2) as arrow.fx.Schedule<F, C, D>
+}
+
+@JvmName("lmap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, A, B, C> Kind<Kind<Kind<ForSchedule, F>, A>, B>.lmap(arg1: Function1<C, A>): Schedule<F, C,
+    B> = arrow.fx.Schedule.profunctor<F>().run {
+  this@lmap.lmap<A, B, C>(arg1) as arrow.fx.Schedule<F, C, B>
+}
+
+@JvmName("rmap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, A, B, D> Kind<Kind<Kind<ForSchedule, F>, A>, B>.rmap(arg1: Function1<B, D>): Schedule<F, A,
+    D> = arrow.fx.Schedule.profunctor<F>().run {
+  this@rmap.rmap<A, B, D>(arg1) as arrow.fx.Schedule<F, A, D>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F> Companion.profunctor(): ScheduleProfunctor<F> = profunctor_singleton as
+    arrow.fx.extensions.ScheduleProfunctor<F>

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/semigroup/ScheduleSemigroup.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/semigroup/ScheduleSemigroup.kt
@@ -1,0 +1,52 @@
+package arrow.fx.extensions.schedule.semigroup
+
+import arrow.fx.IODeprecation
+import arrow.fx.Schedule
+import arrow.fx.Schedule.Companion
+import arrow.fx.extensions.ScheduleSemigroup
+import arrow.typeclasses.Semigroup
+import kotlin.Deprecated
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+@JvmName("plus")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, Output> Schedule<F, Input, Output>.plus(
+  OI: Semigroup<Output>,
+  arg1: Schedule<F,
+      Input, Output>
+): Schedule<F, Input, Output> = arrow.fx.Schedule.semigroup<F, Input,
+    Output>(OI).run {
+  this@plus.plus(arg1) as arrow.fx.Schedule<F, Input, Output>
+}
+
+@JvmName("maybeCombine")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, Output> Schedule<F, Input, Output>.maybeCombine(
+  OI: Semigroup<Output>,
+  arg1: Schedule<F, Input, Output>
+): Schedule<F, Input, Output> = arrow.fx.Schedule.semigroup<F,
+    Input, Output>(OI).run {
+  this@maybeCombine.maybeCombine(arg1) as arrow.fx.Schedule<F, Input, Output>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, Input, Output> Companion.semigroup(OI: Semigroup<Output>): ScheduleSemigroup<F,
+    Input, Output> = object : arrow.fx.extensions.ScheduleSemigroup<F, Input, Output> { override fun
+    OI(): arrow.typeclasses.Semigroup<Output> = OI }

--- a/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/semigroupK/ScheduleSemigroupK.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/extensions/schedule/semigroupK/ScheduleSemigroupK.kt
@@ -1,0 +1,58 @@
+package arrow.fx.extensions.schedule.semigroupK
+
+import arrow.Kind
+import arrow.fx.ForSchedule
+import arrow.fx.IODeprecation
+import arrow.fx.Schedule
+import arrow.fx.Schedule.Companion
+import arrow.fx.extensions.ScheduleSemigroupK
+import arrow.typeclasses.Semigroup
+import kotlin.Any
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val semigroupK_singleton: ScheduleSemigroupK<Any?, Any?> = object :
+    ScheduleSemigroupK<Any?, Any?> {}
+
+@JvmName("combineK")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A> Kind<Kind<Kind<ForSchedule, F>, Input>,
+    A>.combineK(arg1: Kind<Kind<Kind<ForSchedule, F>, Input>, A>): Schedule<F, Input, A> =
+    arrow.fx.Schedule.semigroupK<F, Input>().run {
+  this@combineK.combineK<A>(arg1) as arrow.fx.Schedule<F, Input, A>
+}
+
+@JvmName("algebra")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(IODeprecation)
+fun <F, Input, A> algebra(): Semigroup<Kind<Kind<Kind<ForSchedule, F>, Input>, A>> =
+    arrow.fx.Schedule
+   .semigroupK<F, Input>()
+   .algebra<A>() as
+    arrow.typeclasses.Semigroup<arrow.Kind<arrow.Kind<arrow.Kind<arrow.fx.ForSchedule, F>, Input>,
+    A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(IODeprecation)
+inline fun <F, Input> Companion.semigroupK(): ScheduleSemigroupK<F, Input> = semigroupK_singleton as
+    arrow.fx.extensions.ScheduleSemigroupK<F, Input>

--- a/arrow-fx/src/main/kotlin/arrow/fx/internal/IQueue.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/internal/IQueue.kt
@@ -7,6 +7,7 @@ import arrow.core.Some
 import arrow.core.toT
 import arrow.core.extensions.list.foldable.exists
 import arrow.core.extensions.list.foldable.nonEmpty
+import arrow.fx.IODeprecation
 
 /**
  *  Port of `scala.collection.immutable.Queue`
@@ -18,7 +19,7 @@ import arrow.core.extensions.list.foldable.nonEmpty
  *  queue is pivoted by replacing the ''out'' list by ''in.reverse'', and ''in'' by ''Nil''.
  *
  */
-
+@Deprecated(IODeprecation)
 class IQueue<A> internal constructor(val lIn: List<A>, val lOut: List<A>) : Iterable<A> {
 
   private fun <A> Iterable<A>.head() = first()

--- a/arrow-fx/src/main/kotlin/arrow/fx/internal/UnsafePromise.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/internal/UnsafePromise.kt
@@ -1,9 +1,11 @@
 package arrow.fx.internal
 
 import arrow.core.Either
+import arrow.fx.IODeprecation
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 
+@Deprecated(IODeprecation)
 class UnsafePromise<A> {
 
   private sealed class State<out A> {

--- a/arrow-fx/src/main/kotlin/arrow/fx/internal/Utils.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/internal/Utils.kt
@@ -7,6 +7,7 @@ import arrow.core.Some
 import arrow.core.left
 import arrow.core.right
 import arrow.fx.IO
+import arrow.fx.IODeprecation
 import arrow.fx.IOOf
 import arrow.fx.coroutines.SuspendConnection
 import arrow.fx.fix
@@ -25,9 +26,11 @@ internal open class ArrowInternalException(
 private const val initialIndex: Int = 0
 private const val chunkSize: Int = 8
 
+@Deprecated(IODeprecation)
 object Platform {
 
   @Suppress("UNCHECKED_CAST")
+  @Deprecated(IODeprecation)
   class ArrayStack<A> {
 
     private val initialArray: Array<Any?> = arrayOfNulls<Any?>(chunkSize)
@@ -126,8 +129,10 @@ object Platform {
    *  - therefore a "map fusion" that goes 128 in stack depth can use
    *    about 4 KB of stack space
    */
+  @Deprecated(IODeprecation)
   const val maxStackDepthSize = 127
 
+  @Deprecated(IODeprecation)
   inline fun <A> onceOnly(crossinline f: (A) -> Unit): (A) -> Unit {
     val wasCalled = AtomicBooleanW(false)
 
@@ -149,6 +154,7 @@ object Platform {
     }
   }
 
+  @Deprecated(IODeprecation)
   fun <A> unsafeResync(ioa: IO<A>, limit: Duration): Option<A> {
     val latch = OneShotLatch()
     var ref: Either<Throwable, A>? = null
@@ -177,6 +183,7 @@ object Platform {
    * On top of the JVM this function uses Throwable#addSuppressed, available since Java 7. On top of JavaScript the
    * function would return a CompositeException.
    */
+  @Deprecated(IODeprecation)
   fun composeErrors(first: Throwable, vararg rest: Throwable): Throwable {
     rest.forEach { if (it != first) first.addSuppressed(it) }
     return first
@@ -189,11 +196,13 @@ object Platform {
    * On top of the JVM this function uses Throwable#addSuppressed, available since Java 7. On top of JavaScript the
    * function would return a CompositeException.
    */
+  @Deprecated(IODeprecation)
   fun composeErrors(first: Throwable, rest: List<Throwable>): Throwable {
     rest.forEach { if (it != first) first.addSuppressed(it) }
     return first
   }
 
+  @Deprecated(IODeprecation)
   inline fun trampoline(crossinline f: () -> Unit): Unit =
     _trampoline.get().execute(Runnable { f() })
 

--- a/arrow-fx/src/main/kotlin/arrow/fx/internal/atomic.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/internal/atomic.kt
@@ -1,5 +1,6 @@
 package arrow.fx.internal
 
+import arrow.fx.IODeprecation
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.updateAndGet
 import kotlinx.atomicfu.getAndUpdate
@@ -7,6 +8,7 @@ import kotlinx.atomicfu.getAndUpdate
 /**
  * Internal wrapper for Atomic-FU Atomics to be used as local variables
  */
+@Deprecated(IODeprecation)
 class AtomicRefW<A>(a: A) {
   private val atomicRef = atomic(a)
 
@@ -35,6 +37,7 @@ class AtomicRefW<A>(a: A) {
     value.toString()
 }
 
+@Deprecated(IODeprecation)
 class AtomicBooleanW(a: Boolean) {
   private val atomicRef = atomic(a)
 
@@ -63,6 +66,7 @@ class AtomicBooleanW(a: Boolean) {
     value.toString()
 }
 
+@Deprecated(IODeprecation)
 class AtomicIntW(a: Int) {
   private val atomicRef = atomic(a)
 

--- a/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Duration.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Duration.kt
@@ -34,46 +34,61 @@ data class Duration(val amount: Long, val timeUnit: TimeUnit) {
   }
 }
 
+@Deprecated(IODeprecation)
 operator fun Int.times(d: Duration) = d * this
 
+@Deprecated(IODeprecation)
 val Long.days: Duration
   get() = Duration(this, TimeUnit.DAYS)
 
+@Deprecated(IODeprecation)
 val Int.days: Duration
   get() = Duration(this.toLong(), TimeUnit.DAYS)
 
+@Deprecated(IODeprecation)
 val Long.hours: Duration
   get() = Duration(this, TimeUnit.HOURS)
 
+@Deprecated(IODeprecation)
 val Int.hours: Duration
   get() = Duration(this.toLong(), TimeUnit.HOURS)
 
+@Deprecated(IODeprecation)
 val Long.microseconds: Duration
   get() = Duration(this, TimeUnit.MICROSECONDS)
 
+@Deprecated(IODeprecation)
 val Int.microseconds: Duration
   get() = Duration(this.toLong(), TimeUnit.MICROSECONDS)
 
+@Deprecated(IODeprecation)
 val Long.minutes: Duration
   get() = Duration(this, TimeUnit.MINUTES)
 
+@Deprecated(IODeprecation)
 val Int.minutes: Duration
   get() = Duration(this.toLong(), TimeUnit.MINUTES)
 
+@Deprecated(IODeprecation)
 val Long.milliseconds: Duration
   get() = Duration(this, TimeUnit.MILLISECONDS)
 
+@Deprecated(IODeprecation)
 val Int.milliseconds: Duration
   get() = Duration(this.toLong(), TimeUnit.MILLISECONDS)
 
+@Deprecated(IODeprecation)
 val Long.nanoseconds: Duration
   get() = Duration(this, TimeUnit.NANOSECONDS)
 
+@Deprecated(IODeprecation)
 val Int.nanoseconds: Duration
   get() = Duration(this.toLong(), TimeUnit.NANOSECONDS)
 
+@Deprecated(IODeprecation)
 val Long.seconds: Duration
   get() = Duration(this, TimeUnit.SECONDS)
 
+@Deprecated(IODeprecation)
 val Int.seconds: Duration
   get() = Duration(this.toLong(), TimeUnit.SECONDS)

--- a/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Fiber.kt
+++ b/arrow-fx/src/main/kotlin/arrow/fx/typeclasses/Fiber.kt
@@ -3,7 +3,19 @@ package arrow.fx.typeclasses
 import arrow.Kind
 import arrow.fx.IODeprecation
 
-import arrow.higherkind
+@Deprecated(IODeprecation)
+class ForFiber private constructor() { companion object }
+
+@Deprecated(IODeprecation)
+typealias FiberOf<F, A> = arrow.Kind2<ForFiber, F, A>
+
+@Deprecated(IODeprecation)
+typealias FiberPartialOf<F> = arrow.Kind<ForFiber, F>
+
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(IODeprecation)
+inline fun <F, A> FiberOf<F, A>.fix(): Fiber<F, A> =
+  this as Fiber<F, A>
 
 /**
  * [Fiber] represents the pure result of an [Async] data type
@@ -12,7 +24,6 @@ import arrow.higherkind
  * You can think of fibers as being lightweight threads, a Fiber being a
  * concurrency primitive for doing cooperative multi-tasking.
  */
-@higherkind
 @Deprecated(IODeprecation)
 interface Fiber<F, out A> : FiberOf<F, A> {
 


### PR DESCRIPTION
## Status
READY

## Description
This PR removes all `@extension` from the Arrow Fx (`IO`) module, and deprecates all public code

## Related PRs
* https://github.com/arrow-kt/arrow-fx/pull/357
