### PR TITLE
CU-bcu7fc Deprecate all public functions, data types and generated code for Reactor

### DIFF
--- a/arrow-fx-reactor/build.gradle
+++ b/arrow-fx-reactor/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "org.jetbrains.kotlin.jvm"
-    id "org.jetbrains.kotlin.kapt"
     id "org.jlleitschuh.gradle.ktlint"
 }
 
@@ -10,8 +9,6 @@ apply from: "$DOC_CREATION"
 dependencies {
     compile project(":arrow-fx")
     compile "io.arrow-kt:arrow-annotations:$VERSION_NAME"
-    kapt "io.arrow-kt:arrow-meta:$VERSION_NAME"
-    kaptTest "io.arrow-kt:arrow-meta:$VERSION_NAME"
     testRuntime "org.junit.vintage:junit-vintage-engine:$JUNIT_VINTAGE_VERSION"
     testCompile "io.kotlintest:kotlintest-runner-junit5:$KOTLIN_TEST_VERSION", excludeArrow
     testCompile project(":arrow-fx-test")

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk.kt
@@ -4,7 +4,6 @@ import arrow.Kind
 import arrow.core.Either
 import arrow.core.Eval
 import arrow.core.Option
-import arrow.extension
 import arrow.fx.Timer
 import arrow.fx.reactor.DeprecateReactor
 import arrow.fx.reactor.FluxK
@@ -42,14 +41,12 @@ import reactor.core.publisher.toFlux
 import kotlin.coroutines.CoroutineContext
 import arrow.fx.reactor.handleErrorWith as fluxHandleErrorWith
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKFunctor : Functor<ForFluxK> {
   override fun <A, B> FluxKOf<A>.map(f: (A) -> B): FluxK<B> =
     fix().map(f)
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKApplicative : Applicative<ForFluxK> {
   override fun <A> just(a: A): FluxK<A> =
@@ -65,7 +62,6 @@ interface FluxKApplicative : Applicative<ForFluxK> {
     Eval.now(fix().ap(FluxK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKMonad : Monad<ForFluxK>, FluxKApplicative {
   override fun <A, B> FluxKOf<A>.ap(ff: FluxKOf<(A) -> B>): FluxK<B> =
@@ -84,7 +80,6 @@ interface FluxKMonad : Monad<ForFluxK>, FluxKApplicative {
     Eval.now(fix().ap(FluxK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKFoldable : Foldable<ForFluxK> {
   override fun <A, B> FluxKOf<A>.foldLeft(b: B, f: (B, A) -> B): B =
@@ -94,7 +89,6 @@ interface FluxKFoldable : Foldable<ForFluxK> {
     fix().foldRight(lb, f)
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKTraverse : Traverse<ForFluxK> {
   override fun <A, B> FluxKOf<A>.map(f: (A) -> B): FluxK<B> =
@@ -110,7 +104,6 @@ interface FluxKTraverse : Traverse<ForFluxK> {
     fix().foldRight(lb, f)
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKApplicativeError :
   ApplicativeError<ForFluxK, Throwable>,
@@ -122,7 +115,6 @@ interface FluxKApplicativeError :
     fix().fluxHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKMonadError :
   MonadError<ForFluxK, Throwable>,
@@ -134,18 +126,15 @@ interface FluxKMonadError :
     fix().fluxHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKMonadThrow : MonadThrow<ForFluxK>, FluxKMonadError
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKBracket : Bracket<ForFluxK, Throwable>, FluxKMonadThrow {
   override fun <A, B> FluxKOf<A>.bracketCase(release: (A, ExitCase<Throwable>) -> Kind<ForFluxK, Unit>, use: (A) -> FluxKOf<B>): FluxK<B> =
     fix().bracketCase({ use(it) }, { a, e -> release(a, e) })
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKMonadDefer :
   MonadDefer<ForFluxK>,
@@ -154,7 +143,6 @@ interface FluxKMonadDefer :
     FluxK.defer(fa)
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKAsync :
   Async<ForFluxK>,
@@ -169,7 +157,6 @@ interface FluxKAsync :
     fix().continueOn(ctx)
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKEffect :
   Effect<ForFluxK>,
@@ -178,7 +165,6 @@ interface FluxKEffect :
     fix().runAsync(cb)
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKConcurrentEffect :
   ConcurrentEffect<ForFluxK>,
@@ -222,7 +208,6 @@ fun FluxK.Companion.monadErrorSwitch(): FluxKMonadError = object : FluxKMonadErr
 fun <A> FluxK.Companion.fx(c: suspend AsyncSyntax<ForFluxK>.() -> A): FluxK<A> =
   FluxK.async().fx.async(c).fix()
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKTimer : Timer<ForFluxK> {
   override fun sleep(duration: Duration): FluxK<Unit> =
@@ -230,14 +215,12 @@ interface FluxKTimer : Timer<ForFluxK> {
       .map { Unit }.toFlux())
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKFunctorFilter : FunctorFilter<ForFluxK>, FluxKFunctor {
   override fun <A, B> Kind<ForFluxK, A>.filterMap(f: (A) -> Option<B>): FluxK<B> =
     fix().filterMap(f)
 }
 
-@extension
 @Deprecated(DeprecateReactor)
 interface FluxKMonadFilter : MonadFilter<ForFluxK>, FluxKMonad {
   override fun <A> empty(): FluxK<A> =

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/applicative/FluxKApplicative.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/applicative/FluxKApplicative.kt
@@ -1,0 +1,94 @@
+package arrow.fx.reactor.extensions.fluxk.applicative
+
+import arrow.Kind
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKApplicative
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicative_singleton: FluxKApplicative = object :
+    arrow.fx.reactor.extensions.FluxKApplicative {}
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> A.just(): FluxK<A> = arrow.fx.reactor.FluxK.applicative().run {
+  this@just.just<A>() as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun unit(): FluxK<Unit> = arrow.fx.reactor.FluxK
+   .applicative()
+   .unit() as arrow.fx.reactor.FluxK<kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.map(arg1: Function1<A, B>): FluxK<B> =
+    arrow.fx.reactor.FluxK.applicative().run {
+  this@map.map<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.replicate(arg1: Int): FluxK<List<A>> =
+    arrow.fx.reactor.FluxK.applicative().run {
+  this@replicate.replicate<A>(arg1) as arrow.fx.reactor.FluxK<kotlin.collections.List<A>>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.replicate(arg1: Int, arg2: Monoid<A>): FluxK<A> =
+    arrow.fx.reactor.FluxK.applicative().run {
+  this@replicate.replicate<A>(arg1, arg2) as arrow.fx.reactor.FluxK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.applicative(): FluxKApplicative = applicative_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/applicativeError/FluxKApplicativeError.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/applicativeError/FluxKApplicativeError.kt
@@ -1,0 +1,174 @@
+package arrow.fx.reactor.extensions.fluxk.applicativeError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.ForOption
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKApplicativeError
+import arrow.typeclasses.ApplicativeError
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicativeError_singleton: FluxKApplicativeError = object :
+    arrow.fx.reactor.extensions.FluxKApplicativeError {}
+
+@JvmName("handleErrorWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.handleErrorWith(arg1: Function1<Throwable, Kind<ForFluxK, A>>): FluxK<A> =
+    arrow.fx.reactor.FluxK.applicativeError().run {
+  this@handleErrorWith.handleErrorWith<A>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("raiseError1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Throwable.raiseError(): FluxK<A> = arrow.fx.reactor.FluxK.applicativeError().run {
+  this@raiseError.raiseError<A>() as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("fromOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForOption, A>.fromOption(arg1: Function0<Throwable>): FluxK<A> =
+    arrow.fx.reactor.FluxK.applicativeError().run {
+  this@fromOption.fromOption<A>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("fromEither")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, Throwable>): FluxK<A> =
+    arrow.fx.reactor.FluxK.applicativeError().run {
+  this@fromEither.fromEither<A, EE>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("handleError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.handleError(arg1: Function1<Throwable, A>): FluxK<A> =
+    arrow.fx.reactor.FluxK.applicativeError().run {
+  this@handleError.handleError<A>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("redeem")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.redeem(arg1: Function1<Throwable, B>, arg2: Function1<A, B>): FluxK<B> =
+    arrow.fx.reactor.FluxK.applicativeError().run {
+  this@redeem.redeem<A, B>(arg1, arg2) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("attempt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.attempt(): FluxK<Either<Throwable, A>> =
+    arrow.fx.reactor.FluxK.applicativeError().run {
+  this@attempt.attempt<A>() as arrow.fx.reactor.FluxK<arrow.core.Either<kotlin.Throwable, A>>
+}
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> catch(arg0: Function1<Throwable, Throwable>, arg1: Function0<A>): FluxK<A> =
+    arrow.fx.reactor.FluxK
+   .applicativeError()
+   .catch<A>(arg0, arg1) as arrow.fx.reactor.FluxK<A>
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> ApplicativeError<ForFluxK, Throwable>.catch(arg1: Function0<A>): FluxK<A> =
+    arrow.fx.reactor.FluxK.applicativeError().run {
+  this@catch.catch<A>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+suspend fun <A> effectCatch(arg0: Function1<Throwable, Throwable>, arg1: suspend () -> A): FluxK<A> =
+    arrow.fx.reactor.FluxK
+   .applicativeError()
+   .effectCatch<A>(arg0, arg1) as arrow.fx.reactor.FluxK<A>
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+suspend fun <F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend () -> A): Kind<F, A> =
+    arrow.fx.reactor.FluxK.applicativeError().run {
+  this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.applicativeError(): FluxKApplicativeError = applicativeError_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/async/FluxKAsync.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/async/FluxKAsync.kt
@@ -1,0 +1,393 @@
+package arrow.fx.reactor.extensions.fluxk.async
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKAsync
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val async_singleton: FluxKAsync = object : arrow.fx.reactor.extensions.FluxKAsync {}
+
+/**
+ *  [async] variant that can suspend side effects in the provided registration function.
+ *
+ *  The passed in function is injected with a side-effectful callback for signaling the final result of an asynchronous process.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.*
+ *  import arrow.fx.typeclasses.Async
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.makeCompleteAndGetPromiseInAsync() =
+ *     asyncF<String> { cb: (Either<Throwable, String>) -> Unit ->
+ *       Promise.uncancellable<F, String>(this).flatMap { promise ->
+ *         promise.complete("Hello World!").flatMap {
+ *           promise.get().map { str -> cb(Right(str)) }
+ *         }
+ *       }
+ *     }
+ *
+ *   val result = FluxK.async().makeCompleteAndGetPromiseInAsync()
+ *  //sampleEnd
+ *  println(result)
+ *  }
+ *  ```
+ *
+ *  @see async for a simpler, non suspending version.
+ */
+@JvmName("asyncF")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> asyncF(arg0: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForFluxK, Unit>>):
+    FluxK<A> = arrow.fx.reactor.FluxK
+   .async()
+   .asyncF<A>(arg0) as arrow.fx.reactor.FluxK<A>
+
+/**
+ *  Continue the evaluation on provided [CoroutineContext]
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.runOnDefaultDispatcher(): Kind<F, String> =
+ *     just(Unit).continueOn(Dispatchers.Default).flatMap {
+ *       later({ Thread.currentThread().name })
+ *     }
+ *
+ *   val result = FluxK.async().runOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("continueOn")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.continueOn(arg1: CoroutineContext): FluxK<A> =
+    arrow.fx.reactor.FluxK.async().run {
+  this@continueOn.continueOn<A>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     later(Dispatchers.Default, { Thread.currentThread().name })
+ *
+ *   val result = FluxK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> later(arg0: CoroutineContext, arg1: Function0<A>): FluxK<A> = arrow.fx.reactor.FluxK
+   .async()
+   .later<A>(arg0, arg1) as arrow.fx.reactor.FluxK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = FluxK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> effect(arg0: suspend () -> A): FluxK<A> = arrow.fx.reactor.FluxK
+   .async()
+   .effect<A>(arg0) as arrow.fx.reactor.FluxK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = FluxK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> effect(arg0: CoroutineContext, arg1: suspend () -> A): FluxK<A> = arrow.fx.reactor.FluxK
+   .async()
+   .effect<A>(arg0, arg1) as arrow.fx.reactor.FluxK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     defer(Dispatchers.Default, { effect { Thread.currentThread().name } })
+ *
+ *   val result = FluxK.async().invokeOnDefaultDispatcher().fix().unsafeRunSync()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> defer(arg0: CoroutineContext, arg1: Function0<Kind<ForFluxK, A>>): FluxK<A> =
+    arrow.fx.reactor.FluxK
+   .async()
+   .defer<A>(arg0, arg1) as arrow.fx.reactor.FluxK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ */
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> laterOrRaise(arg0: CoroutineContext, arg1: Function0<Either<Throwable, A>>): FluxK<A> =
+    arrow.fx.reactor.FluxK
+   .async()
+   .laterOrRaise<A>(arg0, arg1) as arrow.fx.reactor.FluxK<A>
+
+/**
+ *  Shift evaluation to provided [CoroutineContext].
+ *
+ *  @receiver [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   FluxK.async().run {
+ *     val result = Dispatchers.Default.shift().map {
+ *       Thread.currentThread().name
+ *     }
+ *
+ *     println(result)
+ *   }
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("shift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun CoroutineContext.shift(): FluxK<Unit> = arrow.fx.reactor.FluxK.async().run {
+  this@shift.shift() as arrow.fx.reactor.FluxK<kotlin.Unit>
+}
+
+/**
+ *  Task that never finishes evaluating.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.async.*
+ * import arrow.core.*
+ *
+ *
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val i = FluxK.async().never<Int>()
+ *
+ *   println(i)
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("never")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> never(): FluxK<A> = arrow.fx.reactor.FluxK
+   .async()
+   .never<A>() as arrow.fx.reactor.FluxK<A>
+
+/**
+ *  Helper function that provides an easy way to construct a suspend effect
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun logAndIncrease(s: String): Int {
+ *      println(s)
+ *      return s.toInt() + 1
+ *   }
+ *
+ *   val result = FluxK.async().effect(Dispatchers.Default) { Thread.currentThread().name }.effectMap { s: String -> logAndIncrease(s) }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effectMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.effectMap(arg1: suspend (A) -> B): FluxK<B> =
+    arrow.fx.reactor.FluxK.async().run {
+  this@effectMap.effectMap<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+/**
+ *  [Async] models how a data type runs an asynchronous computation that may fail.
+ *  Defined by the [Proc] signature, which is the consumption of a callback.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.async(): FluxKAsync = async_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/bracket/FluxKBracket.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/bracket/FluxKBracket.kt
@@ -1,0 +1,261 @@
+package arrow.fx.reactor.extensions.fluxk.bracket
+
+import arrow.Kind
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKBracket
+import arrow.fx.typeclasses.ExitCase
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bracket_singleton: FluxKBracket = object : arrow.fx.reactor.extensions.FluxKBracket {}
+
+/**
+ *  A way to safely acquire a resource and release in the face of errors and cancellation.
+ *  It uses [ExitCase] to distinguish between different exit cases when releasing the acquired resource.
+ *
+ *  @param use is the action to consume the resource and produce an [F] with the result.
+ *  Once the resulting [F] terminates, either successfully, error or cancelled.
+ *
+ *  @param release the allocated resource after the resulting [F] of [use] is terminates.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.reactor.extensions.fluxk.monadDefer.defer
+ * import arrow.fx.reactor.extensions.fluxk.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val release: (File, ExitCase<Throwable>) -> Kind<F, Unit> = { file, exitCase ->
+ *       when (exitCase) {
+ * do something * / }
+ * do something * / }
+ * do something * / }
+ *       }
+ *       closeFile(file)
+ *   }
+ *
+ *   val use: (File) -> Kind<F, String> = { file: File -> fileToString(file) }
+ *
+ *   val safeComputation = openFile("data.json").bracketCase(release, use)
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracketCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.bracketCase(
+  arg1: Function2<A, ExitCase<Throwable>, Kind<ForFluxK,
+    Unit>>,
+  arg2: Function1<A, Kind<ForFluxK, B>>
+): FluxK<B> =
+  arrow.fx.reactor.FluxK.bracket().run {
+    this@bracketCase.bracketCase<A, B>(arg1, arg2) as arrow.fx.reactor.FluxK<B>
+  }
+
+/**
+ *  Meant for specifying tasks with safe resource acquisition and release in the face of errors and interruption.
+ *  It would be the the equivalent of `try/catch/finally` statements in mainstream imperative languages for resource
+ *  acquisition and release.
+ *
+ *  @param release is the action that's supposed to release the allocated resource after `use` is done, irregardless
+ *  of its exit condition.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.fluxk.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.reactor.extensions.fluxk.monadDefer.defer
+ * import arrow.fx.reactor.extensions.fluxk.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val safeComputation = openFile("data.json").bracket({ file: File -> closeFile(file) }, { file -> fileToString(file) })
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracket")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.bracket(
+  arg1: Function1<A, Kind<ForFluxK, Unit>>,
+  arg2: Function1<A, Kind<ForFluxK, B>>
+): FluxK<B> = arrow.fx.reactor.FluxK.bracket().run {
+  this@bracket.bracket<A, B>(arg1, arg2) as arrow.fx.reactor.FluxK<B>
+}
+
+/**
+ *  Meant for ensuring a given task continues execution even when interrupted.
+ */
+@JvmName("uncancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.uncancellable(): FluxK<A> = arrow.fx.reactor.FluxK.bracket().run {
+  this@uncancellable.uncancellable<A>() as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("uncancelable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.uncancelable(): FluxK<A> = arrow.fx.reactor.FluxK.bracket().run {
+  this@uncancelable.uncancelable<A>() as arrow.fx.reactor.FluxK<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracket] for the acquisition and release of resources.
+ *
+ *  @see [guaranteeCase] for the version that can discriminate between termination conditions
+ *
+ *  @see [bracket] for the more general operation
+ */
+@JvmName("guarantee")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.guarantee(arg1: Kind<ForFluxK, Unit>): FluxK<A> =
+  arrow.fx.reactor.FluxK.bracket().run {
+    this@guarantee.guarantee<A>(arg1) as arrow.fx.reactor.FluxK<A>
+  }
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled, allowing
+ *  for differentiating between exit conditions. That's thanks to the [ExitCase] argument of the finalizer.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracketCase] for the acquisition and release of resources.
+ *
+ *  @see [guarantee] for the simpler version
+ *
+ *  @see [bracketCase] for the more general operation
+ */
+@JvmName("guaranteeCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.guaranteeCase(arg1: Function1<ExitCase<Throwable>, Kind<ForFluxK, Unit>>):
+  FluxK<A> = arrow.fx.reactor.FluxK.bracket().run {
+  this@guaranteeCase.guaranteeCase<A>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+/**
+ *  Executes the given [finalizer] when the source is cancelled, allowing registering a cancellation token.
+ *
+ *  Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
+ */
+@JvmName("onCancel")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.onCancel(arg1: Kind<ForFluxK, Unit>): FluxK<A> =
+  arrow.fx.reactor.FluxK.bracket().run {
+    this@onCancel.onCancel<A>(arg1) as arrow.fx.reactor.FluxK<A>
+  }
+
+/**
+ *  Executes the given `finalizer` with the given error when the source is finished in error.
+ */
+@JvmName("onError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.onError(arg1: Function1<Throwable, Kind<ForFluxK, Unit>>): FluxK<A> =
+  arrow.fx.reactor.FluxK.bracket().run {
+    this@onError.onError<A>(arg1) as arrow.fx.reactor.FluxK<A>
+  }
+
+/**
+ *  Extension of MonadError exposing the [bracket] operation, a generalized abstracted pattern of safe resource
+ *  acquisition and release in the face of errors or interruption.
+ *
+ *  @define The functions receiver here (Kind<F, A>) would stand for the "acquireParam", and stands for an action that
+ *  "acquires" some expensive resource, that needs to be used and then discarded.
+ *
+ *  @define use is the action that uses the newly allocated resource and that will provide the final result.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.bracket(): FluxKBracket = bracket_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/concurrentEffect/FluxKConcurrentEffect.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/concurrentEffect/FluxKConcurrentEffect.kt
@@ -1,0 +1,47 @@
+package arrow.fx.reactor.extensions.fluxk.concurrentEffect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKConcurrentEffect
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val concurrentEffect_singleton: FluxKConcurrentEffect = object :
+    arrow.fx.reactor.extensions.FluxKConcurrentEffect {}
+
+@JvmName("runAsyncCancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.runAsyncCancellable(
+  arg1: Function1<Either<Throwable, A>, Kind<ForFluxK,
+Unit>>
+): FluxK<Function0<Unit>> = arrow.fx.reactor.FluxK.concurrentEffect().run {
+  this@runAsyncCancellable.runAsyncCancellable<A>(arg1) as
+    arrow.fx.reactor.FluxK<kotlin.Function0<kotlin.Unit>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.concurrentEffect(): FluxKConcurrentEffect = concurrentEffect_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/effect/FluxKEffect.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/effect/FluxKEffect.kt
@@ -1,0 +1,42 @@
+package arrow.fx.reactor.extensions.fluxk.effect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKEffect
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val effect_singleton: FluxKEffect = object : arrow.fx.reactor.extensions.FluxKEffect {}
+
+@JvmName("runAsync")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.runAsync(arg1: Function1<Either<Throwable, A>, Kind<ForFluxK, Unit>>):
+    FluxK<Unit> = arrow.fx.reactor.FluxK.effect().run {
+  this@runAsync.runAsync<A>(arg1) as arrow.fx.reactor.FluxK<kotlin.Unit>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.effect(): FluxKEffect = effect_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/foldable/FluxKFoldable.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/foldable/FluxKFoldable.kt
@@ -1,0 +1,415 @@
+package arrow.fx.reactor.extensions.fluxk.foldable
+
+import arrow.Kind
+import arrow.core.Eval
+import arrow.core.Option
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKFoldable
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import arrow.typeclasses.Monoid
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.Long
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val foldable_singleton: FluxKFoldable = object : arrow.fx.reactor.extensions.FluxKFoldable {}
+
+@JvmName("foldLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@foldLeft.foldLeft<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("foldRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.foldRight(arg1: Eval<B>, arg2: Function2<A, Eval<B>, Eval<B>>): Eval<B> =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@foldRight.foldRight<A, B>(arg1, arg2) as arrow.core.Eval<B>
+  }
+
+@JvmName("fold")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.fold(arg1: Monoid<A>): A = arrow.fx.reactor.FluxK.foldable().run {
+  this@fold.fold<A>(arg1) as A
+}
+
+@JvmName("reduceLeftToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.reduceLeftToOption(arg1: Function1<A, B>, arg2: Function2<B, A, B>):
+  Option<B> = arrow.fx.reactor.FluxK.foldable().run {
+  this@reduceLeftToOption.reduceLeftToOption<A, B>(arg1, arg2) as arrow.core.Option<B>
+}
+
+@JvmName("reduceRightToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.reduceRightToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<A, Eval<B>,
+    Eval<B>>
+): Eval<Option<B>> = arrow.fx.reactor.FluxK.foldable().run {
+  this@reduceRightToOption.reduceRightToOption<A, B>(arg1, arg2) as
+    arrow.core.Eval<arrow.core.Option<B>>
+}
+
+@JvmName("reduceLeftOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("reduceRightOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>): Eval<Option<A>> =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@reduceRightOption.reduceRightOption<A>(arg1) as arrow.core.Eval<arrow.core.Option<A>>
+  }
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.combineAll(arg1: Monoid<A>): A = arrow.fx.reactor.FluxK.foldable().run {
+  this@combineAll.combineAll<A>(arg1) as A
+}
+
+@JvmName("foldMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>): B =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@foldMap.foldMap<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("orEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> orEmpty(arg0: Applicative<ForFluxK>, arg1: Monoid<A>): FluxK<A> = arrow.fx.reactor.FluxK
+  .foldable()
+  .orEmpty<A>(arg0, arg1) as arrow.fx.reactor.FluxK<A>
+
+@JvmName("traverse_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <G, A, B> Kind<ForFluxK, A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>):
+  Kind<G, Unit> = arrow.fx.reactor.FluxK.foldable().run {
+  this@traverse_.traverse_<G, A, B>(arg1, arg2) as arrow.Kind<G, kotlin.Unit>
+}
+
+@JvmName("sequence_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <G, A> Kind<ForFluxK, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
+  }
+
+@JvmName("find")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.find(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@find.find<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("exists")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.exists(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@exists.exists<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("forAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@forAll.forAll<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("all")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.all(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@all.all<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("isEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.isEmpty(): Boolean = arrow.fx.reactor.FluxK.foldable().run {
+  this@isEmpty.isEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("nonEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.nonEmpty(): Boolean = arrow.fx.reactor.FluxK.foldable().run {
+  this@nonEmpty.nonEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("isNotEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.isNotEmpty(): Boolean = arrow.fx.reactor.FluxK.foldable().run {
+  this@isNotEmpty.isNotEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("size")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.size(arg1: Monoid<Long>): Long = arrow.fx.reactor.FluxK.foldable().run {
+  this@size.size<A>(arg1) as kotlin.Long
+}
+
+@JvmName("foldMapA")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForFluxK, A>.foldMapA(
+  arg1: AP,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.reactor.FluxK.foldable().run {
+  this@foldMapA.foldMapA<G, A, B, AP, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldMapM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForFluxK, A>.foldMapM(
+  arg1: MA,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.reactor.FluxK.foldable().run {
+  this@foldMapM.foldMapM<G, A, B, MA, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <G, A, B> Kind<ForFluxK, A>.foldM(
+  arg1: Monad<G>,
+  arg2: B,
+  arg3: Function2<B, A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.reactor.FluxK.foldable().run {
+  this@foldM.foldM<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("get")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.get(arg1: Long): Option<A> = arrow.fx.reactor.FluxK.foldable().run {
+  this@get.get<A>(arg1) as arrow.core.Option<A>
+}
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.firstOption(): Option<A> = arrow.fx.reactor.FluxK.foldable().run {
+  this@firstOption.firstOption<A>() as arrow.core.Option<A>
+}
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.firstOption(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@firstOption.firstOption<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.firstOrNone(): Option<A> = arrow.fx.reactor.FluxK.foldable().run {
+  this@firstOrNone.firstOrNone<A>() as arrow.core.Option<A>
+}
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.reactor.FluxK.foldable().run {
+    this@firstOrNone.firstOrNone<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("toList")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.toList(): List<A> = arrow.fx.reactor.FluxK.foldable().run {
+  this@toList.toList<A>() as kotlin.collections.List<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.foldable(): FluxKFoldable = foldable_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/functor/FluxKFunctor.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/functor/FluxKFunctor.kt
@@ -1,0 +1,155 @@
+package arrow.fx.reactor.extensions.fluxk.functor
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKFunctor
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: FluxKFunctor = object : arrow.fx.reactor.extensions.FluxKFunctor {}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.map(arg1: Function1<A, B>): FluxK<B> =
+    arrow.fx.reactor.FluxK.functor().run {
+  this@map.map<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): FluxK<B> =
+    arrow.fx.reactor.FluxK.functor().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForFluxK, A>, Kind<ForFluxK, B>> =
+    arrow.fx.reactor.FluxK
+   .functor()
+   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.fx.reactor.ForFluxK, A>,
+    arrow.Kind<arrow.fx.reactor.ForFluxK, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.void(): FluxK<Unit> = arrow.fx.reactor.FluxK.functor().run {
+  this@void.void<A>() as arrow.fx.reactor.FluxK<kotlin.Unit>
+}
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.fproduct(arg1: Function1<A, B>): FluxK<Tuple2<A, B>> =
+    arrow.fx.reactor.FluxK.functor().run {
+  this@fproduct.fproduct<A, B>(arg1) as arrow.fx.reactor.FluxK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.mapConst(arg1: B): FluxK<B> = arrow.fx.reactor.FluxK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> A.mapConst(arg1: Kind<ForFluxK, B>): FluxK<A> = arrow.fx.reactor.FluxK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.tupleLeft(arg1: B): FluxK<Tuple2<B, A>> =
+    arrow.fx.reactor.FluxK.functor().run {
+  this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.fx.reactor.FluxK<arrow.core.Tuple2<B, A>>
+}
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.tupleRight(arg1: B): FluxK<Tuple2<A, B>> =
+    arrow.fx.reactor.FluxK.functor().run {
+  this@tupleRight.tupleRight<A, B>(arg1) as arrow.fx.reactor.FluxK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <B, A : B> Kind<ForFluxK, A>.widen(): FluxK<B> = arrow.fx.reactor.FluxK.functor().run {
+  this@widen.widen<B, A>() as arrow.fx.reactor.FluxK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.functor(): FluxKFunctor = functor_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/functorFilter/FluxKFunctorFilter.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/functorFilter/FluxKFunctorFilter.kt
@@ -1,0 +1,82 @@
+package arrow.fx.reactor.extensions.fluxk.functorFilter
+
+import arrow.Kind
+import arrow.core.Option
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKFunctorFilter
+import java.lang.Class
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functorFilter_singleton: FluxKFunctorFilter = object :
+    arrow.fx.reactor.extensions.FluxKFunctorFilter {}
+
+@JvmName("filterMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.filterMap(arg1: Function1<A, Option<B>>): FluxK<B> =
+    arrow.fx.reactor.FluxK.functorFilter().run {
+  this@filterMap.filterMap<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("flattenOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, Option<A>>.flattenOption(): FluxK<A> =
+    arrow.fx.reactor.FluxK.functorFilter().run {
+  this@flattenOption.flattenOption<A>() as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("filter")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.filter(arg1: Function1<A, Boolean>): FluxK<A> =
+    arrow.fx.reactor.FluxK.functorFilter().run {
+  this@filter.filter<A>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("filterIsInstance")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.filterIsInstance(arg1: Class<B>): FluxK<B> =
+    arrow.fx.reactor.FluxK.functorFilter().run {
+  this@filterIsInstance.filterIsInstance<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.functorFilter(): FluxKFunctorFilter = functorFilter_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monad/FluxKMonad.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monad/FluxKMonad.kt
@@ -1,0 +1,266 @@
+package arrow.fx.reactor.extensions.fluxk.monad
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.Tuple2
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKMonad
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monad_singleton: FluxKMonad = object : arrow.fx.reactor.extensions.FluxKMonad {}
+
+@JvmName("flatMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.flatMap(arg1: Function1<A, Kind<ForFluxK, B>>): FluxK<B> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@flatMap.flatMap<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("tailRecM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForFluxK, Either<A, B>>>): FluxK<B> =
+    arrow.fx.reactor.FluxK
+   .monad()
+   .tailRecM<A, B>(arg0, arg1) as arrow.fx.reactor.FluxK<B>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.map(arg1: Function1<A, B>): FluxK<B> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@map.map<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.ap(arg1: Kind<ForFluxK, Function1<A, B>>): FluxK<B> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@ap.ap<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("flatten")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, Kind<ForFluxK, A>>.flatten(): FluxK<A> = arrow.fx.reactor.FluxK.monad().run {
+  this@flatten.flatten<A>() as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.followedBy(arg1: Kind<ForFluxK, B>): FluxK<B> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.apTap(arg1: Kind<ForFluxK, B>): FluxK<A> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@apTap.apTap<A, B>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("followedByEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.followedByEval(arg1: Eval<Kind<ForFluxK, B>>): FluxK<B> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@followedByEval.followedByEval<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("effectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.effectM(arg1: Function1<A, Kind<ForFluxK, B>>): FluxK<A> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@effectM.effectM<A, B>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("flatTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.flatTap(arg1: Function1<A, Kind<ForFluxK, B>>): FluxK<A> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@flatTap.flatTap<A, B>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("productL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.productL(arg1: Kind<ForFluxK, B>): FluxK<A> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@productL.productL<A, B>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("forEffect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.forEffect(arg1: Kind<ForFluxK, B>): FluxK<A> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@forEffect.forEffect<A, B>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("productLEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.productLEval(arg1: Eval<Kind<ForFluxK, B>>): FluxK<A> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@productLEval.productLEval<A, B>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("forEffectEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.forEffectEval(arg1: Eval<Kind<ForFluxK, B>>): FluxK<A> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@forEffectEval.forEffectEval<A, B>(arg1) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("mproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.mproduct(arg1: Function1<A, Kind<ForFluxK, B>>): FluxK<Tuple2<A, B>> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@mproduct.mproduct<A, B>(arg1) as arrow.fx.reactor.FluxK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("ifM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <B> Kind<ForFluxK, Boolean>.ifM(
+  arg1: Function0<Kind<ForFluxK, B>>,
+  arg2: Function0<Kind<ForFluxK, B>>
+): FluxK<B> = arrow.fx.reactor.FluxK.monad().run {
+  this@ifM.ifM<B>(arg1, arg2) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("selectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, Either<A, B>>.selectM(arg1: Kind<ForFluxK, Function1<A, B>>): FluxK<B> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@selectM.selectM<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, Either<A, B>>.select(arg1: Kind<ForFluxK, Function1<A, B>>): FluxK<B> =
+    arrow.fx.reactor.FluxK.monad().run {
+  this@select.select<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.monad(): FluxKMonad = monad_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monadDefer/FluxKMonadDefer.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monadDefer/FluxKMonadDefer.kt
@@ -1,0 +1,103 @@
+package arrow.fx.reactor.extensions.fluxk.monadDefer
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.Ref
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKMonadDefer
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadDefer_singleton: FluxKMonadDefer = object :
+    arrow.fx.reactor.extensions.FluxKMonadDefer {}
+
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> defer(arg0: Function0<Kind<ForFluxK, A>>): FluxK<A> = arrow.fx.reactor.FluxK
+   .monadDefer()
+   .defer<A>(arg0) as arrow.fx.reactor.FluxK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> later(arg0: Function0<A>): FluxK<A> = arrow.fx.reactor.FluxK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.reactor.FluxK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> later(arg0: Kind<ForFluxK, A>): FluxK<A> = arrow.fx.reactor.FluxK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.reactor.FluxK<A>
+
+@JvmName("lazy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun lazy(): FluxK<Unit> = arrow.fx.reactor.FluxK
+   .monadDefer()
+   .lazy() as arrow.fx.reactor.FluxK<kotlin.Unit>
+
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> laterOrRaise(arg0: Function0<Either<Throwable, A>>): FluxK<A> = arrow.fx.reactor.FluxK
+   .monadDefer()
+   .laterOrRaise<A>(arg0) as arrow.fx.reactor.FluxK<A>
+
+@JvmName("Ref")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Ref(arg0: A): FluxK<Ref<ForFluxK, A>> = arrow.fx.reactor.FluxK
+   .monadDefer()
+   .Ref<A>(arg0) as arrow.fx.reactor.FluxK<arrow.fx.Ref<arrow.fx.reactor.ForFluxK, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.monadDefer(): FluxKMonadDefer = monadDefer_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monadError/FluxKMonadError.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monadError/FluxKMonadError.kt
@@ -1,0 +1,72 @@
+package arrow.fx.reactor.extensions.fluxk.monadError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKMonadError
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadError_singleton: FluxKMonadError = object :
+    arrow.fx.reactor.extensions.FluxKMonadError {}
+
+@JvmName("ensure")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, A>.ensure(arg1: Function0<Throwable>, arg2: Function1<A, Boolean>): FluxK<A> =
+    arrow.fx.reactor.FluxK.monadError().run {
+  this@ensure.ensure<A>(arg1, arg2) as arrow.fx.reactor.FluxK<A>
+}
+
+@JvmName("redeemWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.redeemWith(
+  arg1: Function1<Throwable, Kind<ForFluxK, B>>,
+  arg2: Function1<A, Kind<ForFluxK, B>>
+): FluxK<B> = arrow.fx.reactor.FluxK.monadError().run {
+  this@redeemWith.redeemWith<A, B>(arg1, arg2) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("rethrow")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForFluxK, Either<Throwable, A>>.rethrow(): FluxK<A> =
+    arrow.fx.reactor.FluxK.monadError().run {
+  this@rethrow.rethrow<A>() as arrow.fx.reactor.FluxK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.monadError(): FluxKMonadError = monadError_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monadFilter/FluxKMonadFilter.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monadFilter/FluxKMonadFilter.kt
@@ -1,0 +1,55 @@
+package arrow.fx.reactor.extensions.fluxk.monadFilter
+
+import arrow.Kind
+import arrow.core.Option
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKMonadFilter
+import arrow.typeclasses.MonadFilterSyntax
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadFilter_singleton: FluxKMonadFilter = object :
+    arrow.fx.reactor.extensions.FluxKMonadFilter {}
+
+@JvmName("filterMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.filterMap(arg1: Function1<A, Option<B>>): FluxK<B> =
+    arrow.fx.reactor.FluxK.monadFilter().run {
+  this@filterMap.filterMap<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("bindingFilter")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <B> bindingFilter(arg0: suspend MonadFilterSyntax<ForFluxK>.() -> B): FluxK<B> =
+    arrow.fx.reactor.FluxK
+   .monadFilter()
+   .bindingFilter<B>(arg0) as arrow.fx.reactor.FluxK<B>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.monadFilter(): FluxKMonadFilter = monadFilter_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monadThrow/FluxKMonadThrow.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/monadThrow/FluxKMonadThrow.kt
@@ -1,0 +1,37 @@
+package arrow.fx.reactor.extensions.fluxk.monadThrow
+
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.extensions.FluxKMonadThrow
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadThrow_singleton: FluxKMonadThrow = object :
+    arrow.fx.reactor.extensions.FluxKMonadThrow {}
+
+@JvmName("raiseNonFatal")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Throwable.raiseNonFatal(): FluxK<A> = arrow.fx.reactor.FluxK.monadThrow().run {
+  this@raiseNonFatal.raiseNonFatal<A>() as arrow.fx.reactor.FluxK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.monadThrow(): FluxKMonadThrow = monadThrow_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/timer/FluxKTimer.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/timer/FluxKTimer.kt
@@ -1,0 +1,20 @@
+package arrow.fx.reactor.extensions.fluxk.timer
+
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.extensions.FluxKTimer
+import kotlin.PublishedApi
+import kotlin.Suppress
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val timer_singleton: FluxKTimer = object : arrow.fx.reactor.extensions.FluxKTimer {}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.timer(): FluxKTimer = timer_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/traverse/FluxKTraverse.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/fluxk/traverse/FluxKTraverse.kt
@@ -1,0 +1,86 @@
+package arrow.fx.reactor.extensions.fluxk.traverse
+
+import arrow.Kind
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.FluxK
+import arrow.fx.reactor.FluxK.Companion
+import arrow.fx.reactor.ForFluxK
+import arrow.fx.reactor.extensions.FluxKTraverse
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val traverse_singleton: FluxKTraverse = object : arrow.fx.reactor.extensions.FluxKTraverse
+    {}
+
+@JvmName("traverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <G, A, B> Kind<ForFluxK, A>.traverse(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>):
+    Kind<G, Kind<ForFluxK, B>> = arrow.fx.reactor.FluxK.traverse().run {
+  this@traverse.traverse<G, A, B>(arg1, arg2) as arrow.Kind<G, arrow.Kind<arrow.fx.reactor.ForFluxK,
+    B>>
+}
+
+@JvmName("sequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <G, A> Kind<ForFluxK, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G, Kind<ForFluxK, A>> =
+    arrow.fx.reactor.FluxK.traverse().run {
+  this@sequence.sequence<G, A>(arg1) as arrow.Kind<G, arrow.Kind<arrow.fx.reactor.ForFluxK, A>>
+}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForFluxK, A>.map(arg1: Function1<A, B>): FluxK<B> =
+    arrow.fx.reactor.FluxK.traverse().run {
+  this@map.map<A, B>(arg1) as arrow.fx.reactor.FluxK<B>
+}
+
+@JvmName("flatTraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <G, A, B> Kind<ForFluxK, A>.flatTraverse(
+  arg1: Monad<ForFluxK>,
+  arg2: Applicative<G>,
+  arg3: Function1<A, Kind<G, Kind<ForFluxK, B>>>
+): Kind<G, Kind<ForFluxK, B>> = arrow.fx.reactor.FluxK.traverse().run {
+  this@flatTraverse.flatTraverse<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G,
+    arrow.Kind<arrow.fx.reactor.ForFluxK, B>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.traverse(): FluxKTraverse = traverse_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok.kt
@@ -3,8 +3,8 @@ package arrow.fx.reactor.extensions
 import arrow.Kind
 import arrow.core.Either
 import arrow.core.Eval
-import arrow.extension
 import arrow.fx.Timer
+import arrow.fx.reactor.DeprecateReactor
 import arrow.fx.reactor.ForMonoK
 import arrow.fx.reactor.MonoK
 import arrow.fx.reactor.MonoKOf
@@ -31,13 +31,13 @@ import reactor.core.publisher.Mono
 import kotlin.coroutines.CoroutineContext
 import arrow.fx.reactor.handleErrorWith as monoHandleErrorWith
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKFunctor : Functor<ForMonoK> {
   override fun <A, B> MonoKOf<A>.map(f: (A) -> B): MonoK<B> =
     fix().map(f)
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKApplicative : Applicative<ForMonoK>, MonoKFunctor {
   override fun <A, B> MonoKOf<A>.map(f: (A) -> B): MonoK<B> =
     fix().map(f)
@@ -52,7 +52,7 @@ interface MonoKApplicative : Applicative<ForMonoK>, MonoKFunctor {
     Eval.now(fix().ap(MonoK.defer { ff.value() }))
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKMonad : Monad<ForMonoK>, MonoKApplicative {
   override fun <A, B> MonoKOf<A>.map(f: (A) -> B): MonoK<B> =
     fix().map(f)
@@ -70,7 +70,7 @@ interface MonoKMonad : Monad<ForMonoK>, MonoKApplicative {
     Eval.now(fix().ap(MonoK.defer { ff.value() }))
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKApplicativeError : ApplicativeError<ForMonoK, Throwable>, MonoKApplicative {
   override fun <A> raiseError(e: Throwable): MonoK<A> =
     MonoK.raiseError(e)
@@ -79,7 +79,7 @@ interface MonoKApplicativeError : ApplicativeError<ForMonoK, Throwable>, MonoKAp
     fix().monoHandleErrorWith { f(it).fix() }
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKMonadError : MonadError<ForMonoK, Throwable>, MonoKMonad, MonoKApplicativeError {
   override fun <A, B> MonoKOf<A>.map(f: (A) -> B): MonoK<B> =
     fix().map(f)
@@ -91,22 +91,22 @@ interface MonoKMonadError : MonadError<ForMonoK, Throwable>, MonoKMonad, MonoKAp
     fix().monoHandleErrorWith { f(it).fix() }
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKMonadThrow : MonadThrow<ForMonoK>, MonoKMonadError
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKBracket : Bracket<ForMonoK, Throwable>, MonoKMonadThrow {
   override fun <A, B> MonoKOf<A>.bracketCase(release: (A, ExitCase<Throwable>) -> MonoKOf<Unit>, use: (A) -> MonoKOf<B>): MonoK<B> =
     fix().bracketCase({ use(it) }, { a, e -> release(a, e) })
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKMonadDefer : MonadDefer<ForMonoK>, MonoKBracket {
   override fun <A> defer(fa: () -> MonoKOf<A>): MonoK<A> =
     MonoK.defer(fa)
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKAsync : Async<ForMonoK>, MonoKMonadDefer {
   override fun <A> async(fa: Proc<A>): MonoK<A> =
     MonoK.async(fa)
@@ -118,19 +118,19 @@ interface MonoKAsync : Async<ForMonoK>, MonoKMonadDefer {
     fix().continueOn(ctx)
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKEffect : Effect<ForMonoK>, MonoKAsync {
   override fun <A> MonoKOf<A>.runAsync(cb: (Either<Throwable, A>) -> MonoKOf<Unit>): MonoK<Unit> =
     fix().runAsync(cb)
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKConcurrentEffect : ConcurrentEffect<ForMonoK>, MonoKEffect {
   override fun <A> MonoKOf<A>.runAsyncCancellable(cb: (Either<Throwable, A>) -> MonoKOf<Unit>): MonoK<Disposable> =
     fix().runAsyncCancellable(cb)
 }
 
-@extension
+@Deprecated(DeprecateReactor)
 interface MonoKTimer : Timer<ForMonoK> {
   override fun sleep(duration: Duration): MonoK<Unit> =
     MonoK(Mono.delay(java.time.Duration.ofNanos(duration.nanoseconds))
@@ -138,5 +138,6 @@ interface MonoKTimer : Timer<ForMonoK> {
 }
 
 // TODO FluxK does not yet have a Concurrent instance
+@Deprecated(DeprecateReactor)
 fun <A> MonoK.Companion.fx(c: suspend AsyncSyntax<ForMonoK>.() -> A): MonoK<A> =
   MonoK.async().fx.async(c).fix()

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/applicative/MonoKApplicative.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/applicative/MonoKApplicative.kt
@@ -1,0 +1,94 @@
+package arrow.fx.reactor.extensions.monok.applicative
+
+import arrow.Kind
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKApplicative
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicative_singleton: MonoKApplicative = object :
+    arrow.fx.reactor.extensions.MonoKApplicative {}
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> A.just(): MonoK<A> = arrow.fx.reactor.MonoK.applicative().run {
+  this@just.just<A>() as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun unit(): MonoK<Unit> = arrow.fx.reactor.MonoK
+   .applicative()
+   .unit() as arrow.fx.reactor.MonoK<kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.map(arg1: Function1<A, B>): MonoK<B> =
+    arrow.fx.reactor.MonoK.applicative().run {
+  this@map.map<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.replicate(arg1: Int): MonoK<List<A>> =
+    arrow.fx.reactor.MonoK.applicative().run {
+  this@replicate.replicate<A>(arg1) as arrow.fx.reactor.MonoK<kotlin.collections.List<A>>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.replicate(arg1: Int, arg2: Monoid<A>): MonoK<A> =
+    arrow.fx.reactor.MonoK.applicative().run {
+  this@replicate.replicate<A>(arg1, arg2) as arrow.fx.reactor.MonoK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.applicative(): MonoKApplicative = applicative_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/applicativeError/MonoKApplicativeError.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/applicativeError/MonoKApplicativeError.kt
@@ -1,0 +1,174 @@
+package arrow.fx.reactor.extensions.monok.applicativeError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.ForOption
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKApplicativeError
+import arrow.typeclasses.ApplicativeError
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicativeError_singleton: MonoKApplicativeError = object :
+    arrow.fx.reactor.extensions.MonoKApplicativeError {}
+
+@JvmName("handleErrorWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.handleErrorWith(arg1: Function1<Throwable, Kind<ForMonoK, A>>): MonoK<A> =
+    arrow.fx.reactor.MonoK.applicativeError().run {
+  this@handleErrorWith.handleErrorWith<A>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("raiseError1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Throwable.raiseError(): MonoK<A> = arrow.fx.reactor.MonoK.applicativeError().run {
+  this@raiseError.raiseError<A>() as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("fromOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForOption, A>.fromOption(arg1: Function0<Throwable>): MonoK<A> =
+    arrow.fx.reactor.MonoK.applicativeError().run {
+  this@fromOption.fromOption<A>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("fromEither")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, Throwable>): MonoK<A> =
+    arrow.fx.reactor.MonoK.applicativeError().run {
+  this@fromEither.fromEither<A, EE>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("handleError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.handleError(arg1: Function1<Throwable, A>): MonoK<A> =
+    arrow.fx.reactor.MonoK.applicativeError().run {
+  this@handleError.handleError<A>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("redeem")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.redeem(arg1: Function1<Throwable, B>, arg2: Function1<A, B>): MonoK<B> =
+    arrow.fx.reactor.MonoK.applicativeError().run {
+  this@redeem.redeem<A, B>(arg1, arg2) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("attempt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.attempt(): MonoK<Either<Throwable, A>> =
+    arrow.fx.reactor.MonoK.applicativeError().run {
+  this@attempt.attempt<A>() as arrow.fx.reactor.MonoK<arrow.core.Either<kotlin.Throwable, A>>
+}
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> catch(arg0: Function1<Throwable, Throwable>, arg1: Function0<A>): MonoK<A> =
+    arrow.fx.reactor.MonoK
+   .applicativeError()
+   .catch<A>(arg0, arg1) as arrow.fx.reactor.MonoK<A>
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> ApplicativeError<ForMonoK, Throwable>.catch(arg1: Function0<A>): MonoK<A> =
+    arrow.fx.reactor.MonoK.applicativeError().run {
+  this@catch.catch<A>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+suspend fun <A> effectCatch(arg0: Function1<Throwable, Throwable>, arg1: suspend () -> A): MonoK<A> =
+    arrow.fx.reactor.MonoK
+   .applicativeError()
+   .effectCatch<A>(arg0, arg1) as arrow.fx.reactor.MonoK<A>
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+suspend fun <F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend () -> A): Kind<F, A> =
+    arrow.fx.reactor.MonoK.applicativeError().run {
+  this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.applicativeError(): MonoKApplicativeError = applicativeError_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/async/MonoKAsync.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/async/MonoKAsync.kt
@@ -1,0 +1,393 @@
+package arrow.fx.reactor.extensions.monok.async
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKAsync
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val async_singleton: MonoKAsync = object : arrow.fx.reactor.extensions.MonoKAsync {}
+
+/**
+ *  [async] variant that can suspend side effects in the provided registration function.
+ *
+ *  The passed in function is injected with a side-effectful callback for signaling the final result of an asynchronous process.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.*
+ *  import arrow.fx.typeclasses.Async
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.makeCompleteAndGetPromiseInAsync() =
+ *     asyncF<String> { cb: (Either<Throwable, String>) -> Unit ->
+ *       Promise.uncancellable<F, String>(this).flatMap { promise ->
+ *         promise.complete("Hello World!").flatMap {
+ *           promise.get().map { str -> cb(Right(str)) }
+ *         }
+ *       }
+ *     }
+ *
+ *   val result = MonoK.async().makeCompleteAndGetPromiseInAsync()
+ *  //sampleEnd
+ *  println(result)
+ *  }
+ *  ```
+ *
+ *  @see async for a simpler, non suspending version.
+ */
+@JvmName("asyncF")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> asyncF(arg0: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForMonoK, Unit>>):
+    MonoK<A> = arrow.fx.reactor.MonoK
+   .async()
+   .asyncF<A>(arg0) as arrow.fx.reactor.MonoK<A>
+
+/**
+ *  Continue the evaluation on provided [CoroutineContext]
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.runOnDefaultDispatcher(): Kind<F, String> =
+ *     just(Unit).continueOn(Dispatchers.Default).flatMap {
+ *       later({ Thread.currentThread().name })
+ *     }
+ *
+ *   val result = MonoK.async().runOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("continueOn")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.continueOn(arg1: CoroutineContext): MonoK<A> =
+    arrow.fx.reactor.MonoK.async().run {
+  this@continueOn.continueOn<A>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     later(Dispatchers.Default, { Thread.currentThread().name })
+ *
+ *   val result = MonoK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> later(arg0: CoroutineContext, arg1: Function0<A>): MonoK<A> = arrow.fx.reactor.MonoK
+   .async()
+   .later<A>(arg0, arg1) as arrow.fx.reactor.MonoK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = MonoK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> effect(arg0: suspend () -> A): MonoK<A> = arrow.fx.reactor.MonoK
+   .async()
+   .effect<A>(arg0) as arrow.fx.reactor.MonoK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = MonoK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> effect(arg0: CoroutineContext, arg1: suspend () -> A): MonoK<A> = arrow.fx.reactor.MonoK
+   .async()
+   .effect<A>(arg0, arg1) as arrow.fx.reactor.MonoK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     defer(Dispatchers.Default, { effect { Thread.currentThread().name } })
+ *
+ *   val result = MonoK.async().invokeOnDefaultDispatcher().fix().unsafeRunSync()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> defer(arg0: CoroutineContext, arg1: Function0<Kind<ForMonoK, A>>): MonoK<A> =
+    arrow.fx.reactor.MonoK
+   .async()
+   .defer<A>(arg0, arg1) as arrow.fx.reactor.MonoK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ */
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> laterOrRaise(arg0: CoroutineContext, arg1: Function0<Either<Throwable, A>>): MonoK<A> =
+    arrow.fx.reactor.MonoK
+   .async()
+   .laterOrRaise<A>(arg0, arg1) as arrow.fx.reactor.MonoK<A>
+
+/**
+ *  Shift evaluation to provided [CoroutineContext].
+ *
+ *  @receiver [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   MonoK.async().run {
+ *     val result = Dispatchers.Default.shift().map {
+ *       Thread.currentThread().name
+ *     }
+ *
+ *     println(result)
+ *   }
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("shift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun CoroutineContext.shift(): MonoK<Unit> = arrow.fx.reactor.MonoK.async().run {
+  this@shift.shift() as arrow.fx.reactor.MonoK<kotlin.Unit>
+}
+
+/**
+ *  Task that never finishes evaluating.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.async.*
+ * import arrow.core.*
+ *
+ *
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val i = MonoK.async().never<Int>()
+ *
+ *   println(i)
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("never")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> never(): MonoK<A> = arrow.fx.reactor.MonoK
+   .async()
+   .never<A>() as arrow.fx.reactor.MonoK<A>
+
+/**
+ *  Helper function that provides an easy way to construct a suspend effect
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun logAndIncrease(s: String): Int {
+ *      println(s)
+ *      return s.toInt() + 1
+ *   }
+ *
+ *   val result = MonoK.async().effect(Dispatchers.Default) { Thread.currentThread().name }.effectMap { s: String -> logAndIncrease(s) }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effectMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.effectMap(arg1: suspend (A) -> B): MonoK<B> =
+    arrow.fx.reactor.MonoK.async().run {
+  this@effectMap.effectMap<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+/**
+ *  [Async] models how a data type runs an asynchronous computation that may fail.
+ *  Defined by the [Proc] signature, which is the consumption of a callback.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.async(): MonoKAsync = async_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/bracket/MonoKBracket.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/bracket/MonoKBracket.kt
@@ -1,0 +1,262 @@
+package arrow.fx.reactor.extensions.monok.bracket
+
+import arrow.Kind
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKBracket
+import arrow.fx.typeclasses.ExitCase
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bracket_singleton: MonoKBracket = object : arrow.fx.reactor.extensions.MonoKBracket {}
+
+/**
+ *  A way to safely acquire a resource and release in the face of errors and cancellation.
+ *  It uses [ExitCase] to distinguish between different exit cases when releasing the acquired resource.
+ *
+ *  @param use is the action to consume the resource and produce an [F] with the result.
+ *  Once the resulting [F] terminates, either successfully, error or cancelled.
+ *
+ *  @param release the allocated resource after the resulting [F] of [use] is terminates.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.reactor.extensions.monok.monadDefer.defer
+ * import arrow.fx.reactor.extensions.monok.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val release: (File, ExitCase<Throwable>) -> Kind<F, Unit> = { file, exitCase ->
+ *       when (exitCase) {
+ * do something * / }
+ * do something * / }
+ * do something * / }
+ *       }
+ *       closeFile(file)
+ *   }
+ *
+ *   val use: (File) -> Kind<F, String> = { file: File -> fileToString(file) }
+ *
+ *   val safeComputation = openFile("data.json").bracketCase(release, use)
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracketCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.bracketCase(
+  arg1: Function2<A, ExitCase<Throwable>, Kind<ForMonoK,
+    Unit>>,
+  arg2: Function1<A, Kind<ForMonoK, B>>
+): MonoK<B> =
+  arrow.fx.reactor.MonoK.bracket().run {
+    this@bracketCase.bracketCase<A, B>(arg1, arg2) as arrow.fx.reactor.MonoK<B>
+  }
+
+/**
+ *  Meant for specifying tasks with safe resource acquisition and release in the face of errors and interruption.
+ *  It would be the the equivalent of `try/catch/finally` statements in mainstream imperative languages for resource
+ *  acquisition and release.
+ *
+ *  @param release is the action that's supposed to release the allocated resource after `use` is done, irregardless
+ *  of its exit condition.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.reactor.*
+ * import arrow.fx.reactor.extensions.monok.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.reactor.extensions.monok.monadDefer.defer
+ * import arrow.fx.reactor.extensions.monok.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val safeComputation = openFile("data.json").bracket({ file: File -> closeFile(file) }, { file -> fileToString(file) })
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracket")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.bracket(
+  arg1: Function1<A, Kind<ForMonoK, Unit>>,
+  arg2: Function1<A,
+    Kind<ForMonoK, B>>
+): MonoK<B> = arrow.fx.reactor.MonoK.bracket().run {
+  this@bracket.bracket<A, B>(arg1, arg2) as arrow.fx.reactor.MonoK<B>
+}
+
+/**
+ *  Meant for ensuring a given task continues execution even when interrupted.
+ */
+@JvmName("uncancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.uncancellable(): MonoK<A> = arrow.fx.reactor.MonoK.bracket().run {
+  this@uncancellable.uncancellable<A>() as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("uncancelable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.uncancelable(): MonoK<A> = arrow.fx.reactor.MonoK.bracket().run {
+  this@uncancelable.uncancelable<A>() as arrow.fx.reactor.MonoK<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracket] for the acquisition and release of resources.
+ *
+ *  @see [guaranteeCase] for the version that can discriminate between termination conditions
+ *
+ *  @see [bracket] for the more general operation
+ */
+@JvmName("guarantee")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.guarantee(arg1: Kind<ForMonoK, Unit>): MonoK<A> =
+  arrow.fx.reactor.MonoK.bracket().run {
+    this@guarantee.guarantee<A>(arg1) as arrow.fx.reactor.MonoK<A>
+  }
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled, allowing
+ *  for differentiating between exit conditions. That's thanks to the [ExitCase] argument of the finalizer.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracketCase] for the acquisition and release of resources.
+ *
+ *  @see [guarantee] for the simpler version
+ *
+ *  @see [bracketCase] for the more general operation
+ */
+@JvmName("guaranteeCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.guaranteeCase(arg1: Function1<ExitCase<Throwable>, Kind<ForMonoK, Unit>>):
+  MonoK<A> = arrow.fx.reactor.MonoK.bracket().run {
+  this@guaranteeCase.guaranteeCase<A>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+/**
+ *  Executes the given [finalizer] when the source is cancelled, allowing registering a cancellation token.
+ *
+ *  Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
+ */
+@JvmName("onCancel")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.onCancel(arg1: Kind<ForMonoK, Unit>): MonoK<A> =
+  arrow.fx.reactor.MonoK.bracket().run {
+    this@onCancel.onCancel<A>(arg1) as arrow.fx.reactor.MonoK<A>
+  }
+
+/**
+ *  Executes the given `finalizer` with the given error when the source is finished in error.
+ */
+@JvmName("onError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.onError(arg1: Function1<Throwable, Kind<ForMonoK, Unit>>): MonoK<A> =
+  arrow.fx.reactor.MonoK.bracket().run {
+    this@onError.onError<A>(arg1) as arrow.fx.reactor.MonoK<A>
+  }
+
+/**
+ *  Extension of MonadError exposing the [bracket] operation, a generalized abstracted pattern of safe resource
+ *  acquisition and release in the face of errors or interruption.
+ *
+ *  @define The functions receiver here (Kind<F, A>) would stand for the "acquireParam", and stands for an action that
+ *  "acquires" some expensive resource, that needs to be used and then discarded.
+ *
+ *  @define use is the action that uses the newly allocated resource and that will provide the final result.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.bracket(): MonoKBracket = bracket_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/concurrentEffect/MonoKConcurrentEffect.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/concurrentEffect/MonoKConcurrentEffect.kt
@@ -1,0 +1,47 @@
+package arrow.fx.reactor.extensions.monok.concurrentEffect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKConcurrentEffect
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val concurrentEffect_singleton: MonoKConcurrentEffect = object :
+    arrow.fx.reactor.extensions.MonoKConcurrentEffect {}
+
+@JvmName("runAsyncCancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.runAsyncCancellable(
+  arg1: Function1<Either<Throwable, A>, Kind<ForMonoK,
+Unit>>
+): MonoK<Function0<Unit>> = arrow.fx.reactor.MonoK.concurrentEffect().run {
+  this@runAsyncCancellable.runAsyncCancellable<A>(arg1) as
+    arrow.fx.reactor.MonoK<kotlin.Function0<kotlin.Unit>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.concurrentEffect(): MonoKConcurrentEffect = concurrentEffect_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/effect/MonoKEffect.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/effect/MonoKEffect.kt
@@ -1,0 +1,42 @@
+package arrow.fx.reactor.extensions.monok.effect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKEffect
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val effect_singleton: MonoKEffect = object : arrow.fx.reactor.extensions.MonoKEffect {}
+
+@JvmName("runAsync")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.runAsync(arg1: Function1<Either<Throwable, A>, Kind<ForMonoK, Unit>>):
+    MonoK<Unit> = arrow.fx.reactor.MonoK.effect().run {
+  this@runAsync.runAsync<A>(arg1) as arrow.fx.reactor.MonoK<kotlin.Unit>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.effect(): MonoKEffect = effect_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/functor/MonoKFunctor.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/functor/MonoKFunctor.kt
@@ -1,0 +1,155 @@
+package arrow.fx.reactor.extensions.monok.functor
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKFunctor
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: MonoKFunctor = object : arrow.fx.reactor.extensions.MonoKFunctor {}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.map(arg1: Function1<A, B>): MonoK<B> =
+    arrow.fx.reactor.MonoK.functor().run {
+  this@map.map<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): MonoK<B> =
+    arrow.fx.reactor.MonoK.functor().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForMonoK, A>, Kind<ForMonoK, B>> =
+    arrow.fx.reactor.MonoK
+   .functor()
+   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.fx.reactor.ForMonoK, A>,
+    arrow.Kind<arrow.fx.reactor.ForMonoK, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.void(): MonoK<Unit> = arrow.fx.reactor.MonoK.functor().run {
+  this@void.void<A>() as arrow.fx.reactor.MonoK<kotlin.Unit>
+}
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.fproduct(arg1: Function1<A, B>): MonoK<Tuple2<A, B>> =
+    arrow.fx.reactor.MonoK.functor().run {
+  this@fproduct.fproduct<A, B>(arg1) as arrow.fx.reactor.MonoK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.mapConst(arg1: B): MonoK<B> = arrow.fx.reactor.MonoK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> A.mapConst(arg1: Kind<ForMonoK, B>): MonoK<A> = arrow.fx.reactor.MonoK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.tupleLeft(arg1: B): MonoK<Tuple2<B, A>> =
+    arrow.fx.reactor.MonoK.functor().run {
+  this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.fx.reactor.MonoK<arrow.core.Tuple2<B, A>>
+}
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.tupleRight(arg1: B): MonoK<Tuple2<A, B>> =
+    arrow.fx.reactor.MonoK.functor().run {
+  this@tupleRight.tupleRight<A, B>(arg1) as arrow.fx.reactor.MonoK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <B, A : B> Kind<ForMonoK, A>.widen(): MonoK<B> = arrow.fx.reactor.MonoK.functor().run {
+  this@widen.widen<B, A>() as arrow.fx.reactor.MonoK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.functor(): MonoKFunctor = functor_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/monad/MonoKMonad.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/monad/MonoKMonad.kt
@@ -1,0 +1,266 @@
+package arrow.fx.reactor.extensions.monok.monad
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.Tuple2
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKMonad
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monad_singleton: MonoKMonad = object : arrow.fx.reactor.extensions.MonoKMonad {}
+
+@JvmName("flatMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.flatMap(arg1: Function1<A, Kind<ForMonoK, B>>): MonoK<B> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@flatMap.flatMap<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("tailRecM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForMonoK, Either<A, B>>>): MonoK<B> =
+    arrow.fx.reactor.MonoK
+   .monad()
+   .tailRecM<A, B>(arg0, arg1) as arrow.fx.reactor.MonoK<B>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.map(arg1: Function1<A, B>): MonoK<B> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@map.map<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.ap(arg1: Kind<ForMonoK, Function1<A, B>>): MonoK<B> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@ap.ap<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("flatten")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, Kind<ForMonoK, A>>.flatten(): MonoK<A> = arrow.fx.reactor.MonoK.monad().run {
+  this@flatten.flatten<A>() as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.followedBy(arg1: Kind<ForMonoK, B>): MonoK<B> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.apTap(arg1: Kind<ForMonoK, B>): MonoK<A> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@apTap.apTap<A, B>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("followedByEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.followedByEval(arg1: Eval<Kind<ForMonoK, B>>): MonoK<B> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@followedByEval.followedByEval<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("effectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.effectM(arg1: Function1<A, Kind<ForMonoK, B>>): MonoK<A> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@effectM.effectM<A, B>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("flatTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.flatTap(arg1: Function1<A, Kind<ForMonoK, B>>): MonoK<A> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@flatTap.flatTap<A, B>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("productL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.productL(arg1: Kind<ForMonoK, B>): MonoK<A> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@productL.productL<A, B>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("forEffect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.forEffect(arg1: Kind<ForMonoK, B>): MonoK<A> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@forEffect.forEffect<A, B>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("productLEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.productLEval(arg1: Eval<Kind<ForMonoK, B>>): MonoK<A> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@productLEval.productLEval<A, B>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("forEffectEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.forEffectEval(arg1: Eval<Kind<ForMonoK, B>>): MonoK<A> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@forEffectEval.forEffectEval<A, B>(arg1) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("mproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.mproduct(arg1: Function1<A, Kind<ForMonoK, B>>): MonoK<Tuple2<A, B>> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@mproduct.mproduct<A, B>(arg1) as arrow.fx.reactor.MonoK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("ifM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <B> Kind<ForMonoK, Boolean>.ifM(
+  arg1: Function0<Kind<ForMonoK, B>>,
+  arg2: Function0<Kind<ForMonoK, B>>
+): MonoK<B> = arrow.fx.reactor.MonoK.monad().run {
+  this@ifM.ifM<B>(arg1, arg2) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("selectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, Either<A, B>>.selectM(arg1: Kind<ForMonoK, Function1<A, B>>): MonoK<B> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@selectM.selectM<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, Either<A, B>>.select(arg1: Kind<ForMonoK, Function1<A, B>>): MonoK<B> =
+    arrow.fx.reactor.MonoK.monad().run {
+  this@select.select<A, B>(arg1) as arrow.fx.reactor.MonoK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.monad(): MonoKMonad = monad_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/monadDefer/MonoKMonadDefer.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/monadDefer/MonoKMonadDefer.kt
@@ -1,0 +1,103 @@
+package arrow.fx.reactor.extensions.monok.monadDefer
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.Ref
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKMonadDefer
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadDefer_singleton: MonoKMonadDefer = object :
+    arrow.fx.reactor.extensions.MonoKMonadDefer {}
+
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> defer(arg0: Function0<Kind<ForMonoK, A>>): MonoK<A> = arrow.fx.reactor.MonoK
+   .monadDefer()
+   .defer<A>(arg0) as arrow.fx.reactor.MonoK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> later(arg0: Function0<A>): MonoK<A> = arrow.fx.reactor.MonoK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.reactor.MonoK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> later(arg0: Kind<ForMonoK, A>): MonoK<A> = arrow.fx.reactor.MonoK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.reactor.MonoK<A>
+
+@JvmName("lazy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun lazy(): MonoK<Unit> = arrow.fx.reactor.MonoK
+   .monadDefer()
+   .lazy() as arrow.fx.reactor.MonoK<kotlin.Unit>
+
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> laterOrRaise(arg0: Function0<Either<Throwable, A>>): MonoK<A> = arrow.fx.reactor.MonoK
+   .monadDefer()
+   .laterOrRaise<A>(arg0) as arrow.fx.reactor.MonoK<A>
+
+@JvmName("Ref")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Ref(arg0: A): MonoK<Ref<ForMonoK, A>> = arrow.fx.reactor.MonoK
+   .monadDefer()
+   .Ref<A>(arg0) as arrow.fx.reactor.MonoK<arrow.fx.Ref<arrow.fx.reactor.ForMonoK, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.monadDefer(): MonoKMonadDefer = monadDefer_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/monadError/MonoKMonadError.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/monadError/MonoKMonadError.kt
@@ -1,0 +1,72 @@
+package arrow.fx.reactor.extensions.monok.monadError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.ForMonoK
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKMonadError
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadError_singleton: MonoKMonadError = object :
+    arrow.fx.reactor.extensions.MonoKMonadError {}
+
+@JvmName("ensure")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, A>.ensure(arg1: Function0<Throwable>, arg2: Function1<A, Boolean>): MonoK<A> =
+    arrow.fx.reactor.MonoK.monadError().run {
+  this@ensure.ensure<A>(arg1, arg2) as arrow.fx.reactor.MonoK<A>
+}
+
+@JvmName("redeemWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A, B> Kind<ForMonoK, A>.redeemWith(
+  arg1: Function1<Throwable, Kind<ForMonoK, B>>,
+  arg2: Function1<A, Kind<ForMonoK, B>>
+): MonoK<B> = arrow.fx.reactor.MonoK.monadError().run {
+  this@redeemWith.redeemWith<A, B>(arg1, arg2) as arrow.fx.reactor.MonoK<B>
+}
+
+@JvmName("rethrow")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Kind<ForMonoK, Either<Throwable, A>>.rethrow(): MonoK<A> =
+    arrow.fx.reactor.MonoK.monadError().run {
+  this@rethrow.rethrow<A>() as arrow.fx.reactor.MonoK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.monadError(): MonoKMonadError = monadError_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/monadThrow/MonoKMonadThrow.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/monadThrow/MonoKMonadThrow.kt
@@ -1,0 +1,37 @@
+package arrow.fx.reactor.extensions.monok.monadThrow
+
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.MonoK
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKMonadThrow
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadThrow_singleton: MonoKMonadThrow = object :
+    arrow.fx.reactor.extensions.MonoKMonadThrow {}
+
+@JvmName("raiseNonFatal")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateReactor)
+fun <A> Throwable.raiseNonFatal(): MonoK<A> = arrow.fx.reactor.MonoK.monadThrow().run {
+  this@raiseNonFatal.raiseNonFatal<A>() as arrow.fx.reactor.MonoK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.monadThrow(): MonoKMonadThrow = monadThrow_singleton

--- a/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/timer/MonoKTimer.kt
+++ b/arrow-fx-reactor/src/main/kotlin/arrow/fx/reactor/extensions/monok/timer/MonoKTimer.kt
@@ -1,0 +1,20 @@
+package arrow.fx.reactor.extensions.monok.timer
+
+import arrow.fx.reactor.DeprecateReactor
+import arrow.fx.reactor.MonoK.Companion
+import arrow.fx.reactor.extensions.MonoKTimer
+import kotlin.PublishedApi
+import kotlin.Suppress
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val timer_singleton: MonoKTimer = object : arrow.fx.reactor.extensions.MonoKTimer {}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateReactor)
+inline fun Companion.timer(): MonoKTimer = timer_singleton


### PR DESCRIPTION
## Status
READY

## Description
This PR removes all `@extension` from the Arrow Fx Reactor module, and deprecates all public code.

## Related PRs
* https://github.com/arrow-kt/arrow-fx/pull/383 (Didn't deprecate generated code)
