### PR TITLE
Deprecate all public functions, data types and generated code for Arr…

### DIFF
--- a/arrow-fx-rx2/build.gradle
+++ b/arrow-fx-rx2/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "org.jetbrains.kotlin.jvm"
-    id "org.jetbrains.kotlin.kapt"
     id "org.jlleitschuh.gradle.ktlint"
 }
 
@@ -10,8 +9,6 @@ apply from: "$DOC_CREATION"
 dependencies {
     compile project(":arrow-fx")
     compile "io.arrow-kt:arrow-annotations:$VERSION_NAME"
-    kapt "io.arrow-kt:arrow-meta:$VERSION_NAME"
-    kaptTest "io.arrow-kt:arrow-meta:$VERSION_NAME"
     testRuntime "org.junit.vintage:junit-vintage-engine:$JUNIT_VINTAGE_VERSION"
     testCompile "io.kotlintest:kotlintest-runner-junit5:$KOTLIN_TEST_VERSION", excludeArrow
     testCompile project(":arrow-fx-test")

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
@@ -147,7 +147,6 @@ interface FlowableKMonadError :
 @Deprecated(DeprecateRxJava)
 interface FlowableKMonadThrow : MonadThrow<ForFlowableK>, FlowableKMonadError
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKBracket : Bracket<ForFlowableK, Throwable>, FlowableKMonadThrow {
   override fun <A, B> FlowableKOf<A>.bracketCase(release: (A, ExitCase<Throwable>) -> FlowableKOf<Unit>, use: (A) -> FlowableKOf<B>): FlowableK<B> =

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
@@ -59,14 +59,12 @@ import io.reactivex.subjects.ReplaySubject
 import io.reactivex.disposables.Disposable as RxDisposable
 import arrow.fx.rx2.handleErrorWith as flowableHandleErrorWith
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKFunctor : Functor<ForFlowableK> {
   override fun <A, B> FlowableKOf<A>.map(f: (A) -> B): FlowableK<B> =
     fix().map(f)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKApplicative : Applicative<ForFlowableK> {
   override fun <A, B> FlowableKOf<A>.ap(ff: FlowableKOf<(A) -> B>): FlowableK<B> =
@@ -82,7 +80,6 @@ interface FlowableKApplicative : Applicative<ForFlowableK> {
     Eval.now(fix().ap(FlowableK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKMonad : Monad<ForFlowableK>, FlowableKApplicative {
   override fun <A, B> FlowableKOf<A>.ap(ff: FlowableKOf<(A) -> B>): FlowableK<B> =
@@ -101,7 +98,6 @@ interface FlowableKMonad : Monad<ForFlowableK>, FlowableKApplicative {
     Eval.now(fix().ap(FlowableK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKFoldable : Foldable<ForFlowableK> {
   override fun <A, B> FlowableKOf<A>.foldLeft(b: B, f: (B, A) -> B): B =
@@ -111,7 +107,6 @@ interface FlowableKFoldable : Foldable<ForFlowableK> {
     fix().foldRight(lb, f)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKTraverse : Traverse<ForFlowableK> {
   override fun <A, B> FlowableKOf<A>.map(f: (A) -> B): FlowableK<B> =
@@ -127,7 +122,6 @@ interface FlowableKTraverse : Traverse<ForFlowableK> {
     fix().foldRight(lb, f)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKApplicativeError :
   ApplicativeError<ForFlowableK, Throwable>,
@@ -139,7 +133,6 @@ interface FlowableKApplicativeError :
     fix().flowableHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKMonadError :
   MonadError<ForFlowableK, Throwable>,
@@ -151,7 +144,6 @@ interface FlowableKMonadError :
     fix().flowableHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKMonadThrow : MonadThrow<ForFlowableK>, FlowableKMonadError
 
@@ -162,7 +154,6 @@ interface FlowableKBracket : Bracket<ForFlowableK, Throwable>, FlowableKMonadThr
     fix().bracketCase({ use(it) }, { a, e -> release(a, e) })
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKMonadDefer : MonadDefer<ForFlowableK>, FlowableKBracket {
   override fun <A> defer(fa: () -> FlowableKOf<A>): FlowableK<A> =
@@ -171,7 +162,6 @@ interface FlowableKMonadDefer : MonadDefer<ForFlowableK>, FlowableKBracket {
   fun BS(): BackpressureStrategy = BackpressureStrategy.BUFFER
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKAsync :
   Async<ForFlowableK>,
@@ -186,7 +176,6 @@ interface FlowableKAsync :
     fix().continueOn(ctx)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKEffect :
   Effect<ForFlowableK>,
@@ -273,7 +262,6 @@ fun FlowableK.Companion.concurrent(dispatchers: Dispatchers<ForFlowableK> = Flow
   override fun dispatchers(): Dispatchers<ForFlowableK> = dispatchers
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKDispatchers : Dispatchers<ForFlowableK> {
   override fun default(): CoroutineContext =
@@ -283,7 +271,6 @@ interface FlowableKDispatchers : Dispatchers<ForFlowableK> {
     IOScheduler
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKConcurrentEffect : ConcurrentEffect<ForFlowableK>, FlowableKEffect {
   override fun <A> FlowableKOf<A>.runAsyncCancellable(cb: (Either<Throwable, A>) -> FlowableKOf<Unit>): FlowableK<Disposable> =
@@ -389,7 +376,6 @@ fun FlowableK.Companion.effectMissing(): FlowableKEffect = object : FlowableKEff
   override fun BS(): BackpressureStrategy = BackpressureStrategy.MISSING
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKTimer : Timer<ForFlowableK> {
   override fun sleep(duration: Duration): FlowableK<Unit> =
@@ -397,14 +383,12 @@ interface FlowableKTimer : Timer<ForFlowableK> {
       .map { Unit })
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKFunctorFilter : FunctorFilter<ForFlowableK>, FlowableKFunctor {
   override fun <A, B> Kind<ForFlowableK, A>.filterMap(f: (A) -> Option<B>): FlowableK<B> =
     fix().filterMap(f)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface FlowableKMonadFilter : MonadFilter<ForFlowableK>, FlowableKMonad {
   override fun <A> empty(): FlowableK<A> =

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek.kt
@@ -31,7 +31,6 @@ import arrow.fx.typeclasses.ProcF
 import arrow.fx.Timer
 import arrow.fx.typeclasses.Concurrent
 import arrow.fx.typeclasses.Fiber
-import arrow.extension
 import arrow.fx.rx2.DeprecateRxJava
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.ApplicativeError

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/applicative/FlowableKApplicative.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/applicative/FlowableKApplicative.kt
@@ -1,0 +1,94 @@
+package arrow.fx.rx2.extensions.flowablek.applicative
+
+import arrow.Kind
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKApplicative
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicative_singleton: FlowableKApplicative = object :
+    arrow.fx.rx2.extensions.FlowableKApplicative {}
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> A.just(): FlowableK<A> = arrow.fx.rx2.FlowableK.applicative().run {
+  this@just.just<A>() as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun unit(): FlowableK<Unit> = arrow.fx.rx2.FlowableK
+   .applicative()
+   .unit() as arrow.fx.rx2.FlowableK<kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.map(arg1: Function1<A, B>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.applicative().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.replicate(arg1: Int): FlowableK<List<A>> =
+    arrow.fx.rx2.FlowableK.applicative().run {
+  this@replicate.replicate<A>(arg1) as arrow.fx.rx2.FlowableK<kotlin.collections.List<A>>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.replicate(arg1: Int, arg2: Monoid<A>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.applicative().run {
+  this@replicate.replicate<A>(arg1, arg2) as arrow.fx.rx2.FlowableK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.applicative(): FlowableKApplicative = applicative_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/applicativeError/FlowableKApplicativeError.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/applicativeError/FlowableKApplicativeError.kt
@@ -1,0 +1,174 @@
+package arrow.fx.rx2.extensions.flowablek.applicativeError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.ForOption
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKApplicativeError
+import arrow.typeclasses.ApplicativeError
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicativeError_singleton: FlowableKApplicativeError = object :
+    arrow.fx.rx2.extensions.FlowableKApplicativeError {}
+
+@JvmName("handleErrorWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.handleErrorWith(arg1: Function1<Throwable, Kind<ForFlowableK, A>>):
+    FlowableK<A> = arrow.fx.rx2.FlowableK.applicativeError().run {
+  this@handleErrorWith.handleErrorWith<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("raiseError1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Throwable.raiseError(): FlowableK<A> = arrow.fx.rx2.FlowableK.applicativeError().run {
+  this@raiseError.raiseError<A>() as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("fromOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForOption, A>.fromOption(arg1: Function0<Throwable>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.applicativeError().run {
+  this@fromOption.fromOption<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("fromEither")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, Throwable>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.applicativeError().run {
+  this@fromEither.fromEither<A, EE>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("handleError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.handleError(arg1: Function1<Throwable, A>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.applicativeError().run {
+  this@handleError.handleError<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("redeem")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.redeem(arg1: Function1<Throwable, B>, arg2: Function1<A, B>):
+    FlowableK<B> = arrow.fx.rx2.FlowableK.applicativeError().run {
+  this@redeem.redeem<A, B>(arg1, arg2) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("attempt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.attempt(): FlowableK<Either<Throwable, A>> =
+    arrow.fx.rx2.FlowableK.applicativeError().run {
+  this@attempt.attempt<A>() as arrow.fx.rx2.FlowableK<arrow.core.Either<kotlin.Throwable, A>>
+}
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> catch(arg0: Function1<Throwable, Throwable>, arg1: Function0<A>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK
+   .applicativeError()
+   .catch<A>(arg0, arg1) as arrow.fx.rx2.FlowableK<A>
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> ApplicativeError<ForFlowableK, Throwable>.catch(arg1: Function0<A>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.applicativeError().run {
+  this@catch.catch<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <A> effectCatch(arg0: Function1<Throwable, Throwable>, arg1: suspend () -> A):
+    FlowableK<A> = arrow.fx.rx2.FlowableK
+   .applicativeError()
+   .effectCatch<A>(arg0, arg1) as arrow.fx.rx2.FlowableK<A>
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend () -> A): Kind<F, A> =
+    arrow.fx.rx2.FlowableK.applicativeError().run {
+  this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.applicativeError(): FlowableKApplicativeError = applicativeError_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/async/FlowableKAsync.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/async/FlowableKAsync.kt
@@ -1,0 +1,393 @@
+package arrow.fx.rx2.extensions.flowablek.async
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKAsync
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val async_singleton: FlowableKAsync = object : arrow.fx.rx2.extensions.FlowableKAsync {}
+
+/**
+ *  [async] variant that can suspend side effects in the provided registration function.
+ *
+ *  The passed in function is injected with a side-effectful callback for signaling the final result of an asynchronous process.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.*
+ *  import arrow.fx.typeclasses.Async
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.makeCompleteAndGetPromiseInAsync() =
+ *     asyncF<String> { cb: (Either<Throwable, String>) -> Unit ->
+ *       Promise.uncancellable<F, String>(this).flatMap { promise ->
+ *         promise.complete("Hello World!").flatMap {
+ *           promise.get().map { str -> cb(Right(str)) }
+ *         }
+ *       }
+ *     }
+ *
+ *   val result = FlowableK.async().makeCompleteAndGetPromiseInAsync()
+ *  //sampleEnd
+ *  println(result)
+ *  }
+ *  ```
+ *
+ *  @see async for a simpler, non suspending version.
+ */
+@JvmName("asyncF")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> asyncF(arg0: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForFlowableK, Unit>>):
+    FlowableK<A> = arrow.fx.rx2.FlowableK
+   .async()
+   .asyncF<A>(arg0) as arrow.fx.rx2.FlowableK<A>
+
+/**
+ *  Continue the evaluation on provided [CoroutineContext]
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.runOnDefaultDispatcher(): Kind<F, String> =
+ *     just(Unit).continueOn(Dispatchers.Default).flatMap {
+ *       later({ Thread.currentThread().name })
+ *     }
+ *
+ *   val result = FlowableK.async().runOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("continueOn")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.continueOn(arg1: CoroutineContext): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.async().run {
+  this@continueOn.continueOn<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     later(Dispatchers.Default, { Thread.currentThread().name })
+ *
+ *   val result = FlowableK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: CoroutineContext, arg1: Function0<A>): FlowableK<A> = arrow.fx.rx2.FlowableK
+   .async()
+   .later<A>(arg0, arg1) as arrow.fx.rx2.FlowableK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = FlowableK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> effect(arg0: suspend () -> A): FlowableK<A> = arrow.fx.rx2.FlowableK
+   .async()
+   .effect<A>(arg0) as arrow.fx.rx2.FlowableK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = FlowableK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> effect(arg0: CoroutineContext, arg1: suspend () -> A): FlowableK<A> = arrow.fx.rx2.FlowableK
+   .async()
+   .effect<A>(arg0, arg1) as arrow.fx.rx2.FlowableK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     defer(Dispatchers.Default, { effect { Thread.currentThread().name } })
+ *
+ *   val result = FlowableK.async().invokeOnDefaultDispatcher().fix().unsafeRunSync()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> defer(arg0: CoroutineContext, arg1: Function0<Kind<ForFlowableK, A>>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK
+   .async()
+   .defer<A>(arg0, arg1) as arrow.fx.rx2.FlowableK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ */
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> laterOrRaise(arg0: CoroutineContext, arg1: Function0<Either<Throwable, A>>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK
+   .async()
+   .laterOrRaise<A>(arg0, arg1) as arrow.fx.rx2.FlowableK<A>
+
+/**
+ *  Shift evaluation to provided [CoroutineContext].
+ *
+ *  @receiver [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   FlowableK.async().run {
+ *     val result = Dispatchers.Default.shift().map {
+ *       Thread.currentThread().name
+ *     }
+ *
+ *     println(result)
+ *   }
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("shift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun CoroutineContext.shift(): FlowableK<Unit> = arrow.fx.rx2.FlowableK.async().run {
+  this@shift.shift() as arrow.fx.rx2.FlowableK<kotlin.Unit>
+}
+
+/**
+ *  Task that never finishes evaluating.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val i = FlowableK.async().never<Int>()
+ *
+ *   println(i)
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("never")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> never(): FlowableK<A> = arrow.fx.rx2.FlowableK
+   .async()
+   .never<A>() as arrow.fx.rx2.FlowableK<A>
+
+/**
+ *  Helper function that provides an easy way to construct a suspend effect
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun logAndIncrease(s: String): Int {
+ *      println(s)
+ *      return s.toInt() + 1
+ *   }
+ *
+ *   val result = FlowableK.async().effect(Dispatchers.Default) { Thread.currentThread().name }.effectMap { s: String -> logAndIncrease(s) }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effectMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.effectMap(arg1: suspend (A) -> B): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.async().run {
+  this@effectMap.effectMap<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+/**
+ *  [Async] models how a data type runs an asynchronous computation that may fail.
+ *  Defined by the [Proc] signature, which is the consumption of a callback.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.async(): FlowableKAsync = async_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/bracket/FlowableKBracket.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/bracket/FlowableKBracket.kt
@@ -1,0 +1,265 @@
+package arrow.fx.rx2.extensions.flowablek.bracket
+
+import arrow.Kind
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKBracket
+import arrow.fx.typeclasses.ExitCase
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bracket_singleton: FlowableKBracket = object : arrow.fx.rx2.extensions.FlowableKBracket
+    {}
+
+/**
+ *  A way to safely acquire a resource and release in the face of errors and cancellation.
+ *  It uses [ExitCase] to distinguish between different exit cases when releasing the acquired resource.
+ *
+ *  @param use is the action to consume the resource and produce an [F] with the result.
+ *  Once the resulting [F] terminates, either successfully, error or cancelled.
+ *
+ *  @param release the allocated resource after the resulting [F] of [use] is terminates.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.rx2.extensions.flowablek.monadDefer.defer
+ * import arrow.fx.rx2.extensions.flowablek.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val release: (File, ExitCase<Throwable>) -> Kind<F, Unit> = { file, exitCase ->
+ *       when (exitCase) {
+ * do something * / }
+ * do something * / }
+ * do something * / }
+ *       }
+ *       closeFile(file)
+ *   }
+ *
+ *   val use: (File) -> Kind<F, String> = { file: File -> fileToString(file) }
+ *
+ *   val safeComputation = openFile("data.json").bracketCase(release, use)
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracketCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.bracketCase(
+  arg1: Function2<A, ExitCase<Throwable>,
+Kind<ForFlowableK, Unit>>,
+  arg2: Function1<A, Kind<ForFlowableK, B>>
+): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.bracket().run {
+  this@bracketCase.bracketCase<A, B>(arg1, arg2) as arrow.fx.rx2.FlowableK<B>
+}
+
+/**
+ *  Meant for specifying tasks with safe resource acquisition and release in the face of errors and interruption.
+ *  It would be the the equivalent of `try/catch/finally` statements in mainstream imperative languages for resource
+ *  acquisition and release.
+ *
+ *  @param release is the action that's supposed to release the allocated resource after `use` is done, irregardless
+ *  of its exit condition.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.flowablek.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.rx2.extensions.flowablek.monadDefer.defer
+ * import arrow.fx.rx2.extensions.flowablek.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val safeComputation = openFile("data.json").bracket({ file: File -> closeFile(file) }, { file -> fileToString(file) })
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracket")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.bracket(
+  arg1: Function1<A, Kind<ForFlowableK, Unit>>,
+  arg2: Function1<A, Kind<ForFlowableK, B>>
+): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.bracket().run {
+  this@bracket.bracket<A, B>(arg1, arg2) as arrow.fx.rx2.FlowableK<B>
+}
+
+/**
+ *  Meant for ensuring a given task continues execution even when interrupted.
+ */
+@JvmName("uncancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.uncancellable(): FlowableK<A> = arrow.fx.rx2.FlowableK.bracket().run {
+  this@uncancellable.uncancellable<A>() as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("uncancelable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.uncancelable(): FlowableK<A> = arrow.fx.rx2.FlowableK.bracket().run {
+  this@uncancelable.uncancelable<A>() as arrow.fx.rx2.FlowableK<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracket] for the acquisition and release of resources.
+ *
+ *  @see [guaranteeCase] for the version that can discriminate between termination conditions
+ *
+ *  @see [bracket] for the more general operation
+ */
+@JvmName("guarantee")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.guarantee(arg1: Kind<ForFlowableK, Unit>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.bracket().run {
+  this@guarantee.guarantee<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled, allowing
+ *  for differentiating between exit conditions. That's thanks to the [ExitCase] argument of the finalizer.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracketCase] for the acquisition and release of resources.
+ *
+ *  @see [guarantee] for the simpler version
+ *
+ *  @see [bracketCase] for the more general operation
+ */
+@JvmName("guaranteeCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.guaranteeCase(
+  arg1: Function1<ExitCase<Throwable>, Kind<ForFlowableK,
+Unit>>
+): FlowableK<A> = arrow.fx.rx2.FlowableK.bracket().run {
+  this@guaranteeCase.guaranteeCase<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+/**
+ *  Executes the given [finalizer] when the source is cancelled, allowing registering a cancellation token.
+ *
+ *  Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
+ */
+@JvmName("onCancel")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.onCancel(arg1: Kind<ForFlowableK, Unit>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.bracket().run {
+  this@onCancel.onCancel<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+/**
+ *  Executes the given `finalizer` with the given error when the source is finished in error.
+ */
+@JvmName("onError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.onError(arg1: Function1<Throwable, Kind<ForFlowableK, Unit>>):
+    FlowableK<A> = arrow.fx.rx2.FlowableK.bracket().run {
+  this@onError.onError<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+/**
+ *  Extension of MonadError exposing the [bracket] operation, a generalized abstracted pattern of safe resource
+ *  acquisition and release in the face of errors or interruption.
+ *
+ *  @define The functions receiver here (Kind<F, A>) would stand for the "acquireParam", and stands for an action that
+ *  "acquires" some expensive resource, that needs to be used and then discarded.
+ *
+ *  @define use is the action that uses the newly allocated resource and that will provide the final result.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.bracket(): FlowableKBracket = bracket_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/concurrentEffect/FlowableKConcurrentEffect.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/concurrentEffect/FlowableKConcurrentEffect.kt
@@ -1,0 +1,48 @@
+package arrow.fx.rx2.extensions.flowablek.concurrentEffect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKConcurrentEffect
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val concurrentEffect_singleton: FlowableKConcurrentEffect = object :
+    arrow.fx.rx2.extensions.FlowableKConcurrentEffect {}
+
+@JvmName("runAsyncCancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.runAsyncCancellable(
+  arg1: Function1<Either<Throwable, A>,
+Kind<ForFlowableK, Unit>>
+): FlowableK<Function0<Unit>> =
+    arrow.fx.rx2.FlowableK.concurrentEffect().run {
+  this@runAsyncCancellable.runAsyncCancellable<A>(arg1) as
+    arrow.fx.rx2.FlowableK<kotlin.Function0<kotlin.Unit>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.concurrentEffect(): FlowableKConcurrentEffect = concurrentEffect_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/dispatchers/FlowableKDispatchers.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/dispatchers/FlowableKDispatchers.kt
@@ -1,0 +1,48 @@
+package arrow.fx.rx2.extensions.flowablek.dispatchers
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.extensions.FlowableKDispatchers
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val dispatchers_singleton: FlowableKDispatchers = object :
+    arrow.fx.rx2.extensions.FlowableKDispatchers {}
+
+@JvmName("default")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun default(): CoroutineContext = arrow.fx.rx2.FlowableK
+   .dispatchers()
+   .default() as kotlin.coroutines.CoroutineContext
+
+@JvmName("io")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun io(): CoroutineContext = arrow.fx.rx2.FlowableK
+   .dispatchers()
+   .io() as kotlin.coroutines.CoroutineContext
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.dispatchers(): FlowableKDispatchers = dispatchers_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/effect/FlowableKEffect.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/effect/FlowableKEffect.kt
@@ -1,0 +1,44 @@
+package arrow.fx.rx2.extensions.flowablek.effect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKEffect
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val effect_singleton: FlowableKEffect = object : arrow.fx.rx2.extensions.FlowableKEffect {}
+
+@JvmName("runAsync")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.runAsync(
+  arg1: Function1<Either<Throwable, A>, Kind<ForFlowableK,
+Unit>>
+): FlowableK<Unit> = arrow.fx.rx2.FlowableK.effect().run {
+  this@runAsync.runAsync<A>(arg1) as arrow.fx.rx2.FlowableK<kotlin.Unit>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.effect(): FlowableKEffect = effect_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/foldable/FlowableKFoldable.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/foldable/FlowableKFoldable.kt
@@ -1,0 +1,422 @@
+package arrow.fx.rx2.extensions.flowablek.foldable
+
+import arrow.Kind
+import arrow.core.Eval
+import arrow.core.Option
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKFoldable
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import arrow.typeclasses.Monoid
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.Long
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val foldable_singleton: FlowableKFoldable = object :
+  arrow.fx.rx2.extensions.FlowableKFoldable {}
+
+@JvmName("foldLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@foldLeft.foldLeft<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("foldRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.foldRight(arg1: Eval<B>, arg2: Function2<A, Eval<B>, Eval<B>>):
+  Eval<B> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@foldRight.foldRight<A, B>(arg1, arg2) as arrow.core.Eval<B>
+}
+
+@JvmName("fold")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.fold(arg1: Monoid<A>): A = arrow.fx.rx2.FlowableK.foldable().run {
+  this@fold.fold<A>(arg1) as A
+}
+
+@JvmName("reduceLeftToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.reduceLeftToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<B, A,
+    B>
+): Option<B> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@reduceLeftToOption.reduceLeftToOption<A, B>(arg1, arg2) as arrow.core.Option<B>
+}
+
+@JvmName("reduceRightToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.reduceRightToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<A,
+    Eval<B>, Eval<B>>
+): Eval<Option<B>> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@reduceRightToOption.reduceRightToOption<A, B>(arg1, arg2) as
+    arrow.core.Eval<arrow.core.Option<B>>
+}
+
+@JvmName("reduceLeftOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("reduceRightOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>):
+  Eval<Option<A>> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@reduceRightOption.reduceRightOption<A>(arg1) as arrow.core.Eval<arrow.core.Option<A>>
+}
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.combineAll(arg1: Monoid<A>): A =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@combineAll.combineAll<A>(arg1) as A
+  }
+
+@JvmName("foldMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>): B =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@foldMap.foldMap<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("orEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> orEmpty(arg0: Applicative<ForFlowableK>, arg1: Monoid<A>): FlowableK<A> =
+  arrow.fx.rx2.FlowableK
+    .foldable()
+    .orEmpty<A>(arg0, arg1) as arrow.fx.rx2.FlowableK<A>
+
+@JvmName("traverse_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B> Kind<ForFlowableK, A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>):
+  Kind<G, Unit> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@traverse_.traverse_<G, A, B>(arg1, arg2) as arrow.Kind<G, kotlin.Unit>
+}
+
+@JvmName("sequence_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A> Kind<ForFlowableK, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
+  }
+
+@JvmName("find")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.find(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@find.find<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("exists")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.exists(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@exists.exists<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("forAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@forAll.forAll<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("all")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.all(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@all.all<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("isEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.isEmpty(): Boolean = arrow.fx.rx2.FlowableK.foldable().run {
+  this@isEmpty.isEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("nonEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.nonEmpty(): Boolean = arrow.fx.rx2.FlowableK.foldable().run {
+  this@nonEmpty.nonEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("isNotEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.isNotEmpty(): Boolean = arrow.fx.rx2.FlowableK.foldable().run {
+  this@isNotEmpty.isNotEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("size")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.size(arg1: Monoid<Long>): Long =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@size.size<A>(arg1) as kotlin.Long
+  }
+
+@JvmName("foldMapA")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForFlowableK, A>.foldMapA(
+  arg1: AP,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@foldMapA.foldMapA<G, A, B, AP, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldMapM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForFlowableK, A>.foldMapM(
+  arg1: MA,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@foldMapM.foldMapM<G, A, B, MA, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B> Kind<ForFlowableK, A>.foldM(
+  arg1: Monad<G>,
+  arg2: B,
+  arg3: Function2<B, A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@foldM.foldM<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("get")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.get(arg1: Long): Option<A> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@get.get<A>(arg1) as arrow.core.Option<A>
+}
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.firstOption(): Option<A> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@firstOption.firstOption<A>() as arrow.core.Option<A>
+}
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.firstOption(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@firstOption.firstOption<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.firstOrNone(): Option<A> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@firstOrNone.firstOrNone<A>() as arrow.core.Option<A>
+}
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.rx2.FlowableK.foldable().run {
+    this@firstOrNone.firstOrNone<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("toList")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.toList(): List<A> = arrow.fx.rx2.FlowableK.foldable().run {
+  this@toList.toList<A>() as kotlin.collections.List<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.foldable(): FlowableKFoldable = foldable_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/functor/FlowableKFunctor.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/functor/FlowableKFunctor.kt
@@ -1,0 +1,158 @@
+package arrow.fx.rx2.extensions.flowablek.functor
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKFunctor
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: FlowableKFunctor = object : arrow.fx.rx2.extensions.FlowableKFunctor
+    {}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.map(arg1: Function1<A, B>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.functor().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.functor().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForFlowableK, A>, Kind<ForFlowableK, B>> =
+    arrow.fx.rx2.FlowableK
+   .functor()
+   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.fx.rx2.ForFlowableK, A>,
+    arrow.Kind<arrow.fx.rx2.ForFlowableK, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.void(): FlowableK<Unit> = arrow.fx.rx2.FlowableK.functor().run {
+  this@void.void<A>() as arrow.fx.rx2.FlowableK<kotlin.Unit>
+}
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.fproduct(arg1: Function1<A, B>): FlowableK<Tuple2<A, B>> =
+    arrow.fx.rx2.FlowableK.functor().run {
+  this@fproduct.fproduct<A, B>(arg1) as arrow.fx.rx2.FlowableK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.mapConst(arg1: B): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> A.mapConst(arg1: Kind<ForFlowableK, B>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.tupleLeft(arg1: B): FlowableK<Tuple2<B, A>> =
+    arrow.fx.rx2.FlowableK.functor().run {
+  this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.fx.rx2.FlowableK<arrow.core.Tuple2<B, A>>
+}
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.tupleRight(arg1: B): FlowableK<Tuple2<A, B>> =
+    arrow.fx.rx2.FlowableK.functor().run {
+  this@tupleRight.tupleRight<A, B>(arg1) as arrow.fx.rx2.FlowableK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <B, A : B> Kind<ForFlowableK, A>.widen(): FlowableK<B> = arrow.fx.rx2.FlowableK.functor().run {
+  this@widen.widen<B, A>() as arrow.fx.rx2.FlowableK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.functor(): FlowableKFunctor = functor_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/functorFilter/FlowableKFunctorFilter.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/functorFilter/FlowableKFunctorFilter.kt
@@ -1,0 +1,82 @@
+package arrow.fx.rx2.extensions.flowablek.functorFilter
+
+import arrow.Kind
+import arrow.core.Option
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKFunctorFilter
+import java.lang.Class
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functorFilter_singleton: FlowableKFunctorFilter = object :
+    arrow.fx.rx2.extensions.FlowableKFunctorFilter {}
+
+@JvmName("filterMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.filterMap(arg1: Function1<A, Option<B>>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.functorFilter().run {
+  this@filterMap.filterMap<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("flattenOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, Option<A>>.flattenOption(): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.functorFilter().run {
+  this@flattenOption.flattenOption<A>() as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("filter")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.filter(arg1: Function1<A, Boolean>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.functorFilter().run {
+  this@filter.filter<A>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("filterIsInstance")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.filterIsInstance(arg1: Class<B>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.functorFilter().run {
+  this@filterIsInstance.filterIsInstance<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.functorFilter(): FlowableKFunctorFilter = functorFilter_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monad/FlowableKMonad.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monad/FlowableKMonad.kt
@@ -1,0 +1,267 @@
+package arrow.fx.rx2.extensions.flowablek.monad
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.Tuple2
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKMonad
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monad_singleton: FlowableKMonad = object : arrow.fx.rx2.extensions.FlowableKMonad {}
+
+@JvmName("flatMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.flatMap(arg1: Function1<A, Kind<ForFlowableK, B>>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@flatMap.flatMap<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("tailRecM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForFlowableK, Either<A, B>>>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK
+   .monad()
+   .tailRecM<A, B>(arg0, arg1) as arrow.fx.rx2.FlowableK<B>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.map(arg1: Function1<A, B>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.ap(arg1: Kind<ForFlowableK, Function1<A, B>>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@ap.ap<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("flatten")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, Kind<ForFlowableK, A>>.flatten(): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@flatten.flatten<A>() as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.followedBy(arg1: Kind<ForFlowableK, B>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.apTap(arg1: Kind<ForFlowableK, B>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@apTap.apTap<A, B>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("followedByEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.followedByEval(arg1: Eval<Kind<ForFlowableK, B>>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@followedByEval.followedByEval<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("effectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.effectM(arg1: Function1<A, Kind<ForFlowableK, B>>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@effectM.effectM<A, B>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("flatTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.flatTap(arg1: Function1<A, Kind<ForFlowableK, B>>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@flatTap.flatTap<A, B>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("productL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.productL(arg1: Kind<ForFlowableK, B>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@productL.productL<A, B>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("forEffect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.forEffect(arg1: Kind<ForFlowableK, B>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@forEffect.forEffect<A, B>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("productLEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.productLEval(arg1: Eval<Kind<ForFlowableK, B>>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@productLEval.productLEval<A, B>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("forEffectEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.forEffectEval(arg1: Eval<Kind<ForFlowableK, B>>): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.monad().run {
+  this@forEffectEval.forEffectEval<A, B>(arg1) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("mproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.mproduct(arg1: Function1<A, Kind<ForFlowableK, B>>):
+    FlowableK<Tuple2<A, B>> = arrow.fx.rx2.FlowableK.monad().run {
+  this@mproduct.mproduct<A, B>(arg1) as arrow.fx.rx2.FlowableK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("ifM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <B> Kind<ForFlowableK, Boolean>.ifM(
+  arg1: Function0<Kind<ForFlowableK, B>>,
+  arg2: Function0<Kind<ForFlowableK, B>>
+): FlowableK<B> = arrow.fx.rx2.FlowableK.monad().run {
+  this@ifM.ifM<B>(arg1, arg2) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("selectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, Either<A, B>>.selectM(arg1: Kind<ForFlowableK, Function1<A, B>>):
+    FlowableK<B> = arrow.fx.rx2.FlowableK.monad().run {
+  this@selectM.selectM<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, Either<A, B>>.select(arg1: Kind<ForFlowableK, Function1<A, B>>):
+    FlowableK<B> = arrow.fx.rx2.FlowableK.monad().run {
+  this@select.select<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monad(): FlowableKMonad = monad_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monadDefer/FlowableKMonadDefer.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monadDefer/FlowableKMonadDefer.kt
@@ -1,0 +1,103 @@
+package arrow.fx.rx2.extensions.flowablek.monadDefer
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.Ref
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKMonadDefer
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadDefer_singleton: FlowableKMonadDefer = object :
+    arrow.fx.rx2.extensions.FlowableKMonadDefer {}
+
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> defer(arg0: Function0<Kind<ForFlowableK, A>>): FlowableK<A> = arrow.fx.rx2.FlowableK
+   .monadDefer()
+   .defer<A>(arg0) as arrow.fx.rx2.FlowableK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: Function0<A>): FlowableK<A> = arrow.fx.rx2.FlowableK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.rx2.FlowableK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: Kind<ForFlowableK, A>): FlowableK<A> = arrow.fx.rx2.FlowableK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.rx2.FlowableK<A>
+
+@JvmName("lazy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun lazy(): FlowableK<Unit> = arrow.fx.rx2.FlowableK
+   .monadDefer()
+   .lazy() as arrow.fx.rx2.FlowableK<kotlin.Unit>
+
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> laterOrRaise(arg0: Function0<Either<Throwable, A>>): FlowableK<A> = arrow.fx.rx2.FlowableK
+   .monadDefer()
+   .laterOrRaise<A>(arg0) as arrow.fx.rx2.FlowableK<A>
+
+@JvmName("Ref")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Ref(arg0: A): FlowableK<Ref<ForFlowableK, A>> = arrow.fx.rx2.FlowableK
+   .monadDefer()
+   .Ref<A>(arg0) as arrow.fx.rx2.FlowableK<arrow.fx.Ref<arrow.fx.rx2.ForFlowableK, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadDefer(): FlowableKMonadDefer = monadDefer_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monadError/FlowableKMonadError.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monadError/FlowableKMonadError.kt
@@ -1,0 +1,73 @@
+package arrow.fx.rx2.extensions.flowablek.monadError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKMonadError
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadError_singleton: FlowableKMonadError = object :
+    arrow.fx.rx2.extensions.FlowableKMonadError {}
+
+@JvmName("ensure")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, A>.ensure(arg1: Function0<Throwable>, arg2: Function1<A, Boolean>):
+    FlowableK<A> = arrow.fx.rx2.FlowableK.monadError().run {
+  this@ensure.ensure<A>(arg1, arg2) as arrow.fx.rx2.FlowableK<A>
+}
+
+@JvmName("redeemWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.redeemWith(
+  arg1: Function1<Throwable, Kind<ForFlowableK, B>>,
+  arg2: Function1<A, Kind<ForFlowableK, B>>
+): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.monadError().run {
+  this@redeemWith.redeemWith<A, B>(arg1, arg2) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("rethrow")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForFlowableK, Either<Throwable, A>>.rethrow(): FlowableK<A> =
+    arrow.fx.rx2.FlowableK.monadError().run {
+  this@rethrow.rethrow<A>() as arrow.fx.rx2.FlowableK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadError(): FlowableKMonadError = monadError_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monadFilter/FlowableKMonadFilter.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monadFilter/FlowableKMonadFilter.kt
@@ -1,0 +1,55 @@
+package arrow.fx.rx2.extensions.flowablek.monadFilter
+
+import arrow.Kind
+import arrow.core.Option
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKMonadFilter
+import arrow.typeclasses.MonadFilterSyntax
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadFilter_singleton: FlowableKMonadFilter = object :
+    arrow.fx.rx2.extensions.FlowableKMonadFilter {}
+
+@JvmName("filterMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.filterMap(arg1: Function1<A, Option<B>>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.monadFilter().run {
+  this@filterMap.filterMap<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("bindingFilter")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <B> bindingFilter(arg0: suspend MonadFilterSyntax<ForFlowableK>.() -> B): FlowableK<B> =
+    arrow.fx.rx2.FlowableK
+   .monadFilter()
+   .bindingFilter<B>(arg0) as arrow.fx.rx2.FlowableK<B>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadFilter(): FlowableKMonadFilter = monadFilter_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monadThrow/FlowableKMonadThrow.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/monadThrow/FlowableKMonadThrow.kt
@@ -1,0 +1,37 @@
+package arrow.fx.rx2.extensions.flowablek.monadThrow
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.extensions.FlowableKMonadThrow
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadThrow_singleton: FlowableKMonadThrow = object :
+    arrow.fx.rx2.extensions.FlowableKMonadThrow {}
+
+@JvmName("raiseNonFatal")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Throwable.raiseNonFatal(): FlowableK<A> = arrow.fx.rx2.FlowableK.monadThrow().run {
+  this@raiseNonFatal.raiseNonFatal<A>() as arrow.fx.rx2.FlowableK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadThrow(): FlowableKMonadThrow = monadThrow_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/timer/FlowableKTimer.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/timer/FlowableKTimer.kt
@@ -1,0 +1,20 @@
+package arrow.fx.rx2.extensions.flowablek.timer
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.extensions.FlowableKTimer
+import kotlin.PublishedApi
+import kotlin.Suppress
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val timer_singleton: FlowableKTimer = object : arrow.fx.rx2.extensions.FlowableKTimer {}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.timer(): FlowableKTimer = timer_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/traverse/FlowableKTraverse.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/flowablek/traverse/FlowableKTraverse.kt
@@ -1,0 +1,86 @@
+package arrow.fx.rx2.extensions.flowablek.traverse
+
+import arrow.Kind
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.FlowableK
+import arrow.fx.rx2.FlowableK.Companion
+import arrow.fx.rx2.ForFlowableK
+import arrow.fx.rx2.extensions.FlowableKTraverse
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val traverse_singleton: FlowableKTraverse = object :
+    arrow.fx.rx2.extensions.FlowableKTraverse {}
+
+@JvmName("traverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B> Kind<ForFlowableK, A>.traverse(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>):
+    Kind<G, Kind<ForFlowableK, B>> = arrow.fx.rx2.FlowableK.traverse().run {
+  this@traverse.traverse<G, A, B>(arg1, arg2) as arrow.Kind<G, arrow.Kind<arrow.fx.rx2.ForFlowableK,
+    B>>
+}
+
+@JvmName("sequence")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A> Kind<ForFlowableK, Kind<G, A>>.sequence(arg1: Applicative<G>): Kind<G, Kind<ForFlowableK,
+    A>> = arrow.fx.rx2.FlowableK.traverse().run {
+  this@sequence.sequence<G, A>(arg1) as arrow.Kind<G, arrow.Kind<arrow.fx.rx2.ForFlowableK, A>>
+}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForFlowableK, A>.map(arg1: Function1<A, B>): FlowableK<B> =
+    arrow.fx.rx2.FlowableK.traverse().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.FlowableK<B>
+}
+
+@JvmName("flatTraverse")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B> Kind<ForFlowableK, A>.flatTraverse(
+  arg1: Monad<ForFlowableK>,
+  arg2: Applicative<G>,
+  arg3: Function1<A, Kind<G, Kind<ForFlowableK, B>>>
+): Kind<G, Kind<ForFlowableK, B>> = arrow.fx.rx2.FlowableK.traverse().run {
+  this@flatTraverse.flatTraverse<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G,
+    arrow.Kind<arrow.fx.rx2.ForFlowableK, B>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.traverse(): FlowableKTraverse = traverse_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek.kt
@@ -6,7 +6,6 @@ import arrow.core.Eval
 import arrow.core.Option
 import arrow.core.Tuple2
 import arrow.core.Tuple3
-import arrow.extension
 import arrow.fx.RacePair
 import arrow.fx.RaceTriple
 import arrow.fx.Timer
@@ -54,14 +53,12 @@ import kotlin.coroutines.CoroutineContext
 import arrow.fx.rx2.handleErrorWith as maybeHandleErrorWith
 import io.reactivex.disposables.Disposable as RxDisposable
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKFunctor : Functor<ForMaybeK> {
   override fun <A, B> MaybeKOf<A>.map(f: (A) -> B): MaybeK<B> =
     fix().map(f)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKApplicative : Applicative<ForMaybeK> {
   override fun <A, B> MaybeKOf<A>.ap(ff: MaybeKOf<(A) -> B>): MaybeK<B> =
@@ -77,7 +74,6 @@ interface MaybeKApplicative : Applicative<ForMaybeK> {
     Eval.now(fix().ap(MaybeK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKMonad : Monad<ForMaybeK>, MaybeKApplicative {
   override fun <A, B> MaybeKOf<A>.ap(ff: MaybeKOf<(A) -> B>): MaybeK<B> =
@@ -96,7 +92,6 @@ interface MaybeKMonad : Monad<ForMaybeK>, MaybeKApplicative {
     Eval.now(fix().ap(MaybeK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKFoldable : Foldable<ForMaybeK> {
 
@@ -119,7 +114,6 @@ interface MaybeKFoldable : Foldable<ForMaybeK> {
     fix().nonEmpty()
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKApplicativeError :
   ApplicativeError<ForMaybeK, Throwable>,
@@ -131,7 +125,6 @@ interface MaybeKApplicativeError :
     fix().maybeHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKMonadError :
   MonadError<ForMaybeK, Throwable>,
@@ -143,25 +136,21 @@ interface MaybeKMonadError :
     fix().maybeHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKMonadThrow : MonadThrow<ForMaybeK>, MaybeKMonadError
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKBracket : Bracket<ForMaybeK, Throwable>, MaybeKMonadThrow {
   override fun <A, B> MaybeKOf<A>.bracketCase(release: (A, ExitCase<Throwable>) -> MaybeKOf<Unit>, use: (A) -> MaybeKOf<B>): MaybeK<B> =
     fix().bracketCase({ use(it) }, { a, e -> release(a, e) })
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKMonadDefer : MonadDefer<ForMaybeK>, MaybeKBracket {
   override fun <A> defer(fa: () -> MaybeKOf<A>): MaybeK<A> =
     MaybeK.defer(fa)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKAsync : Async<ForMaybeK>, MaybeKMonadDefer {
   override fun <A> async(fa: Proc<A>): MaybeK<A> =
@@ -174,7 +163,6 @@ interface MaybeKAsync : Async<ForMaybeK>, MaybeKMonadDefer {
     fix().continueOn(ctx)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKEffect :
   Effect<ForMaybeK>,
@@ -283,7 +271,6 @@ fun MaybeK.Companion.concurrent(dispatchers: Dispatchers<ForMaybeK> = MaybeK.dis
   override fun dispatchers(): Dispatchers<ForMaybeK> = dispatchers
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKUnsafeRun : UnsafeRun<ForMaybeK> {
   override suspend fun <A> unsafe.runBlocking(fa: () -> Kind<ForMaybeK, A>): A = fa().fix().unsafeRunSync()
@@ -292,7 +279,6 @@ interface MaybeKUnsafeRun : UnsafeRun<ForMaybeK> {
     fa().fix().unsafeRunAsync(cb)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKDispatchers : Dispatchers<ForMaybeK> {
   override fun default(): CoroutineContext =
@@ -302,7 +288,6 @@ interface MaybeKDispatchers : Dispatchers<ForMaybeK> {
     IOScheduler
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKTimer : Timer<ForMaybeK> {
   override fun sleep(duration: Duration): MaybeK<Unit> =
@@ -310,14 +295,12 @@ interface MaybeKTimer : Timer<ForMaybeK> {
       .map { Unit })
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKFunctorFilter : FunctorFilter<ForMaybeK>, MaybeKFunctor {
   override fun <A, B> Kind<ForMaybeK, A>.filterMap(f: (A) -> Option<B>): Kind<ForMaybeK, B> =
     fix().filterMap(f)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface MaybeKMonadFilter : MonadFilter<ForMaybeK>, MaybeKMonad {
   override fun <A> empty(): MaybeK<A> =

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/applicative/MaybeKApplicative.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/applicative/MaybeKApplicative.kt
@@ -1,0 +1,94 @@
+package arrow.fx.rx2.extensions.maybek.applicative
+
+import arrow.Kind
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKApplicative
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicative_singleton: MaybeKApplicative = object :
+    arrow.fx.rx2.extensions.MaybeKApplicative {}
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> A.just(): MaybeK<A> = arrow.fx.rx2.MaybeK.applicative().run {
+  this@just.just<A>() as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun unit(): MaybeK<Unit> = arrow.fx.rx2.MaybeK
+   .applicative()
+   .unit() as arrow.fx.rx2.MaybeK<kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.map(arg1: Function1<A, B>): MaybeK<B> =
+    arrow.fx.rx2.MaybeK.applicative().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.replicate(arg1: Int): MaybeK<List<A>> =
+    arrow.fx.rx2.MaybeK.applicative().run {
+  this@replicate.replicate<A>(arg1) as arrow.fx.rx2.MaybeK<kotlin.collections.List<A>>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.replicate(arg1: Int, arg2: Monoid<A>): MaybeK<A> =
+    arrow.fx.rx2.MaybeK.applicative().run {
+  this@replicate.replicate<A>(arg1, arg2) as arrow.fx.rx2.MaybeK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.applicative(): MaybeKApplicative = applicative_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/applicativeError/MaybeKApplicativeError.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/applicativeError/MaybeKApplicativeError.kt
@@ -1,0 +1,174 @@
+package arrow.fx.rx2.extensions.maybek.applicativeError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.ForOption
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKApplicativeError
+import arrow.typeclasses.ApplicativeError
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicativeError_singleton: MaybeKApplicativeError = object :
+    arrow.fx.rx2.extensions.MaybeKApplicativeError {}
+
+@JvmName("handleErrorWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.handleErrorWith(arg1: Function1<Throwable, Kind<ForMaybeK, A>>):
+    MaybeK<A> = arrow.fx.rx2.MaybeK.applicativeError().run {
+  this@handleErrorWith.handleErrorWith<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("raiseError1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Throwable.raiseError(): MaybeK<A> = arrow.fx.rx2.MaybeK.applicativeError().run {
+  this@raiseError.raiseError<A>() as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("fromOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForOption, A>.fromOption(arg1: Function0<Throwable>): MaybeK<A> =
+    arrow.fx.rx2.MaybeK.applicativeError().run {
+  this@fromOption.fromOption<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("fromEither")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, Throwable>): MaybeK<A> =
+    arrow.fx.rx2.MaybeK.applicativeError().run {
+  this@fromEither.fromEither<A, EE>(arg1) as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("handleError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.handleError(arg1: Function1<Throwable, A>): MaybeK<A> =
+    arrow.fx.rx2.MaybeK.applicativeError().run {
+  this@handleError.handleError<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("redeem")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.redeem(arg1: Function1<Throwable, B>, arg2: Function1<A, B>):
+    MaybeK<B> = arrow.fx.rx2.MaybeK.applicativeError().run {
+  this@redeem.redeem<A, B>(arg1, arg2) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("attempt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.attempt(): MaybeK<Either<Throwable, A>> =
+    arrow.fx.rx2.MaybeK.applicativeError().run {
+  this@attempt.attempt<A>() as arrow.fx.rx2.MaybeK<arrow.core.Either<kotlin.Throwable, A>>
+}
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> catch(arg0: Function1<Throwable, Throwable>, arg1: Function0<A>): MaybeK<A> =
+    arrow.fx.rx2.MaybeK
+   .applicativeError()
+   .catch<A>(arg0, arg1) as arrow.fx.rx2.MaybeK<A>
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> ApplicativeError<ForMaybeK, Throwable>.catch(arg1: Function0<A>): MaybeK<A> =
+    arrow.fx.rx2.MaybeK.applicativeError().run {
+  this@catch.catch<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <A> effectCatch(arg0: Function1<Throwable, Throwable>, arg1: suspend () -> A): MaybeK<A> =
+    arrow.fx.rx2.MaybeK
+   .applicativeError()
+   .effectCatch<A>(arg0, arg1) as arrow.fx.rx2.MaybeK<A>
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend () -> A): Kind<F, A> =
+    arrow.fx.rx2.MaybeK.applicativeError().run {
+  this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.applicativeError(): MaybeKApplicativeError = applicativeError_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/async/MaybeKAsync.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/async/MaybeKAsync.kt
@@ -1,0 +1,393 @@
+package arrow.fx.rx2.extensions.maybek.async
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKAsync
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val async_singleton: MaybeKAsync = object : arrow.fx.rx2.extensions.MaybeKAsync {}
+
+/**
+ *  [async] variant that can suspend side effects in the provided registration function.
+ *
+ *  The passed in function is injected with a side-effectful callback for signaling the final result of an asynchronous process.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.*
+ *  import arrow.fx.typeclasses.Async
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.makeCompleteAndGetPromiseInAsync() =
+ *     asyncF<String> { cb: (Either<Throwable, String>) -> Unit ->
+ *       Promise.uncancellable<F, String>(this).flatMap { promise ->
+ *         promise.complete("Hello World!").flatMap {
+ *           promise.get().map { str -> cb(Right(str)) }
+ *         }
+ *       }
+ *     }
+ *
+ *   val result = MaybeK.async().makeCompleteAndGetPromiseInAsync()
+ *  //sampleEnd
+ *  println(result)
+ *  }
+ *  ```
+ *
+ *  @see async for a simpler, non suspending version.
+ */
+@JvmName("asyncF")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> asyncF(arg0: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForMaybeK, Unit>>):
+    MaybeK<A> = arrow.fx.rx2.MaybeK
+   .async()
+   .asyncF<A>(arg0) as arrow.fx.rx2.MaybeK<A>
+
+/**
+ *  Continue the evaluation on provided [CoroutineContext]
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.runOnDefaultDispatcher(): Kind<F, String> =
+ *     just(Unit).continueOn(Dispatchers.Default).flatMap {
+ *       later({ Thread.currentThread().name })
+ *     }
+ *
+ *   val result = MaybeK.async().runOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("continueOn")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.continueOn(arg1: CoroutineContext): MaybeK<A> =
+    arrow.fx.rx2.MaybeK.async().run {
+  this@continueOn.continueOn<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+}
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     later(Dispatchers.Default, { Thread.currentThread().name })
+ *
+ *   val result = MaybeK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: CoroutineContext, arg1: Function0<A>): MaybeK<A> = arrow.fx.rx2.MaybeK
+   .async()
+   .later<A>(arg0, arg1) as arrow.fx.rx2.MaybeK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = MaybeK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> effect(arg0: suspend () -> A): MaybeK<A> = arrow.fx.rx2.MaybeK
+   .async()
+   .effect<A>(arg0) as arrow.fx.rx2.MaybeK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = MaybeK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> effect(arg0: CoroutineContext, arg1: suspend () -> A): MaybeK<A> = arrow.fx.rx2.MaybeK
+   .async()
+   .effect<A>(arg0, arg1) as arrow.fx.rx2.MaybeK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     defer(Dispatchers.Default, { effect { Thread.currentThread().name } })
+ *
+ *   val result = MaybeK.async().invokeOnDefaultDispatcher().fix().unsafeRunSync()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> defer(arg0: CoroutineContext, arg1: Function0<Kind<ForMaybeK, A>>): MaybeK<A> =
+    arrow.fx.rx2.MaybeK
+   .async()
+   .defer<A>(arg0, arg1) as arrow.fx.rx2.MaybeK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ */
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> laterOrRaise(arg0: CoroutineContext, arg1: Function0<Either<Throwable, A>>): MaybeK<A> =
+    arrow.fx.rx2.MaybeK
+   .async()
+   .laterOrRaise<A>(arg0, arg1) as arrow.fx.rx2.MaybeK<A>
+
+/**
+ *  Shift evaluation to provided [CoroutineContext].
+ *
+ *  @receiver [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   MaybeK.async().run {
+ *     val result = Dispatchers.Default.shift().map {
+ *       Thread.currentThread().name
+ *     }
+ *
+ *     println(result)
+ *   }
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("shift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun CoroutineContext.shift(): MaybeK<Unit> = arrow.fx.rx2.MaybeK.async().run {
+  this@shift.shift() as arrow.fx.rx2.MaybeK<kotlin.Unit>
+}
+
+/**
+ *  Task that never finishes evaluating.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.async.*
+ * import arrow.core.*
+ *
+ *
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val i = MaybeK.async().never<Int>()
+ *
+ *   println(i)
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("never")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> never(): MaybeK<A> = arrow.fx.rx2.MaybeK
+   .async()
+   .never<A>() as arrow.fx.rx2.MaybeK<A>
+
+/**
+ *  Helper function that provides an easy way to construct a suspend effect
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun logAndIncrease(s: String): Int {
+ *      println(s)
+ *      return s.toInt() + 1
+ *   }
+ *
+ *   val result = MaybeK.async().effect(Dispatchers.Default) { Thread.currentThread().name }.effectMap { s: String -> logAndIncrease(s) }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effectMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.effectMap(arg1: suspend (A) -> B): MaybeK<B> =
+    arrow.fx.rx2.MaybeK.async().run {
+  this@effectMap.effectMap<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+}
+
+/**
+ *  [Async] models how a data type runs an asynchronous computation that may fail.
+ *  Defined by the [Proc] signature, which is the consumption of a callback.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.async(): MaybeKAsync = async_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/bracket/MaybeKBracket.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/bracket/MaybeKBracket.kt
@@ -1,0 +1,263 @@
+package arrow.fx.rx2.extensions.maybek.bracket
+
+import arrow.Kind
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKBracket
+import arrow.fx.typeclasses.ExitCase
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bracket_singleton: MaybeKBracket = object : arrow.fx.rx2.extensions.MaybeKBracket {}
+
+/**
+ *  A way to safely acquire a resource and release in the face of errors and cancellation.
+ *  It uses [ExitCase] to distinguish between different exit cases when releasing the acquired resource.
+ *
+ *  @param use is the action to consume the resource and produce an [F] with the result.
+ *  Once the resulting [F] terminates, either successfully, error or cancelled.
+ *
+ *  @param release the allocated resource after the resulting [F] of [use] is terminates.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.rx2.extensions.maybek.monadDefer.defer
+ * import arrow.fx.rx2.extensions.maybek.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val release: (File, ExitCase<Throwable>) -> Kind<F, Unit> = { file, exitCase ->
+ *       when (exitCase) {
+ * do something * / }
+ * do something * / }
+ * do something * / }
+ *       }
+ *       closeFile(file)
+ *   }
+ *
+ *   val use: (File) -> Kind<F, String> = { file: File -> fileToString(file) }
+ *
+ *   val safeComputation = openFile("data.json").bracketCase(release, use)
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracketCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.bracketCase(
+  arg1: Function2<A, ExitCase<Throwable>, Kind<ForMaybeK,
+    Unit>>,
+  arg2: Function1<A, Kind<ForMaybeK, B>>
+): MaybeK<B> = arrow.fx.rx2.MaybeK.bracket().run {
+  this@bracketCase.bracketCase<A, B>(arg1, arg2) as arrow.fx.rx2.MaybeK<B>
+}
+
+/**
+ *  Meant for specifying tasks with safe resource acquisition and release in the face of errors and interruption.
+ *  It would be the the equivalent of `try/catch/finally` statements in mainstream imperative languages for resource
+ *  acquisition and release.
+ *
+ *  @param release is the action that's supposed to release the allocated resource after `use` is done, irregardless
+ *  of its exit condition.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.maybek.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.rx2.extensions.maybek.monadDefer.defer
+ * import arrow.fx.rx2.extensions.maybek.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val safeComputation = openFile("data.json").bracket({ file: File -> closeFile(file) }, { file -> fileToString(file) })
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracket")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.bracket(
+  arg1: Function1<A, Kind<ForMaybeK, Unit>>,
+  arg2: Function1<A,
+    Kind<ForMaybeK, B>>
+): MaybeK<B> = arrow.fx.rx2.MaybeK.bracket().run {
+  this@bracket.bracket<A, B>(arg1, arg2) as arrow.fx.rx2.MaybeK<B>
+}
+
+/**
+ *  Meant for ensuring a given task continues execution even when interrupted.
+ */
+@JvmName("uncancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.uncancellable(): MaybeK<A> = arrow.fx.rx2.MaybeK.bracket().run {
+  this@uncancellable.uncancellable<A>() as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("uncancelable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.uncancelable(): MaybeK<A> = arrow.fx.rx2.MaybeK.bracket().run {
+  this@uncancelable.uncancelable<A>() as arrow.fx.rx2.MaybeK<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracket] for the acquisition and release of resources.
+ *
+ *  @see [guaranteeCase] for the version that can discriminate between termination conditions
+ *
+ *  @see [bracket] for the more general operation
+ */
+@JvmName("guarantee")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.guarantee(arg1: Kind<ForMaybeK, Unit>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.bracket().run {
+    this@guarantee.guarantee<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled, allowing
+ *  for differentiating between exit conditions. That's thanks to the [ExitCase] argument of the finalizer.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracketCase] for the acquisition and release of resources.
+ *
+ *  @see [guarantee] for the simpler version
+ *
+ *  @see [bracketCase] for the more general operation
+ */
+@JvmName("guaranteeCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.guaranteeCase(
+  arg1: Function1<ExitCase<Throwable>, Kind<ForMaybeK,
+    Unit>>
+): MaybeK<A> = arrow.fx.rx2.MaybeK.bracket().run {
+  this@guaranteeCase.guaranteeCase<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+}
+
+/**
+ *  Executes the given [finalizer] when the source is cancelled, allowing registering a cancellation token.
+ *
+ *  Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
+ */
+@JvmName("onCancel")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.onCancel(arg1: Kind<ForMaybeK, Unit>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.bracket().run {
+    this@onCancel.onCancel<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+/**
+ *  Executes the given `finalizer` with the given error when the source is finished in error.
+ */
+@JvmName("onError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.onError(arg1: Function1<Throwable, Kind<ForMaybeK, Unit>>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.bracket().run {
+    this@onError.onError<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+/**
+ *  Extension of MonadError exposing the [bracket] operation, a generalized abstracted pattern of safe resource
+ *  acquisition and release in the face of errors or interruption.
+ *
+ *  @define The functions receiver here (Kind<F, A>) would stand for the "acquireParam", and stands for an action that
+ *  "acquires" some expensive resource, that needs to be used and then discarded.
+ *
+ *  @define use is the action that uses the newly allocated resource and that will provide the final result.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.bracket(): MaybeKBracket = bracket_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/dispatchers/MaybeKDispatchers.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/dispatchers/MaybeKDispatchers.kt
@@ -1,0 +1,48 @@
+package arrow.fx.rx2.extensions.maybek.dispatchers
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKDispatchers
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val dispatchers_singleton: MaybeKDispatchers = object :
+    arrow.fx.rx2.extensions.MaybeKDispatchers {}
+
+@JvmName("default")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun default(): CoroutineContext = arrow.fx.rx2.MaybeK
+   .dispatchers()
+   .default() as kotlin.coroutines.CoroutineContext
+
+@JvmName("io")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun io(): CoroutineContext = arrow.fx.rx2.MaybeK
+   .dispatchers()
+   .io() as kotlin.coroutines.CoroutineContext
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.dispatchers(): MaybeKDispatchers = dispatchers_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/effect/MaybeKEffect.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/effect/MaybeKEffect.kt
@@ -1,0 +1,42 @@
+package arrow.fx.rx2.extensions.maybek.effect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKEffect
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val effect_singleton: MaybeKEffect = object : arrow.fx.rx2.extensions.MaybeKEffect {}
+
+@JvmName("runAsync")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.runAsync(arg1: Function1<Either<Throwable, A>, Kind<ForMaybeK, Unit>>):
+    MaybeK<Unit> = arrow.fx.rx2.MaybeK.effect().run {
+  this@runAsync.runAsync<A>(arg1) as arrow.fx.rx2.MaybeK<kotlin.Unit>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.effect(): MaybeKEffect = effect_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/foldable/MaybeKFoldable.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/foldable/MaybeKFoldable.kt
@@ -1,0 +1,415 @@
+package arrow.fx.rx2.extensions.maybek.foldable
+
+import arrow.Kind
+import arrow.core.Eval
+import arrow.core.Option
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKFoldable
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import arrow.typeclasses.Monoid
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.Long
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val foldable_singleton: MaybeKFoldable = object : arrow.fx.rx2.extensions.MaybeKFoldable {}
+
+@JvmName("foldLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@foldLeft.foldLeft<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("foldRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.foldRight(arg1: Eval<B>, arg2: Function2<A, Eval<B>, Eval<B>>):
+  Eval<B> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@foldRight.foldRight<A, B>(arg1, arg2) as arrow.core.Eval<B>
+}
+
+@JvmName("fold")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.fold(arg1: Monoid<A>): A = arrow.fx.rx2.MaybeK.foldable().run {
+  this@fold.fold<A>(arg1) as A
+}
+
+@JvmName("reduceLeftToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.reduceLeftToOption(arg1: Function1<A, B>, arg2: Function2<B, A, B>):
+  Option<B> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@reduceLeftToOption.reduceLeftToOption<A, B>(arg1, arg2) as arrow.core.Option<B>
+}
+
+@JvmName("reduceRightToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.reduceRightToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<A, Eval<B>,
+    Eval<B>>
+): Eval<Option<B>> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@reduceRightToOption.reduceRightToOption<A, B>(arg1, arg2) as
+    arrow.core.Eval<arrow.core.Option<B>>
+}
+
+@JvmName("reduceLeftOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("reduceRightOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>): Eval<Option<A>> =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@reduceRightOption.reduceRightOption<A>(arg1) as arrow.core.Eval<arrow.core.Option<A>>
+  }
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.combineAll(arg1: Monoid<A>): A = arrow.fx.rx2.MaybeK.foldable().run {
+  this@combineAll.combineAll<A>(arg1) as A
+}
+
+@JvmName("foldMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>): B =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@foldMap.foldMap<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("orEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> orEmpty(arg0: Applicative<ForMaybeK>, arg1: Monoid<A>): MaybeK<A> = arrow.fx.rx2.MaybeK
+  .foldable()
+  .orEmpty<A>(arg0, arg1) as arrow.fx.rx2.MaybeK<A>
+
+@JvmName("traverse_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B> Kind<ForMaybeK, A>.traverse_(arg1: Applicative<G>, arg2: Function1<A, Kind<G, B>>):
+  Kind<G, Unit> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@traverse_.traverse_<G, A, B>(arg1, arg2) as arrow.Kind<G, kotlin.Unit>
+}
+
+@JvmName("sequence_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A> Kind<ForMaybeK, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
+  }
+
+@JvmName("find")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.find(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@find.find<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("exists")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.exists(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@exists.exists<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("forAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@forAll.forAll<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("all")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.all(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@all.all<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("isEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.isEmpty(): Boolean = arrow.fx.rx2.MaybeK.foldable().run {
+  this@isEmpty.isEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("nonEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.nonEmpty(): Boolean = arrow.fx.rx2.MaybeK.foldable().run {
+  this@nonEmpty.nonEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("isNotEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.isNotEmpty(): Boolean = arrow.fx.rx2.MaybeK.foldable().run {
+  this@isNotEmpty.isNotEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("size")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.size(arg1: Monoid<Long>): Long = arrow.fx.rx2.MaybeK.foldable().run {
+  this@size.size<A>(arg1) as kotlin.Long
+}
+
+@JvmName("foldMapA")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForMaybeK, A>.foldMapA(
+  arg1: AP,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@foldMapA.foldMapA<G, A, B, AP, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldMapM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForMaybeK, A>.foldMapM(
+  arg1: MA,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@foldMapM.foldMapM<G, A, B, MA, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B> Kind<ForMaybeK, A>.foldM(
+  arg1: Monad<G>,
+  arg2: B,
+  arg3: Function2<B, A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@foldM.foldM<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("get")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.get(arg1: Long): Option<A> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@get.get<A>(arg1) as arrow.core.Option<A>
+}
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.firstOption(): Option<A> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@firstOption.firstOption<A>() as arrow.core.Option<A>
+}
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.firstOption(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@firstOption.firstOption<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.firstOrNone(): Option<A> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@firstOrNone.firstOrNone<A>() as arrow.core.Option<A>
+}
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.rx2.MaybeK.foldable().run {
+    this@firstOrNone.firstOrNone<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("toList")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.toList(): List<A> = arrow.fx.rx2.MaybeK.foldable().run {
+  this@toList.toList<A>() as kotlin.collections.List<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.foldable(): MaybeKFoldable = foldable_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/functor/MaybeKFunctor.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/functor/MaybeKFunctor.kt
@@ -1,0 +1,155 @@
+package arrow.fx.rx2.extensions.maybek.functor
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKFunctor
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: MaybeKFunctor = object : arrow.fx.rx2.extensions.MaybeKFunctor {}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.map(arg1: Function1<A, B>): MaybeK<B> =
+    arrow.fx.rx2.MaybeK.functor().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): MaybeK<B> =
+    arrow.fx.rx2.MaybeK.functor().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForMaybeK, A>, Kind<ForMaybeK, B>> =
+    arrow.fx.rx2.MaybeK
+   .functor()
+   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.fx.rx2.ForMaybeK, A>,
+    arrow.Kind<arrow.fx.rx2.ForMaybeK, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.void(): MaybeK<Unit> = arrow.fx.rx2.MaybeK.functor().run {
+  this@void.void<A>() as arrow.fx.rx2.MaybeK<kotlin.Unit>
+}
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.fproduct(arg1: Function1<A, B>): MaybeK<Tuple2<A, B>> =
+    arrow.fx.rx2.MaybeK.functor().run {
+  this@fproduct.fproduct<A, B>(arg1) as arrow.fx.rx2.MaybeK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.mapConst(arg1: B): MaybeK<B> = arrow.fx.rx2.MaybeK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> A.mapConst(arg1: Kind<ForMaybeK, B>): MaybeK<A> = arrow.fx.rx2.MaybeK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.tupleLeft(arg1: B): MaybeK<Tuple2<B, A>> =
+    arrow.fx.rx2.MaybeK.functor().run {
+  this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.fx.rx2.MaybeK<arrow.core.Tuple2<B, A>>
+}
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.tupleRight(arg1: B): MaybeK<Tuple2<A, B>> =
+    arrow.fx.rx2.MaybeK.functor().run {
+  this@tupleRight.tupleRight<A, B>(arg1) as arrow.fx.rx2.MaybeK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <B, A : B> Kind<ForMaybeK, A>.widen(): MaybeK<B> = arrow.fx.rx2.MaybeK.functor().run {
+  this@widen.widen<B, A>() as arrow.fx.rx2.MaybeK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.functor(): MaybeKFunctor = functor_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/functorFilter/MaybeKFunctorFilter.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/functorFilter/MaybeKFunctorFilter.kt
@@ -1,0 +1,82 @@
+package arrow.fx.rx2.extensions.maybek.functorFilter
+
+import arrow.Kind
+import arrow.core.Option
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKFunctorFilter
+import java.lang.Class
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functorFilter_singleton: MaybeKFunctorFilter = object :
+    arrow.fx.rx2.extensions.MaybeKFunctorFilter {}
+
+@JvmName("filterMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.filterMap(arg1: Function1<A, Option<B>>): MaybeK<B> =
+    arrow.fx.rx2.MaybeK.functorFilter().run {
+  this@filterMap.filterMap<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("flattenOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, Option<A>>.flattenOption(): MaybeK<A> =
+    arrow.fx.rx2.MaybeK.functorFilter().run {
+  this@flattenOption.flattenOption<A>() as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("filter")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.filter(arg1: Function1<A, Boolean>): MaybeK<A> =
+    arrow.fx.rx2.MaybeK.functorFilter().run {
+  this@filter.filter<A>(arg1) as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("filterIsInstance")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.filterIsInstance(arg1: Class<B>): MaybeK<B> =
+    arrow.fx.rx2.MaybeK.functorFilter().run {
+  this@filterIsInstance.filterIsInstance<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.functorFilter(): MaybeKFunctorFilter = functorFilter_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monad/MaybeKMonad.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monad/MaybeKMonad.kt
@@ -1,0 +1,265 @@
+package arrow.fx.rx2.extensions.maybek.monad
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.Tuple2
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKMonad
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monad_singleton: MaybeKMonad = object : arrow.fx.rx2.extensions.MaybeKMonad {}
+
+@JvmName("flatMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.flatMap(arg1: Function1<A, Kind<ForMaybeK, B>>): MaybeK<B> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@flatMap.flatMap<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+  }
+
+@JvmName("tailRecM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForMaybeK, Either<A, B>>>): MaybeK<B> =
+  arrow.fx.rx2.MaybeK
+    .monad()
+    .tailRecM<A, B>(arg0, arg1) as arrow.fx.rx2.MaybeK<B>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.map(arg1: Function1<A, B>): MaybeK<B> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@map.map<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+  }
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.ap(arg1: Kind<ForMaybeK, Function1<A, B>>): MaybeK<B> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@ap.ap<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+  }
+
+@JvmName("flatten")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, Kind<ForMaybeK, A>>.flatten(): MaybeK<A> = arrow.fx.rx2.MaybeK.monad().run {
+  this@flatten.flatten<A>() as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.followedBy(arg1: Kind<ForMaybeK, B>): MaybeK<B> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@followedBy.followedBy<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+  }
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.apTap(arg1: Kind<ForMaybeK, B>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@apTap.apTap<A, B>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+@JvmName("followedByEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.followedByEval(arg1: Eval<Kind<ForMaybeK, B>>): MaybeK<B> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@followedByEval.followedByEval<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+  }
+
+@JvmName("effectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.effectM(arg1: Function1<A, Kind<ForMaybeK, B>>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@effectM.effectM<A, B>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+@JvmName("flatTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.flatTap(arg1: Function1<A, Kind<ForMaybeK, B>>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@flatTap.flatTap<A, B>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+@JvmName("productL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.productL(arg1: Kind<ForMaybeK, B>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@productL.productL<A, B>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+@JvmName("forEffect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.forEffect(arg1: Kind<ForMaybeK, B>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@forEffect.forEffect<A, B>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+@JvmName("productLEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.productLEval(arg1: Eval<Kind<ForMaybeK, B>>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@productLEval.productLEval<A, B>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+@JvmName("forEffectEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.forEffectEval(arg1: Eval<Kind<ForMaybeK, B>>): MaybeK<A> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@forEffectEval.forEffectEval<A, B>(arg1) as arrow.fx.rx2.MaybeK<A>
+  }
+
+@JvmName("mproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.mproduct(arg1: Function1<A, Kind<ForMaybeK, B>>): MaybeK<Tuple2<A, B>> = arrow.fx.rx2.MaybeK.monad().run {
+  this@mproduct.mproduct<A, B>(arg1) as arrow.fx.rx2.MaybeK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("ifM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+
+@Deprecated(DeprecateRxJava)
+fun <B> Kind<ForMaybeK, Boolean>.ifM(
+  arg1: Function0<Kind<ForMaybeK, B>>,
+  arg2: Function0<Kind<ForMaybeK, B>>
+): MaybeK<B> = arrow.fx.rx2.MaybeK.monad().run {
+  this@ifM.ifM<B>(arg1, arg2) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("selectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, Either<A, B>>.selectM(arg1: Kind<ForMaybeK, Function1<A, B>>): MaybeK<B> = arrow.fx.rx2.MaybeK.monad().run {
+  this@selectM.selectM<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, Either<A, B>>.select(arg1: Kind<ForMaybeK, Function1<A, B>>): MaybeK<B> =
+  arrow.fx.rx2.MaybeK.monad().run {
+    this@select.select<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+  }
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monad(): MaybeKMonad = monad_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monadDefer/MaybeKMonadDefer.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monadDefer/MaybeKMonadDefer.kt
@@ -1,0 +1,103 @@
+package arrow.fx.rx2.extensions.maybek.monadDefer
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.Ref
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKMonadDefer
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadDefer_singleton: MaybeKMonadDefer = object :
+    arrow.fx.rx2.extensions.MaybeKMonadDefer {}
+
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> defer(arg0: Function0<Kind<ForMaybeK, A>>): MaybeK<A> = arrow.fx.rx2.MaybeK
+   .monadDefer()
+   .defer<A>(arg0) as arrow.fx.rx2.MaybeK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: Function0<A>): MaybeK<A> = arrow.fx.rx2.MaybeK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.rx2.MaybeK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: Kind<ForMaybeK, A>): MaybeK<A> = arrow.fx.rx2.MaybeK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.rx2.MaybeK<A>
+
+@JvmName("lazy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun lazy(): MaybeK<Unit> = arrow.fx.rx2.MaybeK
+   .monadDefer()
+   .lazy() as arrow.fx.rx2.MaybeK<kotlin.Unit>
+
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> laterOrRaise(arg0: Function0<Either<Throwable, A>>): MaybeK<A> = arrow.fx.rx2.MaybeK
+   .monadDefer()
+   .laterOrRaise<A>(arg0) as arrow.fx.rx2.MaybeK<A>
+
+@JvmName("Ref")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Ref(arg0: A): MaybeK<Ref<ForMaybeK, A>> = arrow.fx.rx2.MaybeK
+   .monadDefer()
+   .Ref<A>(arg0) as arrow.fx.rx2.MaybeK<arrow.fx.Ref<arrow.fx.rx2.ForMaybeK, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadDefer(): MaybeKMonadDefer = monadDefer_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monadError/MaybeKMonadError.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monadError/MaybeKMonadError.kt
@@ -1,0 +1,72 @@
+package arrow.fx.rx2.extensions.maybek.monadError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKMonadError
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadError_singleton: MaybeKMonadError = object :
+    arrow.fx.rx2.extensions.MaybeKMonadError {}
+
+@JvmName("ensure")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, A>.ensure(arg1: Function0<Throwable>, arg2: Function1<A, Boolean>):
+    MaybeK<A> = arrow.fx.rx2.MaybeK.monadError().run {
+  this@ensure.ensure<A>(arg1, arg2) as arrow.fx.rx2.MaybeK<A>
+}
+
+@JvmName("redeemWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.redeemWith(
+  arg1: Function1<Throwable, Kind<ForMaybeK, B>>,
+  arg2: Function1<A, Kind<ForMaybeK, B>>
+): MaybeK<B> = arrow.fx.rx2.MaybeK.monadError().run {
+  this@redeemWith.redeemWith<A, B>(arg1, arg2) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("rethrow")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForMaybeK, Either<Throwable, A>>.rethrow(): MaybeK<A> =
+    arrow.fx.rx2.MaybeK.monadError().run {
+  this@rethrow.rethrow<A>() as arrow.fx.rx2.MaybeK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadError(): MaybeKMonadError = monadError_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monadFilter/MaybeKMonadFilter.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monadFilter/MaybeKMonadFilter.kt
@@ -1,0 +1,55 @@
+package arrow.fx.rx2.extensions.maybek.monadFilter
+
+import arrow.Kind
+import arrow.core.Option
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKMonadFilter
+import arrow.typeclasses.MonadFilterSyntax
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadFilter_singleton: MaybeKMonadFilter = object :
+    arrow.fx.rx2.extensions.MaybeKMonadFilter {}
+
+@JvmName("filterMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForMaybeK, A>.filterMap(arg1: Function1<A, Option<B>>): MaybeK<B> =
+    arrow.fx.rx2.MaybeK.monadFilter().run {
+  this@filterMap.filterMap<A, B>(arg1) as arrow.fx.rx2.MaybeK<B>
+}
+
+@JvmName("bindingFilter")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <B> bindingFilter(arg0: suspend MonadFilterSyntax<ForMaybeK>.() -> B): MaybeK<B> =
+    arrow.fx.rx2.MaybeK
+   .monadFilter()
+   .bindingFilter<B>(arg0) as arrow.fx.rx2.MaybeK<B>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadFilter(): MaybeKMonadFilter = monadFilter_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monadThrow/MaybeKMonadThrow.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/monadThrow/MaybeKMonadThrow.kt
@@ -1,0 +1,37 @@
+package arrow.fx.rx2.extensions.maybek.monadThrow
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.MaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKMonadThrow
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadThrow_singleton: MaybeKMonadThrow = object :
+    arrow.fx.rx2.extensions.MaybeKMonadThrow {}
+
+@JvmName("raiseNonFatal")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Throwable.raiseNonFatal(): MaybeK<A> = arrow.fx.rx2.MaybeK.monadThrow().run {
+  this@raiseNonFatal.raiseNonFatal<A>() as arrow.fx.rx2.MaybeK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadThrow(): MaybeKMonadThrow = monadThrow_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/timer/MaybeKTimer.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/timer/MaybeKTimer.kt
@@ -1,0 +1,20 @@
+package arrow.fx.rx2.extensions.maybek.timer
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKTimer
+import kotlin.PublishedApi
+import kotlin.Suppress
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val timer_singleton: MaybeKTimer = object : arrow.fx.rx2.extensions.MaybeKTimer {}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.timer(): MaybeKTimer = timer_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/unsafeRun/MaybeKUnsafeRun.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/maybek/unsafeRun/MaybeKUnsafeRun.kt
@@ -1,0 +1,59 @@
+package arrow.fx.rx2.extensions.maybek.unsafeRun
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForMaybeK
+import arrow.fx.rx2.MaybeK.Companion
+import arrow.fx.rx2.extensions.MaybeKUnsafeRun
+import arrow.unsafe
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val unsafeRun_singleton: MaybeKUnsafeRun = object : arrow.fx.rx2.extensions.MaybeKUnsafeRun
+    {}
+
+@JvmName("runBlocking")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <A> unsafe.runBlocking(arg1: Function0<Kind<ForMaybeK, A>>): A =
+    arrow.fx.rx2.MaybeK.unsafeRun().run {
+  this@runBlocking.runBlocking<A>(arg1) as A
+}
+
+@JvmName("runNonBlocking")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <A> unsafe.runNonBlocking(
+  arg1: Function0<Kind<ForMaybeK, A>>,
+  arg2: Function1<Either<Throwable, A>, Unit>
+): Unit = arrow.fx.rx2.MaybeK.unsafeRun().run {
+  this@runNonBlocking.runNonBlocking<A>(arg1, arg2) as kotlin.Unit
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.unsafeRun(): MaybeKUnsafeRun = unsafeRun_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek.kt
@@ -6,7 +6,6 @@ import arrow.core.Eval
 import arrow.core.Option
 import arrow.core.Tuple2
 import arrow.core.Tuple3
-import arrow.extension
 import arrow.fx.RacePair
 import arrow.fx.RaceTriple
 import arrow.fx.Timer
@@ -52,14 +51,12 @@ import kotlin.coroutines.CoroutineContext
 import arrow.fx.rx2.handleErrorWith as observableHandleErrorWith
 import io.reactivex.disposables.Disposable as RxDisposable
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKFunctor : Functor<ForObservableK> {
   override fun <A, B> ObservableKOf<A>.map(f: (A) -> B): ObservableK<B> =
     fix().map(f)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKApplicative : Applicative<ForObservableK> {
   override fun <A, B> ObservableKOf<A>.ap(ff: ObservableKOf<(A) -> B>): ObservableK<B> =
@@ -75,7 +72,6 @@ interface ObservableKApplicative : Applicative<ForObservableK> {
     Eval.now(fix().ap(ObservableK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKMonad : Monad<ForObservableK>, ObservableKApplicative {
   override fun <A, B> ObservableKOf<A>.ap(ff: ObservableKOf<(A) -> B>): ObservableK<B> =
@@ -94,7 +90,6 @@ interface ObservableKMonad : Monad<ForObservableK>, ObservableKApplicative {
     Eval.now(fix().ap(ObservableK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKFoldable : Foldable<ForObservableK> {
   override fun <A, B> ObservableKOf<A>.foldLeft(b: B, f: (B, A) -> B): B =
@@ -104,7 +99,6 @@ interface ObservableKFoldable : Foldable<ForObservableK> {
     fix().foldRight(lb, f)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKApplicativeError :
   ApplicativeError<ForObservableK, Throwable>,
@@ -116,7 +110,6 @@ interface ObservableKApplicativeError :
     fix().observableHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKMonadError :
   MonadError<ForObservableK, Throwable>,
@@ -128,25 +121,21 @@ interface ObservableKMonadError :
     fix().observableHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKMonadThrow : MonadThrow<ForObservableK>, ObservableKMonadError
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKBracket : Bracket<ForObservableK, Throwable>, ObservableKMonadThrow {
   override fun <A, B> ObservableKOf<A>.bracketCase(release: (A, ExitCase<Throwable>) -> ObservableKOf<Unit>, use: (A) -> ObservableKOf<B>): ObservableK<B> =
     fix().bracketCase({ use(it) }, { a, e -> release(a, e) })
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKMonadDefer : MonadDefer<ForObservableK>, ObservableKBracket {
   override fun <A> defer(fa: () -> ObservableKOf<A>): ObservableK<A> =
     ObservableK.defer(fa)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKAsync : Async<ForObservableK>, ObservableKMonadDefer {
   override fun <A> async(fa: Proc<A>): ObservableK<A> =
@@ -159,7 +148,6 @@ interface ObservableKAsync : Async<ForObservableK>, ObservableKMonadDefer {
     fix().continueOn(ctx)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKEffect : Effect<ForObservableK>, ObservableKAsync {
   override fun <A> ObservableKOf<A>.runAsync(cb: (Either<Throwable, A>) -> ObservableKOf<Unit>): ObservableK<Unit> =
@@ -238,7 +226,6 @@ interface ObservableKConcurrent : Concurrent<ForObservableK>, ObservableKAsync {
     }
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKDispatchers : Dispatchers<ForObservableK> {
   override fun default(): CoroutineContext =
@@ -253,7 +240,6 @@ fun ObservableK.Companion.concurrent(dispatchers: Dispatchers<ForObservableK> = 
   override fun dispatchers(): Dispatchers<ForObservableK> = dispatchers
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKConcurrentEffect : ConcurrentEffect<ForObservableK>, ObservableKEffect {
   override fun <A> ObservableKOf<A>.runAsyncCancellable(cb: (Either<Throwable, A>) -> ObservableKOf<Unit>): ObservableK<Disposable> =
@@ -294,7 +280,6 @@ fun ObservableK.Companion.monadErrorSwitch(): ObservableKMonadError = object : O
 fun <A> ObservableK.Companion.fx(c: suspend ConcurrentSyntax<ForObservableK>.() -> A): ObservableK<A> =
   ObservableK.concurrent().fx.concurrent(c).fix()
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKTimer : Timer<ForObservableK> {
   override fun sleep(duration: Duration): ObservableK<Unit> =
@@ -302,7 +287,6 @@ interface ObservableKTimer : Timer<ForObservableK> {
       .map { Unit })
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface ObservableKFunctorFilter : FunctorFilter<ForObservableK>, ObservableKFunctor {
   override fun <A, B> Kind<ForObservableK, A>.filterMap(f: (A) -> Option<B>): ObservableK<B> =

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/applicative/ObservableKApplicative.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/applicative/ObservableKApplicative.kt
@@ -1,0 +1,94 @@
+package arrow.fx.rx2.extensions.observablek.applicative
+
+import arrow.Kind
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKApplicative
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicative_singleton: ObservableKApplicative = object :
+    arrow.fx.rx2.extensions.ObservableKApplicative {}
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> A.just(): ObservableK<A> = arrow.fx.rx2.ObservableK.applicative().run {
+  this@just.just<A>() as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun unit(): ObservableK<Unit> = arrow.fx.rx2.ObservableK
+   .applicative()
+   .unit() as arrow.fx.rx2.ObservableK<kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.map(arg1: Function1<A, B>): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.applicative().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.replicate(arg1: Int): ObservableK<List<A>> =
+    arrow.fx.rx2.ObservableK.applicative().run {
+  this@replicate.replicate<A>(arg1) as arrow.fx.rx2.ObservableK<kotlin.collections.List<A>>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.replicate(arg1: Int, arg2: Monoid<A>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.applicative().run {
+  this@replicate.replicate<A>(arg1, arg2) as arrow.fx.rx2.ObservableK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.applicative(): ObservableKApplicative = applicative_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/applicativeError/ObservableKApplicativeError.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/applicativeError/ObservableKApplicativeError.kt
@@ -1,0 +1,176 @@
+package arrow.fx.rx2.extensions.observablek.applicativeError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.ForOption
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKApplicativeError
+import arrow.typeclasses.ApplicativeError
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicativeError_singleton: ObservableKApplicativeError = object :
+    arrow.fx.rx2.extensions.ObservableKApplicativeError {}
+
+@JvmName("handleErrorWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.handleErrorWith(
+  arg1: Function1<Throwable, Kind<ForObservableK,
+A>>
+): ObservableK<A> = arrow.fx.rx2.ObservableK.applicativeError().run {
+  this@handleErrorWith.handleErrorWith<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("raiseError1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Throwable.raiseError(): ObservableK<A> = arrow.fx.rx2.ObservableK.applicativeError().run {
+  this@raiseError.raiseError<A>() as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("fromOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForOption, A>.fromOption(arg1: Function0<Throwable>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.applicativeError().run {
+  this@fromOption.fromOption<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("fromEither")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, Throwable>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.applicativeError().run {
+  this@fromEither.fromEither<A, EE>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("handleError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.handleError(arg1: Function1<Throwable, A>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.applicativeError().run {
+  this@handleError.handleError<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("redeem")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.redeem(arg1: Function1<Throwable, B>, arg2: Function1<A, B>):
+    ObservableK<B> = arrow.fx.rx2.ObservableK.applicativeError().run {
+  this@redeem.redeem<A, B>(arg1, arg2) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("attempt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.attempt(): ObservableK<Either<Throwable, A>> =
+    arrow.fx.rx2.ObservableK.applicativeError().run {
+  this@attempt.attempt<A>() as arrow.fx.rx2.ObservableK<arrow.core.Either<kotlin.Throwable, A>>
+}
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> catch(arg0: Function1<Throwable, Throwable>, arg1: Function0<A>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK
+   .applicativeError()
+   .catch<A>(arg0, arg1) as arrow.fx.rx2.ObservableK<A>
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> ApplicativeError<ForObservableK, Throwable>.catch(arg1: Function0<A>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.applicativeError().run {
+  this@catch.catch<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <A> effectCatch(arg0: Function1<Throwable, Throwable>, arg1: suspend () -> A):
+    ObservableK<A> = arrow.fx.rx2.ObservableK
+   .applicativeError()
+   .effectCatch<A>(arg0, arg1) as arrow.fx.rx2.ObservableK<A>
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend () -> A): Kind<F, A> =
+    arrow.fx.rx2.ObservableK.applicativeError().run {
+  this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.applicativeError(): ObservableKApplicativeError = applicativeError_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/async/ObservableKAsync.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/async/ObservableKAsync.kt
@@ -1,0 +1,395 @@
+package arrow.fx.rx2.extensions.observablek.async
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKAsync
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val async_singleton: ObservableKAsync = object : arrow.fx.rx2.extensions.ObservableKAsync
+    {}
+
+/**
+ *  [async] variant that can suspend side effects in the provided registration function.
+ *
+ *  The passed in function is injected with a side-effectful callback for signaling the final result of an asynchronous process.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.*
+ *  import arrow.fx.typeclasses.Async
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.makeCompleteAndGetPromiseInAsync() =
+ *     asyncF<String> { cb: (Either<Throwable, String>) -> Unit ->
+ *       Promise.uncancellable<F, String>(this).flatMap { promise ->
+ *         promise.complete("Hello World!").flatMap {
+ *           promise.get().map { str -> cb(Right(str)) }
+ *         }
+ *       }
+ *     }
+ *
+ *   val result = ObservableK.async().makeCompleteAndGetPromiseInAsync()
+ *  //sampleEnd
+ *  println(result)
+ *  }
+ *  ```
+ *
+ *  @see async for a simpler, non suspending version.
+ */
+@JvmName("asyncF")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> asyncF(arg0: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForObservableK, Unit>>):
+    ObservableK<A> = arrow.fx.rx2.ObservableK
+   .async()
+   .asyncF<A>(arg0) as arrow.fx.rx2.ObservableK<A>
+
+/**
+ *  Continue the evaluation on provided [CoroutineContext]
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.runOnDefaultDispatcher(): Kind<F, String> =
+ *     just(Unit).continueOn(Dispatchers.Default).flatMap {
+ *       later({ Thread.currentThread().name })
+ *     }
+ *
+ *   val result = ObservableK.async().runOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("continueOn")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.continueOn(arg1: CoroutineContext): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.async().run {
+  this@continueOn.continueOn<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     later(Dispatchers.Default, { Thread.currentThread().name })
+ *
+ *   val result = ObservableK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: CoroutineContext, arg1: Function0<A>): ObservableK<A> = arrow.fx.rx2.ObservableK
+   .async()
+   .later<A>(arg0, arg1) as arrow.fx.rx2.ObservableK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = ObservableK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> effect(arg0: suspend () -> A): ObservableK<A> = arrow.fx.rx2.ObservableK
+   .async()
+   .effect<A>(arg0) as arrow.fx.rx2.ObservableK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = ObservableK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> effect(arg0: CoroutineContext, arg1: suspend () -> A): ObservableK<A> =
+    arrow.fx.rx2.ObservableK
+   .async()
+   .effect<A>(arg0, arg1) as arrow.fx.rx2.ObservableK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     defer(Dispatchers.Default, { effect { Thread.currentThread().name } })
+ *
+ *   val result = ObservableK.async().invokeOnDefaultDispatcher().fix().unsafeRunSync()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> defer(arg0: CoroutineContext, arg1: Function0<Kind<ForObservableK, A>>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK
+   .async()
+   .defer<A>(arg0, arg1) as arrow.fx.rx2.ObservableK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ */
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> laterOrRaise(arg0: CoroutineContext, arg1: Function0<Either<Throwable, A>>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK
+   .async()
+   .laterOrRaise<A>(arg0, arg1) as arrow.fx.rx2.ObservableK<A>
+
+/**
+ *  Shift evaluation to provided [CoroutineContext].
+ *
+ *  @receiver [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   ObservableK.async().run {
+ *     val result = Dispatchers.Default.shift().map {
+ *       Thread.currentThread().name
+ *     }
+ *
+ *     println(result)
+ *   }
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("shift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun CoroutineContext.shift(): ObservableK<Unit> = arrow.fx.rx2.ObservableK.async().run {
+  this@shift.shift() as arrow.fx.rx2.ObservableK<kotlin.Unit>
+}
+
+/**
+ *  Task that never finishes evaluating.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val i = ObservableK.async().never<Int>()
+ *
+ *   println(i)
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("never")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> never(): ObservableK<A> = arrow.fx.rx2.ObservableK
+   .async()
+   .never<A>() as arrow.fx.rx2.ObservableK<A>
+
+/**
+ *  Helper function that provides an easy way to construct a suspend effect
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun logAndIncrease(s: String): Int {
+ *      println(s)
+ *      return s.toInt() + 1
+ *   }
+ *
+ *   val result = ObservableK.async().effect(Dispatchers.Default) { Thread.currentThread().name }.effectMap { s: String -> logAndIncrease(s) }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effectMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.effectMap(arg1: suspend (A) -> B): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.async().run {
+  this@effectMap.effectMap<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+/**
+ *  [Async] models how a data type runs an asynchronous computation that may fail.
+ *  Defined by the [Proc] signature, which is the consumption of a callback.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.async(): ObservableKAsync = async_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/bracket/ObservableKBracket.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/bracket/ObservableKBracket.kt
@@ -1,0 +1,267 @@
+package arrow.fx.rx2.extensions.observablek.bracket
+
+import arrow.Kind
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKBracket
+import arrow.fx.typeclasses.ExitCase
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bracket_singleton: ObservableKBracket = object :
+    arrow.fx.rx2.extensions.ObservableKBracket {}
+
+/**
+ *  A way to safely acquire a resource and release in the face of errors and cancellation.
+ *  It uses [ExitCase] to distinguish between different exit cases when releasing the acquired resource.
+ *
+ *  @param use is the action to consume the resource and produce an [F] with the result.
+ *  Once the resulting [F] terminates, either successfully, error or cancelled.
+ *
+ *  @param release the allocated resource after the resulting [F] of [use] is terminates.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.rx2.extensions.observablek.monadDefer.defer
+ * import arrow.fx.rx2.extensions.observablek.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val release: (File, ExitCase<Throwable>) -> Kind<F, Unit> = { file, exitCase ->
+ *       when (exitCase) {
+ * do something * / }
+ * do something * / }
+ * do something * / }
+ *       }
+ *       closeFile(file)
+ *   }
+ *
+ *   val use: (File) -> Kind<F, String> = { file: File -> fileToString(file) }
+ *
+ *   val safeComputation = openFile("data.json").bracketCase(release, use)
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracketCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.bracketCase(
+  arg1: Function2<A, ExitCase<Throwable>,
+Kind<ForObservableK, Unit>>,
+  arg2: Function1<A, Kind<ForObservableK, B>>
+): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.bracket().run {
+  this@bracketCase.bracketCase<A, B>(arg1, arg2) as arrow.fx.rx2.ObservableK<B>
+}
+
+/**
+ *  Meant for specifying tasks with safe resource acquisition and release in the face of errors and interruption.
+ *  It would be the the equivalent of `try/catch/finally` statements in mainstream imperative languages for resource
+ *  acquisition and release.
+ *
+ *  @param release is the action that's supposed to release the allocated resource after `use` is done, irregardless
+ *  of its exit condition.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.observablek.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.rx2.extensions.observablek.monadDefer.defer
+ * import arrow.fx.rx2.extensions.observablek.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val safeComputation = openFile("data.json").bracket({ file: File -> closeFile(file) }, { file -> fileToString(file) })
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracket")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.bracket(
+  arg1: Function1<A, Kind<ForObservableK, Unit>>,
+  arg2: Function1<A, Kind<ForObservableK, B>>
+): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.bracket().run {
+  this@bracket.bracket<A, B>(arg1, arg2) as arrow.fx.rx2.ObservableK<B>
+}
+
+/**
+ *  Meant for ensuring a given task continues execution even when interrupted.
+ */
+@JvmName("uncancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.uncancellable(): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.bracket().run {
+  this@uncancellable.uncancellable<A>() as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("uncancelable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.uncancelable(): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.bracket().run {
+  this@uncancelable.uncancelable<A>() as arrow.fx.rx2.ObservableK<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracket] for the acquisition and release of resources.
+ *
+ *  @see [guaranteeCase] for the version that can discriminate between termination conditions
+ *
+ *  @see [bracket] for the more general operation
+ */
+@JvmName("guarantee")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.guarantee(arg1: Kind<ForObservableK, Unit>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.bracket().run {
+  this@guarantee.guarantee<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled, allowing
+ *  for differentiating between exit conditions. That's thanks to the [ExitCase] argument of the finalizer.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracketCase] for the acquisition and release of resources.
+ *
+ *  @see [guarantee] for the simpler version
+ *
+ *  @see [bracketCase] for the more general operation
+ */
+@JvmName("guaranteeCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.guaranteeCase(
+  arg1: Function1<ExitCase<Throwable>,
+Kind<ForObservableK, Unit>>
+): ObservableK<A> = arrow.fx.rx2.ObservableK.bracket().run {
+  this@guaranteeCase.guaranteeCase<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+/**
+ *  Executes the given [finalizer] when the source is cancelled, allowing registering a cancellation token.
+ *
+ *  Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
+ */
+@JvmName("onCancel")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.onCancel(arg1: Kind<ForObservableK, Unit>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.bracket().run {
+  this@onCancel.onCancel<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+/**
+ *  Executes the given `finalizer` with the given error when the source is finished in error.
+ */
+@JvmName("onError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.onError(arg1: Function1<Throwable, Kind<ForObservableK, Unit>>):
+    ObservableK<A> = arrow.fx.rx2.ObservableK.bracket().run {
+  this@onError.onError<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+/**
+ *  Extension of MonadError exposing the [bracket] operation, a generalized abstracted pattern of safe resource
+ *  acquisition and release in the face of errors or interruption.
+ *
+ *  @define The functions receiver here (Kind<F, A>) would stand for the "acquireParam", and stands for an action that
+ *  "acquires" some expensive resource, that needs to be used and then discarded.
+ *
+ *  @define use is the action that uses the newly allocated resource and that will provide the final result.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.bracket(): ObservableKBracket = bracket_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/concurrentEffect/ObservableKConcurrentEffect.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/concurrentEffect/ObservableKConcurrentEffect.kt
@@ -1,0 +1,48 @@
+package arrow.fx.rx2.extensions.observablek.concurrentEffect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKConcurrentEffect
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val concurrentEffect_singleton: ObservableKConcurrentEffect = object :
+    arrow.fx.rx2.extensions.ObservableKConcurrentEffect {}
+
+@JvmName("runAsyncCancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.runAsyncCancellable(
+  arg1: Function1<Either<Throwable, A>,
+Kind<ForObservableK, Unit>>
+): ObservableK<Function0<Unit>> =
+    arrow.fx.rx2.ObservableK.concurrentEffect().run {
+  this@runAsyncCancellable.runAsyncCancellable<A>(arg1) as
+    arrow.fx.rx2.ObservableK<kotlin.Function0<kotlin.Unit>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.concurrentEffect(): ObservableKConcurrentEffect = concurrentEffect_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/dispatchers/ObservableKDispatchers.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/dispatchers/ObservableKDispatchers.kt
@@ -1,0 +1,48 @@
+package arrow.fx.rx2.extensions.observablek.dispatchers
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKDispatchers
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val dispatchers_singleton: ObservableKDispatchers = object :
+    arrow.fx.rx2.extensions.ObservableKDispatchers {}
+
+@JvmName("default")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun default(): CoroutineContext = arrow.fx.rx2.ObservableK
+   .dispatchers()
+   .default() as kotlin.coroutines.CoroutineContext
+
+@JvmName("io")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun io(): CoroutineContext = arrow.fx.rx2.ObservableK
+   .dispatchers()
+   .io() as kotlin.coroutines.CoroutineContext
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.dispatchers(): ObservableKDispatchers = dispatchers_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/effect/ObservableKEffect.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/effect/ObservableKEffect.kt
@@ -1,0 +1,45 @@
+package arrow.fx.rx2.extensions.observablek.effect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKEffect
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val effect_singleton: ObservableKEffect = object :
+    arrow.fx.rx2.extensions.ObservableKEffect {}
+
+@JvmName("runAsync")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.runAsync(
+  arg1: Function1<Either<Throwable, A>, Kind<ForObservableK,
+Unit>>
+): ObservableK<Unit> = arrow.fx.rx2.ObservableK.effect().run {
+  this@runAsync.runAsync<A>(arg1) as arrow.fx.rx2.ObservableK<kotlin.Unit>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.effect(): ObservableKEffect = effect_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/foldable/ObservableKFoldable.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/foldable/ObservableKFoldable.kt
@@ -1,0 +1,426 @@
+package arrow.fx.rx2.extensions.observablek.foldable
+
+import arrow.Kind
+import arrow.core.Eval
+import arrow.core.Option
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKFoldable
+import arrow.typeclasses.Applicative
+import arrow.typeclasses.Monad
+import arrow.typeclasses.Monoid
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.Long
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val foldable_singleton: ObservableKFoldable = object :
+  arrow.fx.rx2.extensions.ObservableKFoldable {}
+
+@JvmName("foldLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.foldLeft(arg1: B, arg2: Function2<B, A, B>): B =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@foldLeft.foldLeft<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("foldRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.foldRight(arg1: Eval<B>, arg2: Function2<A, Eval<B>, Eval<B>>):
+  Eval<B> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@foldRight.foldRight<A, B>(arg1, arg2) as arrow.core.Eval<B>
+}
+
+@JvmName("fold")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.fold(arg1: Monoid<A>): A = arrow.fx.rx2.ObservableK.foldable().run {
+  this@fold.fold<A>(arg1) as A
+}
+
+@JvmName("reduceLeftToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.reduceLeftToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<B, A,
+    B>
+): Option<B> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@reduceLeftToOption.reduceLeftToOption<A, B>(arg1, arg2) as arrow.core.Option<B>
+}
+
+@JvmName("reduceRightToOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.reduceRightToOption(
+  arg1: Function1<A, B>,
+  arg2: Function2<A,
+    Eval<B>, Eval<B>>
+): Eval<Option<B>> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@reduceRightToOption.reduceRightToOption<A, B>(arg1, arg2) as
+    arrow.core.Eval<arrow.core.Option<B>>
+}
+
+@JvmName("reduceLeftOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.reduceLeftOption(arg1: Function2<A, A, A>): Option<A> =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@reduceLeftOption.reduceLeftOption<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("reduceRightOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.reduceRightOption(arg1: Function2<A, Eval<A>, Eval<A>>):
+  Eval<Option<A>> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@reduceRightOption.reduceRightOption<A>(arg1) as arrow.core.Eval<arrow.core.Option<A>>
+}
+
+@JvmName("combineAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.combineAll(arg1: Monoid<A>): A =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@combineAll.combineAll<A>(arg1) as A
+  }
+
+@JvmName("foldMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.foldMap(arg1: Monoid<B>, arg2: Function1<A, B>): B =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@foldMap.foldMap<A, B>(arg1, arg2) as B
+  }
+
+@JvmName("orEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> orEmpty(arg0: Applicative<ForObservableK>, arg1: Monoid<A>): ObservableK<A> =
+  arrow.fx.rx2.ObservableK
+    .foldable()
+    .orEmpty<A>(arg0, arg1) as arrow.fx.rx2.ObservableK<A>
+
+@JvmName("traverse_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B> Kind<ForObservableK, A>.traverse_(
+  arg1: Applicative<G>,
+  arg2: Function1<A, Kind<G,
+    B>>
+): Kind<G, Unit> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@traverse_.traverse_<G, A, B>(arg1, arg2) as arrow.Kind<G, kotlin.Unit>
+}
+
+@JvmName("sequence_")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A> Kind<ForObservableK, Kind<G, A>>.sequence_(arg1: Applicative<G>): Kind<G, Unit> =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@sequence_.sequence_<G, A>(arg1) as arrow.Kind<G, kotlin.Unit>
+  }
+
+@JvmName("find")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.find(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@find.find<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("exists")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.exists(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@exists.exists<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("forAll")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.forAll(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@forAll.forAll<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("all")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.all(arg1: Function1<A, Boolean>): Boolean =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@all.all<A>(arg1) as kotlin.Boolean
+  }
+
+@JvmName("isEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.isEmpty(): Boolean = arrow.fx.rx2.ObservableK.foldable().run {
+  this@isEmpty.isEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("nonEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.nonEmpty(): Boolean = arrow.fx.rx2.ObservableK.foldable().run {
+  this@nonEmpty.nonEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("isNotEmpty")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.isNotEmpty(): Boolean = arrow.fx.rx2.ObservableK.foldable().run {
+  this@isNotEmpty.isNotEmpty<A>() as kotlin.Boolean
+}
+
+@JvmName("size")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.size(arg1: Monoid<Long>): Long =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@size.size<A>(arg1) as kotlin.Long
+  }
+
+@JvmName("foldMapA")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B, AP : Applicative<G>, MO : Monoid<B>> Kind<ForObservableK, A>.foldMapA(
+  arg1: AP,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@foldMapA.foldMapA<G, A, B, AP, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldMapM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B, MA : Monad<G>, MO : Monoid<B>> Kind<ForObservableK, A>.foldMapM(
+  arg1: MA,
+  arg2: MO,
+  arg3: Function1<A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@foldMapM.foldMapM<G, A, B, MA, MO>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("foldM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <G, A, B> Kind<ForObservableK, A>.foldM(
+  arg1: Monad<G>,
+  arg2: B,
+  arg3: Function2<B, A, Kind<G, B>>
+): Kind<G, B> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@foldM.foldM<G, A, B>(arg1, arg2, arg3) as arrow.Kind<G, B>
+}
+
+@JvmName("get")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.get(arg1: Long): Option<A> =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@get.get<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.firstOption(): Option<A> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@firstOption.firstOption<A>() as arrow.core.Option<A>
+}
+
+@JvmName("firstOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.firstOption(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@firstOption.firstOption<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.firstOrNone(): Option<A> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@firstOrNone.firstOrNone<A>() as arrow.core.Option<A>
+}
+
+@JvmName("firstOrNone")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.firstOrNone(arg1: Function1<A, Boolean>): Option<A> =
+  arrow.fx.rx2.ObservableK.foldable().run {
+    this@firstOrNone.firstOrNone<A>(arg1) as arrow.core.Option<A>
+  }
+
+@JvmName("toList")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.toList(): List<A> = arrow.fx.rx2.ObservableK.foldable().run {
+  this@toList.toList<A>() as kotlin.collections.List<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.foldable(): ObservableKFoldable = foldable_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/functor/ObservableKFunctor.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/functor/ObservableKFunctor.kt
@@ -1,0 +1,159 @@
+package arrow.fx.rx2.extensions.observablek.functor
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKFunctor
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: ObservableKFunctor = object :
+    arrow.fx.rx2.extensions.ObservableKFunctor {}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.map(arg1: Function1<A, B>): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.functor().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>):
+    ObservableK<B> = arrow.fx.rx2.ObservableK.functor().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForObservableK, A>, Kind<ForObservableK, B>> =
+    arrow.fx.rx2.ObservableK
+   .functor()
+   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.fx.rx2.ForObservableK, A>,
+    arrow.Kind<arrow.fx.rx2.ForObservableK, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.void(): ObservableK<Unit> = arrow.fx.rx2.ObservableK.functor().run {
+  this@void.void<A>() as arrow.fx.rx2.ObservableK<kotlin.Unit>
+}
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.fproduct(arg1: Function1<A, B>): ObservableK<Tuple2<A, B>> =
+    arrow.fx.rx2.ObservableK.functor().run {
+  this@fproduct.fproduct<A, B>(arg1) as arrow.fx.rx2.ObservableK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.mapConst(arg1: B): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> A.mapConst(arg1: Kind<ForObservableK, B>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.tupleLeft(arg1: B): ObservableK<Tuple2<B, A>> =
+    arrow.fx.rx2.ObservableK.functor().run {
+  this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.fx.rx2.ObservableK<arrow.core.Tuple2<B, A>>
+}
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.tupleRight(arg1: B): ObservableK<Tuple2<A, B>> =
+    arrow.fx.rx2.ObservableK.functor().run {
+  this@tupleRight.tupleRight<A, B>(arg1) as arrow.fx.rx2.ObservableK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <B, A : B> Kind<ForObservableK, A>.widen(): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.functor().run {
+  this@widen.widen<B, A>() as arrow.fx.rx2.ObservableK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.functor(): ObservableKFunctor = functor_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/functorFilter/ObservableKFunctorFilter.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/functorFilter/ObservableKFunctorFilter.kt
@@ -1,0 +1,82 @@
+package arrow.fx.rx2.extensions.observablek.functorFilter
+
+import arrow.Kind
+import arrow.core.Option
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKFunctorFilter
+import java.lang.Class
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functorFilter_singleton: ObservableKFunctorFilter = object :
+    arrow.fx.rx2.extensions.ObservableKFunctorFilter {}
+
+@JvmName("filterMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.filterMap(arg1: Function1<A, Option<B>>): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.functorFilter().run {
+  this@filterMap.filterMap<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("flattenOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, Option<A>>.flattenOption(): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.functorFilter().run {
+  this@flattenOption.flattenOption<A>() as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("filter")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.filter(arg1: Function1<A, Boolean>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.functorFilter().run {
+  this@filter.filter<A>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("filterIsInstance")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.filterIsInstance(arg1: Class<B>): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.functorFilter().run {
+  this@filterIsInstance.filterIsInstance<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.functorFilter(): ObservableKFunctorFilter = functorFilter_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/monad/ObservableKMonad.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/monad/ObservableKMonad.kt
@@ -1,0 +1,269 @@
+package arrow.fx.rx2.extensions.observablek.monad
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.Tuple2
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKMonad
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monad_singleton: ObservableKMonad = object : arrow.fx.rx2.extensions.ObservableKMonad
+    {}
+
+@JvmName("flatMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.flatMap(arg1: Function1<A, Kind<ForObservableK, B>>):
+    ObservableK<B> = arrow.fx.rx2.ObservableK.monad().run {
+  this@flatMap.flatMap<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("tailRecM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForObservableK, Either<A, B>>>): ObservableK<B> =
+    arrow.fx.rx2.ObservableK
+   .monad()
+   .tailRecM<A, B>(arg0, arg1) as arrow.fx.rx2.ObservableK<B>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.map(arg1: Function1<A, B>): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.monad().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.ap(arg1: Kind<ForObservableK, Function1<A, B>>): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.monad().run {
+  this@ap.ap<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("flatten")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, Kind<ForObservableK, A>>.flatten(): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.monad().run {
+  this@flatten.flatten<A>() as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.followedBy(arg1: Kind<ForObservableK, B>): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.monad().run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.apTap(arg1: Kind<ForObservableK, B>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.monad().run {
+  this@apTap.apTap<A, B>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("followedByEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.followedByEval(arg1: Eval<Kind<ForObservableK, B>>):
+    ObservableK<B> = arrow.fx.rx2.ObservableK.monad().run {
+  this@followedByEval.followedByEval<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("effectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.effectM(arg1: Function1<A, Kind<ForObservableK, B>>):
+    ObservableK<A> = arrow.fx.rx2.ObservableK.monad().run {
+  this@effectM.effectM<A, B>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("flatTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.flatTap(arg1: Function1<A, Kind<ForObservableK, B>>):
+    ObservableK<A> = arrow.fx.rx2.ObservableK.monad().run {
+  this@flatTap.flatTap<A, B>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("productL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.productL(arg1: Kind<ForObservableK, B>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.monad().run {
+  this@productL.productL<A, B>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("forEffect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.forEffect(arg1: Kind<ForObservableK, B>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.monad().run {
+  this@forEffect.forEffect<A, B>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("productLEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.productLEval(arg1: Eval<Kind<ForObservableK, B>>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.monad().run {
+  this@productLEval.productLEval<A, B>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("forEffectEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.forEffectEval(arg1: Eval<Kind<ForObservableK, B>>):
+    ObservableK<A> = arrow.fx.rx2.ObservableK.monad().run {
+  this@forEffectEval.forEffectEval<A, B>(arg1) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("mproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.mproduct(arg1: Function1<A, Kind<ForObservableK, B>>):
+    ObservableK<Tuple2<A, B>> = arrow.fx.rx2.ObservableK.monad().run {
+  this@mproduct.mproduct<A, B>(arg1) as arrow.fx.rx2.ObservableK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("ifM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <B> Kind<ForObservableK, Boolean>.ifM(
+  arg1: Function0<Kind<ForObservableK, B>>,
+  arg2: Function0<Kind<ForObservableK, B>>
+): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.monad().run {
+  this@ifM.ifM<B>(arg1, arg2) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("selectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, Either<A, B>>.selectM(arg1: Kind<ForObservableK, Function1<A, B>>):
+    ObservableK<B> = arrow.fx.rx2.ObservableK.monad().run {
+  this@selectM.selectM<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, Either<A, B>>.select(arg1: Kind<ForObservableK, Function1<A, B>>):
+    ObservableK<B> = arrow.fx.rx2.ObservableK.monad().run {
+  this@select.select<A, B>(arg1) as arrow.fx.rx2.ObservableK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monad(): ObservableKMonad = monad_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/monadDefer/ObservableKMonadDefer.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/monadDefer/ObservableKMonadDefer.kt
@@ -1,0 +1,104 @@
+package arrow.fx.rx2.extensions.observablek.monadDefer
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.Ref
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKMonadDefer
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadDefer_singleton: ObservableKMonadDefer = object :
+    arrow.fx.rx2.extensions.ObservableKMonadDefer {}
+
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> defer(arg0: Function0<Kind<ForObservableK, A>>): ObservableK<A> = arrow.fx.rx2.ObservableK
+   .monadDefer()
+   .defer<A>(arg0) as arrow.fx.rx2.ObservableK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: Function0<A>): ObservableK<A> = arrow.fx.rx2.ObservableK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.rx2.ObservableK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: Kind<ForObservableK, A>): ObservableK<A> = arrow.fx.rx2.ObservableK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.rx2.ObservableK<A>
+
+@JvmName("lazy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun lazy(): ObservableK<Unit> = arrow.fx.rx2.ObservableK
+   .monadDefer()
+   .lazy() as arrow.fx.rx2.ObservableK<kotlin.Unit>
+
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> laterOrRaise(arg0: Function0<Either<Throwable, A>>): ObservableK<A> =
+    arrow.fx.rx2.ObservableK
+   .monadDefer()
+   .laterOrRaise<A>(arg0) as arrow.fx.rx2.ObservableK<A>
+
+@JvmName("Ref")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Ref(arg0: A): ObservableK<Ref<ForObservableK, A>> = arrow.fx.rx2.ObservableK
+   .monadDefer()
+   .Ref<A>(arg0) as arrow.fx.rx2.ObservableK<arrow.fx.Ref<arrow.fx.rx2.ForObservableK, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadDefer(): ObservableKMonadDefer = monadDefer_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/monadError/ObservableKMonadError.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/monadError/ObservableKMonadError.kt
@@ -1,0 +1,73 @@
+package arrow.fx.rx2.extensions.observablek.monadError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForObservableK
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKMonadError
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadError_singleton: ObservableKMonadError = object :
+    arrow.fx.rx2.extensions.ObservableKMonadError {}
+
+@JvmName("ensure")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, A>.ensure(arg1: Function0<Throwable>, arg2: Function1<A, Boolean>):
+    ObservableK<A> = arrow.fx.rx2.ObservableK.monadError().run {
+  this@ensure.ensure<A>(arg1, arg2) as arrow.fx.rx2.ObservableK<A>
+}
+
+@JvmName("redeemWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForObservableK, A>.redeemWith(
+  arg1: Function1<Throwable, Kind<ForObservableK, B>>,
+  arg2: Function1<A, Kind<ForObservableK, B>>
+): ObservableK<B> =
+    arrow.fx.rx2.ObservableK.monadError().run {
+  this@redeemWith.redeemWith<A, B>(arg1, arg2) as arrow.fx.rx2.ObservableK<B>
+}
+
+@JvmName("rethrow")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForObservableK, Either<Throwable, A>>.rethrow(): ObservableK<A> =
+    arrow.fx.rx2.ObservableK.monadError().run {
+  this@rethrow.rethrow<A>() as arrow.fx.rx2.ObservableK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadError(): ObservableKMonadError = monadError_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/monadThrow/ObservableKMonadThrow.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/monadThrow/ObservableKMonadThrow.kt
@@ -1,0 +1,37 @@
+package arrow.fx.rx2.extensions.observablek.monadThrow
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ObservableK
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKMonadThrow
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadThrow_singleton: ObservableKMonadThrow = object :
+    arrow.fx.rx2.extensions.ObservableKMonadThrow {}
+
+@JvmName("raiseNonFatal")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Throwable.raiseNonFatal(): ObservableK<A> = arrow.fx.rx2.ObservableK.monadThrow().run {
+  this@raiseNonFatal.raiseNonFatal<A>() as arrow.fx.rx2.ObservableK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadThrow(): ObservableKMonadThrow = monadThrow_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/timer/ObservableKTimer.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/observablek/timer/ObservableKTimer.kt
@@ -1,0 +1,21 @@
+package arrow.fx.rx2.extensions.observablek.timer
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ObservableK.Companion
+import arrow.fx.rx2.extensions.ObservableKTimer
+import kotlin.PublishedApi
+import kotlin.Suppress
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val timer_singleton: ObservableKTimer = object : arrow.fx.rx2.extensions.ObservableKTimer
+    {}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.timer(): ObservableKTimer = timer_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek.kt
@@ -28,7 +28,6 @@ import arrow.fx.typeclasses.Fiber
 import arrow.fx.typeclasses.MonadDefer
 import arrow.fx.typeclasses.Proc
 import arrow.fx.typeclasses.ProcF
-import arrow.extension
 import arrow.fx.internal.AtomicBooleanW
 import arrow.fx.rx2.DeprecateRxJava
 import arrow.fx.rx2.asScheduler
@@ -53,14 +52,12 @@ import kotlin.coroutines.CoroutineContext
 import io.reactivex.disposables.Disposable as RxDisposable
 import arrow.fx.rx2.handleErrorWith as singleHandleErrorWith
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKFunctor : Functor<ForSingleK> {
   override fun <A, B> SingleKOf<A>.map(f: (A) -> B): SingleK<B> =
     fix().map(f)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKApplicative : Applicative<ForSingleK> {
   override fun <A, B> SingleKOf<A>.ap(ff: SingleKOf<(A) -> B>): SingleK<B> =
@@ -76,7 +73,6 @@ interface SingleKApplicative : Applicative<ForSingleK> {
     Eval.now(fix().ap(SingleK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKMonad : Monad<ForSingleK>, SingleKApplicative {
   override fun <A, B> SingleKOf<A>.ap(ff: SingleKOf<(A) -> B>): SingleK<B> =
@@ -95,7 +91,6 @@ interface SingleKMonad : Monad<ForSingleK>, SingleKApplicative {
     Eval.now(fix().ap(SingleK.defer { ff.value() }))
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKApplicativeError :
   ApplicativeError<ForSingleK, Throwable>,
@@ -107,7 +102,6 @@ interface SingleKApplicativeError :
     fix().singleHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKMonadError :
   MonadError<ForSingleK, Throwable>,
@@ -119,25 +113,21 @@ interface SingleKMonadError :
     fix().singleHandleErrorWith { f(it).fix() }
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKMonadThrow : MonadThrow<ForSingleK>, SingleKMonadError
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKBracket : Bracket<ForSingleK, Throwable>, SingleKMonadThrow {
   override fun <A, B> SingleKOf<A>.bracketCase(release: (A, ExitCase<Throwable>) -> SingleKOf<Unit>, use: (A) -> SingleKOf<B>): SingleK<B> =
     fix().bracketCase({ use(it) }, { a, e -> release(a, e) })
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKMonadDefer : MonadDefer<ForSingleK>, SingleKBracket {
   override fun <A> defer(fa: () -> SingleKOf<A>): SingleK<A> =
     SingleK.defer(fa)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKAsync :
   Async<ForSingleK>,
@@ -152,7 +142,6 @@ interface SingleKAsync :
     fix().continueOn(ctx)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKEffect :
   Effect<ForSingleK>,
@@ -259,7 +248,6 @@ fun SingleK.Companion.concurrent(dispatchers: Dispatchers<ForSingleK> = SingleK.
   override fun dispatchers(): Dispatchers<ForSingleK> = dispatchers
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKDispatchers : Dispatchers<ForSingleK> {
   override fun default(): CoroutineContext =
@@ -269,14 +257,12 @@ interface SingleKDispatchers : Dispatchers<ForSingleK> {
     IOScheduler
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKConcurrentEffect : ConcurrentEffect<ForSingleK>, SingleKEffect {
   override fun <A> SingleKOf<A>.runAsyncCancellable(cb: (Either<Throwable, A>) -> SingleKOf<Unit>): SingleK<Disposable> =
     fix().runAsyncCancellable(cb)
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKTimer : Timer<ForSingleK> {
   override fun sleep(duration: Duration): SingleK<Unit> =
@@ -284,7 +270,6 @@ interface SingleKTimer : Timer<ForSingleK> {
       .map { Unit })
 }
 
-@extension
 @Deprecated(DeprecateRxJava)
 interface SingleKUnsafeRun : UnsafeRun<ForSingleK> {
 

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/applicative/SingleKApplicative.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/applicative/SingleKApplicative.kt
@@ -1,0 +1,94 @@
+package arrow.fx.rx2.extensions.singlek.applicative
+
+import arrow.Kind
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKApplicative
+import arrow.typeclasses.Monoid
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Int
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.List
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicative_singleton: SingleKApplicative = object :
+    arrow.fx.rx2.extensions.SingleKApplicative {}
+
+@JvmName("just1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> A.just(): SingleK<A> = arrow.fx.rx2.SingleK.applicative().run {
+  this@just.just<A>() as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("unit")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun unit(): SingleK<Unit> = arrow.fx.rx2.SingleK
+   .applicative()
+   .unit() as arrow.fx.rx2.SingleK<kotlin.Unit>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.map(arg1: Function1<A, B>): SingleK<B> =
+    arrow.fx.rx2.SingleK.applicative().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.replicate(arg1: Int): SingleK<List<A>> =
+    arrow.fx.rx2.SingleK.applicative().run {
+  this@replicate.replicate<A>(arg1) as arrow.fx.rx2.SingleK<kotlin.collections.List<A>>
+}
+
+@JvmName("replicate")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.replicate(arg1: Int, arg2: Monoid<A>): SingleK<A> =
+    arrow.fx.rx2.SingleK.applicative().run {
+  this@replicate.replicate<A>(arg1, arg2) as arrow.fx.rx2.SingleK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.applicative(): SingleKApplicative = applicative_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/applicativeError/SingleKApplicativeError.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/applicativeError/SingleKApplicativeError.kt
@@ -1,0 +1,174 @@
+package arrow.fx.rx2.extensions.singlek.applicativeError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.ForOption
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKApplicativeError
+import arrow.typeclasses.ApplicativeError
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val applicativeError_singleton: SingleKApplicativeError = object :
+    arrow.fx.rx2.extensions.SingleKApplicativeError {}
+
+@JvmName("handleErrorWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.handleErrorWith(arg1: Function1<Throwable, Kind<ForSingleK, A>>):
+    SingleK<A> = arrow.fx.rx2.SingleK.applicativeError().run {
+  this@handleErrorWith.handleErrorWith<A>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("raiseError1")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Throwable.raiseError(): SingleK<A> = arrow.fx.rx2.SingleK.applicativeError().run {
+  this@raiseError.raiseError<A>() as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("fromOption")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForOption, A>.fromOption(arg1: Function0<Throwable>): SingleK<A> =
+    arrow.fx.rx2.SingleK.applicativeError().run {
+  this@fromOption.fromOption<A>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("fromEither")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, EE> Either<EE, A>.fromEither(arg1: Function1<EE, Throwable>): SingleK<A> =
+    arrow.fx.rx2.SingleK.applicativeError().run {
+  this@fromEither.fromEither<A, EE>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("handleError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.handleError(arg1: Function1<Throwable, A>): SingleK<A> =
+    arrow.fx.rx2.SingleK.applicativeError().run {
+  this@handleError.handleError<A>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("redeem")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.redeem(arg1: Function1<Throwable, B>, arg2: Function1<A, B>):
+    SingleK<B> = arrow.fx.rx2.SingleK.applicativeError().run {
+  this@redeem.redeem<A, B>(arg1, arg2) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("attempt")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.attempt(): SingleK<Either<Throwable, A>> =
+    arrow.fx.rx2.SingleK.applicativeError().run {
+  this@attempt.attempt<A>() as arrow.fx.rx2.SingleK<arrow.core.Either<kotlin.Throwable, A>>
+}
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> catch(arg0: Function1<Throwable, Throwable>, arg1: Function0<A>): SingleK<A> =
+    arrow.fx.rx2.SingleK
+   .applicativeError()
+   .catch<A>(arg0, arg1) as arrow.fx.rx2.SingleK<A>
+
+@JvmName("catch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> ApplicativeError<ForSingleK, Throwable>.catch(arg1: Function0<A>): SingleK<A> =
+    arrow.fx.rx2.SingleK.applicativeError().run {
+  this@catch.catch<A>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <A> effectCatch(arg0: Function1<Throwable, Throwable>, arg1: suspend () -> A):
+    SingleK<A> = arrow.fx.rx2.SingleK
+   .applicativeError()
+   .effectCatch<A>(arg0, arg1) as arrow.fx.rx2.SingleK<A>
+
+@JvmName("effectCatch")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <F, A> ApplicativeError<F, Throwable>.effectCatch(arg1: suspend () -> A): Kind<F, A> =
+    arrow.fx.rx2.SingleK.applicativeError().run {
+  this@effectCatch.effectCatch<F, A>(arg1) as arrow.Kind<F, A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.applicativeError(): SingleKApplicativeError = applicativeError_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/async/SingleKAsync.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/async/SingleKAsync.kt
@@ -1,0 +1,393 @@
+package arrow.fx.rx2.extensions.singlek.async
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKAsync
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val async_singleton: SingleKAsync = object : arrow.fx.rx2.extensions.SingleKAsync {}
+
+/**
+ *  [async] variant that can suspend side effects in the provided registration function.
+ *
+ *  The passed in function is injected with a side-effectful callback for signaling the final result of an asynchronous process.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.*
+ *  import arrow.fx.typeclasses.Async
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.makeCompleteAndGetPromiseInAsync() =
+ *     asyncF<String> { cb: (Either<Throwable, String>) -> Unit ->
+ *       Promise.uncancellable<F, String>(this).flatMap { promise ->
+ *         promise.complete("Hello World!").flatMap {
+ *           promise.get().map { str -> cb(Right(str)) }
+ *         }
+ *       }
+ *     }
+ *
+ *   val result = SingleK.async().makeCompleteAndGetPromiseInAsync()
+ *  //sampleEnd
+ *  println(result)
+ *  }
+ *  ```
+ *
+ *  @see async for a simpler, non suspending version.
+ */
+@JvmName("asyncF")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> asyncF(arg0: Function1<Function1<Either<Throwable, A>, Unit>, Kind<ForSingleK, Unit>>):
+  SingleK<A> = arrow.fx.rx2.SingleK
+  .async()
+  .asyncF<A>(arg0) as arrow.fx.rx2.SingleK<A>
+
+/**
+ *  Continue the evaluation on provided [CoroutineContext]
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.runOnDefaultDispatcher(): Kind<F, String> =
+ *     just(Unit).continueOn(Dispatchers.Default).flatMap {
+ *       later({ Thread.currentThread().name })
+ *     }
+ *
+ *   val result = SingleK.async().runOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("continueOn")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.continueOn(arg1: CoroutineContext): SingleK<A> =
+  arrow.fx.rx2.SingleK.async().run {
+    this@continueOn.continueOn<A>(arg1) as arrow.fx.rx2.SingleK<A>
+  }
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     later(Dispatchers.Default, { Thread.currentThread().name })
+ *
+ *   val result = SingleK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: CoroutineContext, arg1: Function0<A>): SingleK<A> = arrow.fx.rx2.SingleK
+  .async()
+  .later<A>(arg0, arg1) as arrow.fx.rx2.SingleK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = SingleK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> effect(arg0: suspend () -> A): SingleK<A> = arrow.fx.rx2.SingleK
+  .async()
+  .effect<A>(arg0) as arrow.fx.rx2.SingleK<A>
+
+/**
+ *  Delay a suspended effect on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun getThreadSuspended(): String = Thread.currentThread().name
+ *
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     effect(Dispatchers.Default, { getThreadSuspended() })
+ *
+ *   val result = SingleK.async().invokeOnDefaultDispatcher()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> effect(arg0: CoroutineContext, arg1: suspend () -> A): SingleK<A> = arrow.fx.rx2.SingleK
+  .async()
+  .effect<A>(arg0, arg1) as arrow.fx.rx2.SingleK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   fun <F> Async<F>.invokeOnDefaultDispatcher(): Kind<F, String> =
+ *     defer(Dispatchers.Default, { effect { Thread.currentThread().name } })
+ *
+ *   val result = SingleK.async().invokeOnDefaultDispatcher().fix().unsafeRunSync()
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> defer(arg0: CoroutineContext, arg1: Function0<Kind<ForSingleK, A>>): SingleK<A> =
+  arrow.fx.rx2.SingleK
+    .async()
+    .defer<A>(arg0, arg1) as arrow.fx.rx2.SingleK<A>
+
+/**
+ *  Delay a computation on provided [CoroutineContext].
+ *
+ *  @param ctx [CoroutineContext] to run evaluation on.
+ */
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> laterOrRaise(arg0: CoroutineContext, arg1: Function0<Either<Throwable, A>>): SingleK<A> =
+  arrow.fx.rx2.SingleK
+    .async()
+    .laterOrRaise<A>(arg0, arg1) as arrow.fx.rx2.SingleK<A>
+
+/**
+ *  Shift evaluation to provided [CoroutineContext].
+ *
+ *  @receiver [CoroutineContext] to run evaluation on.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   SingleK.async().run {
+ *     val result = Dispatchers.Default.shift().map {
+ *       Thread.currentThread().name
+ *     }
+ *
+ *     println(result)
+ *   }
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("shift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun CoroutineContext.shift(): SingleK<Unit> = arrow.fx.rx2.SingleK.async().run {
+  this@shift.shift() as arrow.fx.rx2.SingleK<kotlin.Unit>
+}
+
+/**
+ *  Task that never finishes evaluating.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.async.*
+ * import arrow.core.*
+ *
+ *
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val i = SingleK.async().never<Int>()
+ *
+ *   println(i)
+ *   //sampleEnd
+ *  }
+ *  ```
+ */
+@JvmName("never")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> never(): SingleK<A> = arrow.fx.rx2.SingleK
+  .async()
+  .never<A>() as arrow.fx.rx2.SingleK<A>
+
+/**
+ *  Helper function that provides an easy way to construct a suspend effect
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.async.*
+ * import arrow.core.*
+ *
+ *
+ *  import kotlinx.coroutines.Dispatchers
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   suspend fun logAndIncrease(s: String): Int {
+ *      println(s)
+ *      return s.toInt() + 1
+ *   }
+ *
+ *   val result = SingleK.async().effect(Dispatchers.Default) { Thread.currentThread().name }.effectMap { s: String -> logAndIncrease(s) }
+ *   //sampleEnd
+ *   println(result)
+ *  }
+ *  ```
+ */
+@JvmName("effectMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.effectMap(arg1: suspend (A) -> B): SingleK<B> =
+  arrow.fx.rx2.SingleK.async().run {
+    this@effectMap.effectMap<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+  }
+
+/**
+ *  [Async] models how a data type runs an asynchronous computation that may fail.
+ *  Defined by the [Proc] signature, which is the consumption of a callback.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.async(): SingleKAsync = async_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/bracket/SingleKBracket.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/bracket/SingleKBracket.kt
@@ -1,0 +1,263 @@
+package arrow.fx.rx2.extensions.singlek.bracket
+
+import arrow.Kind
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKBracket
+import arrow.fx.typeclasses.ExitCase
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.Function2
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val bracket_singleton: SingleKBracket = object : arrow.fx.rx2.extensions.SingleKBracket {}
+
+/**
+ *  A way to safely acquire a resource and release in the face of errors and cancellation.
+ *  It uses [ExitCase] to distinguish between different exit cases when releasing the acquired resource.
+ *
+ *  @param use is the action to consume the resource and produce an [F] with the result.
+ *  Once the resulting [F] terminates, either successfully, error or cancelled.
+ *
+ *  @param release the allocated resource after the resulting [F] of [use] is terminates.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.rx2.extensions.singlek.monadDefer.defer
+ * import arrow.fx.rx2.extensions.singlek.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val release: (File, ExitCase<Throwable>) -> Kind<F, Unit> = { file, exitCase ->
+ *       when (exitCase) {
+ * do something * / }
+ * do something * / }
+ * do something * / }
+ *       }
+ *       closeFile(file)
+ *   }
+ *
+ *   val use: (File) -> Kind<F, String> = { file: File -> fileToString(file) }
+ *
+ *   val safeComputation = openFile("data.json").bracketCase(release, use)
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracketCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.bracketCase(
+  arg1: Function2<A, ExitCase<Throwable>, Kind<ForSingleK,
+Unit>>,
+  arg2: Function1<A, Kind<ForSingleK, B>>
+): SingleK<B> =
+    arrow.fx.rx2.SingleK.bracket().run {
+  this@bracketCase.bracketCase<A, B>(arg1, arg2) as arrow.fx.rx2.SingleK<B>
+}
+
+/**
+ *  Meant for specifying tasks with safe resource acquisition and release in the face of errors and interruption.
+ *  It would be the the equivalent of `try/catch/finally` statements in mainstream imperative languages for resource
+ *  acquisition and release.
+ *
+ *  @param release is the action that's supposed to release the allocated resource after `use` is done, irregardless
+ *  of its exit condition.
+ *
+ *  ```kotlin:ank:playground
+ *  import arrow.fx.rx2.*
+ * import arrow.fx.rx2.extensions.singlek.bracket.*
+ * import arrow.core.*
+ *
+ *
+ *  import arrow.fx.rx2.extensions.singlek.monadDefer.defer
+ * import arrow.fx.rx2.extensions.singlek.monadDefer.later
+ *
+ *  class File(url: String) {
+ *   fun open(): File = this
+ *   fun close(): Unit {}
+ *   override fun toString(): String = "This file contains some interesting content!"
+ *  }
+ *
+ *  fun openFile(uri: String): Kind<F, File> = later({ File(uri).open() })
+ *  fun closeFile(file: File): Kind<F, Unit> = later({ file.close() })
+ *  fun fileToString(file: File): Kind<F, String> = later({ file.toString() })
+ *
+ *  fun main(args: Array<String>) {
+ *   //sampleStart
+ *   val safeComputation = openFile("data.json").bracket({ file: File -> closeFile(file) }, { file -> fileToString(file) })
+ *   //sampleEnd
+ *   println(safeComputation)
+ *  }
+ *  ```
+ */
+@JvmName("bracket")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.bracket(
+  arg1: Function1<A, Kind<ForSingleK, Unit>>,
+  arg2: Function1<A, Kind<ForSingleK, B>>
+): SingleK<B> = arrow.fx.rx2.SingleK.bracket().run {
+  this@bracket.bracket<A, B>(arg1, arg2) as arrow.fx.rx2.SingleK<B>
+}
+
+/**
+ *  Meant for ensuring a given task continues execution even when interrupted.
+ */
+@JvmName("uncancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.uncancellable(): SingleK<A> = arrow.fx.rx2.SingleK.bracket().run {
+  this@uncancellable.uncancellable<A>() as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("uncancelable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.uncancelable(): SingleK<A> = arrow.fx.rx2.SingleK.bracket().run {
+  this@uncancelable.uncancelable<A>() as arrow.fx.rx2.SingleK<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracket] for the acquisition and release of resources.
+ *
+ *  @see [guaranteeCase] for the version that can discriminate between termination conditions
+ *
+ *  @see [bracket] for the more general operation
+ */
+@JvmName("guarantee")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.guarantee(arg1: Kind<ForSingleK, Unit>): SingleK<A> =
+    arrow.fx.rx2.SingleK.bracket().run {
+  this@guarantee.guarantee<A>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+/**
+ *  Executes the given `finalizer` when the source is finished, either in success or in error, or if cancelled, allowing
+ *  for differentiating between exit conditions. That's thanks to the [ExitCase] argument of the finalizer.
+ *
+ *  As best practice, it's not a good idea to release resources via `guaranteeCase` in polymorphic code.
+ *  Prefer [bracketCase] for the acquisition and release of resources.
+ *
+ *  @see [guarantee] for the simpler version
+ *
+ *  @see [bracketCase] for the more general operation
+ */
+@JvmName("guaranteeCase")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.guaranteeCase(
+  arg1: Function1<ExitCase<Throwable>, Kind<ForSingleK,
+Unit>>
+): SingleK<A> = arrow.fx.rx2.SingleK.bracket().run {
+  this@guaranteeCase.guaranteeCase<A>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+/**
+ *  Executes the given [finalizer] when the source is cancelled, allowing registering a cancellation token.
+ *
+ *  Useful for wiring cancellation tokens between fibers, building inter-op with other effect systems or testing.
+ */
+@JvmName("onCancel")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.onCancel(arg1: Kind<ForSingleK, Unit>): SingleK<A> =
+    arrow.fx.rx2.SingleK.bracket().run {
+  this@onCancel.onCancel<A>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+/**
+ *  Executes the given `finalizer` with the given error when the source is finished in error.
+ */
+@JvmName("onError")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.onError(arg1: Function1<Throwable, Kind<ForSingleK, Unit>>): SingleK<A> =
+    arrow.fx.rx2.SingleK.bracket().run {
+  this@onError.onError<A>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+/**
+ *  Extension of MonadError exposing the [bracket] operation, a generalized abstracted pattern of safe resource
+ *  acquisition and release in the face of errors or interruption.
+ *
+ *  @define The functions receiver here (Kind<F, A>) would stand for the "acquireParam", and stands for an action that
+ *  "acquires" some expensive resource, that needs to be used and then discarded.
+ *
+ *  @define use is the action that uses the newly allocated resource and that will provide the final result.
+ */
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.bracket(): SingleKBracket = bracket_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/concurrentEffect/SingleKConcurrentEffect.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/concurrentEffect/SingleKConcurrentEffect.kt
@@ -1,0 +1,48 @@
+package arrow.fx.rx2.extensions.singlek.concurrentEffect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKConcurrentEffect
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val concurrentEffect_singleton: SingleKConcurrentEffect = object :
+    arrow.fx.rx2.extensions.SingleKConcurrentEffect {}
+
+@JvmName("runAsyncCancellable")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.runAsyncCancellable(
+  arg1: Function1<Either<Throwable, A>,
+Kind<ForSingleK, Unit>>
+): SingleK<Function0<Unit>> =
+    arrow.fx.rx2.SingleK.concurrentEffect().run {
+  this@runAsyncCancellable.runAsyncCancellable<A>(arg1) as
+    arrow.fx.rx2.SingleK<kotlin.Function0<kotlin.Unit>>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.concurrentEffect(): SingleKConcurrentEffect = concurrentEffect_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/dispatchers/SingleKDispatchers.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/dispatchers/SingleKDispatchers.kt
@@ -1,0 +1,48 @@
+package arrow.fx.rx2.extensions.singlek.dispatchers
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKDispatchers
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val dispatchers_singleton: SingleKDispatchers = object :
+    arrow.fx.rx2.extensions.SingleKDispatchers {}
+
+@JvmName("default")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun default(): CoroutineContext = arrow.fx.rx2.SingleK
+   .dispatchers()
+   .default() as kotlin.coroutines.CoroutineContext
+
+@JvmName("io")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun io(): CoroutineContext = arrow.fx.rx2.SingleK
+   .dispatchers()
+   .io() as kotlin.coroutines.CoroutineContext
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.dispatchers(): SingleKDispatchers = dispatchers_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/effect/SingleKEffect.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/effect/SingleKEffect.kt
@@ -1,0 +1,42 @@
+package arrow.fx.rx2.extensions.singlek.effect
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKEffect
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val effect_singleton: SingleKEffect = object : arrow.fx.rx2.extensions.SingleKEffect {}
+
+@JvmName("runAsync")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.runAsync(arg1: Function1<Either<Throwable, A>, Kind<ForSingleK, Unit>>):
+    SingleK<Unit> = arrow.fx.rx2.SingleK.effect().run {
+  this@runAsync.runAsync<A>(arg1) as arrow.fx.rx2.SingleK<kotlin.Unit>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.effect(): SingleKEffect = effect_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/functor/SingleKFunctor.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/functor/SingleKFunctor.kt
@@ -1,0 +1,155 @@
+package arrow.fx.rx2.extensions.singlek.functor
+
+import arrow.Kind
+import arrow.core.Tuple2
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKFunctor
+import kotlin.Deprecated
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val functor_singleton: SingleKFunctor = object : arrow.fx.rx2.extensions.SingleKFunctor {}
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.map(arg1: Function1<A, B>): SingleK<B> =
+    arrow.fx.rx2.SingleK.functor().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("imap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.imap(arg1: Function1<A, B>, arg2: Function1<B, A>): SingleK<B> =
+    arrow.fx.rx2.SingleK.functor().run {
+  this@imap.imap<A, B>(arg1, arg2) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("lift")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForSingleK, A>, Kind<ForSingleK, B>> =
+    arrow.fx.rx2.SingleK
+   .functor()
+   .lift<A, B>(arg0) as kotlin.Function1<arrow.Kind<arrow.fx.rx2.ForSingleK, A>,
+    arrow.Kind<arrow.fx.rx2.ForSingleK, B>>
+
+@JvmName("void")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.void(): SingleK<Unit> = arrow.fx.rx2.SingleK.functor().run {
+  this@void.void<A>() as arrow.fx.rx2.SingleK<kotlin.Unit>
+}
+
+@JvmName("fproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.fproduct(arg1: Function1<A, B>): SingleK<Tuple2<A, B>> =
+    arrow.fx.rx2.SingleK.functor().run {
+  this@fproduct.fproduct<A, B>(arg1) as arrow.fx.rx2.SingleK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.mapConst(arg1: B): SingleK<B> = arrow.fx.rx2.SingleK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("mapConst")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> A.mapConst(arg1: Kind<ForSingleK, B>): SingleK<A> = arrow.fx.rx2.SingleK.functor().run {
+  this@mapConst.mapConst<A, B>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("tupleLeft")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.tupleLeft(arg1: B): SingleK<Tuple2<B, A>> =
+    arrow.fx.rx2.SingleK.functor().run {
+  this@tupleLeft.tupleLeft<A, B>(arg1) as arrow.fx.rx2.SingleK<arrow.core.Tuple2<B, A>>
+}
+
+@JvmName("tupleRight")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.tupleRight(arg1: B): SingleK<Tuple2<A, B>> =
+    arrow.fx.rx2.SingleK.functor().run {
+  this@tupleRight.tupleRight<A, B>(arg1) as arrow.fx.rx2.SingleK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("widen")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <B, A : B> Kind<ForSingleK, A>.widen(): SingleK<B> = arrow.fx.rx2.SingleK.functor().run {
+  this@widen.widen<B, A>() as arrow.fx.rx2.SingleK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.functor(): SingleKFunctor = functor_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/monad/SingleKMonad.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/monad/SingleKMonad.kt
@@ -1,0 +1,267 @@
+package arrow.fx.rx2.extensions.singlek.monad
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.core.Eval
+import arrow.core.Tuple2
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKMonad
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monad_singleton: SingleKMonad = object : arrow.fx.rx2.extensions.SingleKMonad {}
+
+@JvmName("flatMap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.flatMap(arg1: Function1<A, Kind<ForSingleK, B>>): SingleK<B> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@flatMap.flatMap<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("tailRecM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> tailRecM(arg0: A, arg1: Function1<A, Kind<ForSingleK, Either<A, B>>>): SingleK<B> =
+    arrow.fx.rx2.SingleK
+   .monad()
+   .tailRecM<A, B>(arg0, arg1) as arrow.fx.rx2.SingleK<B>
+
+@JvmName("map")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.map(arg1: Function1<A, B>): SingleK<B> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@map.map<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("ap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.ap(arg1: Kind<ForSingleK, Function1<A, B>>): SingleK<B> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@ap.ap<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("flatten")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, Kind<ForSingleK, A>>.flatten(): SingleK<A> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@flatten.flatten<A>() as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("followedBy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.followedBy(arg1: Kind<ForSingleK, B>): SingleK<B> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@followedBy.followedBy<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("apTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.apTap(arg1: Kind<ForSingleK, B>): SingleK<A> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@apTap.apTap<A, B>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("followedByEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.followedByEval(arg1: Eval<Kind<ForSingleK, B>>): SingleK<B> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@followedByEval.followedByEval<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("effectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.effectM(arg1: Function1<A, Kind<ForSingleK, B>>): SingleK<A> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@effectM.effectM<A, B>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("flatTap")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.flatTap(arg1: Function1<A, Kind<ForSingleK, B>>): SingleK<A> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@flatTap.flatTap<A, B>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("productL")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.productL(arg1: Kind<ForSingleK, B>): SingleK<A> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@productL.productL<A, B>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("forEffect")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.forEffect(arg1: Kind<ForSingleK, B>): SingleK<A> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@forEffect.forEffect<A, B>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("productLEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.productLEval(arg1: Eval<Kind<ForSingleK, B>>): SingleK<A> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@productLEval.productLEval<A, B>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("forEffectEval")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.forEffectEval(arg1: Eval<Kind<ForSingleK, B>>): SingleK<A> =
+    arrow.fx.rx2.SingleK.monad().run {
+  this@forEffectEval.forEffectEval<A, B>(arg1) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("mproduct")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.mproduct(arg1: Function1<A, Kind<ForSingleK, B>>): SingleK<Tuple2<A,
+    B>> = arrow.fx.rx2.SingleK.monad().run {
+  this@mproduct.mproduct<A, B>(arg1) as arrow.fx.rx2.SingleK<arrow.core.Tuple2<A, B>>
+}
+
+@JvmName("ifM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <B> Kind<ForSingleK, Boolean>.ifM(
+  arg1: Function0<Kind<ForSingleK, B>>,
+  arg2: Function0<Kind<ForSingleK, B>>
+): SingleK<B> = arrow.fx.rx2.SingleK.monad().run {
+  this@ifM.ifM<B>(arg1, arg2) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("selectM")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, Either<A, B>>.selectM(arg1: Kind<ForSingleK, Function1<A, B>>):
+    SingleK<B> = arrow.fx.rx2.SingleK.monad().run {
+  this@selectM.selectM<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("select")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, Either<A, B>>.select(arg1: Kind<ForSingleK, Function1<A, B>>):
+    SingleK<B> = arrow.fx.rx2.SingleK.monad().run {
+  this@select.select<A, B>(arg1) as arrow.fx.rx2.SingleK<B>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monad(): SingleKMonad = monad_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/monadDefer/SingleKMonadDefer.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/monadDefer/SingleKMonadDefer.kt
@@ -1,0 +1,103 @@
+package arrow.fx.rx2.extensions.singlek.monadDefer
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.Ref
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKMonadDefer
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadDefer_singleton: SingleKMonadDefer = object :
+    arrow.fx.rx2.extensions.SingleKMonadDefer {}
+
+@JvmName("defer")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> defer(arg0: Function0<Kind<ForSingleK, A>>): SingleK<A> = arrow.fx.rx2.SingleK
+   .monadDefer()
+   .defer<A>(arg0) as arrow.fx.rx2.SingleK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: Function0<A>): SingleK<A> = arrow.fx.rx2.SingleK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.rx2.SingleK<A>
+
+@JvmName("later")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> later(arg0: Kind<ForSingleK, A>): SingleK<A> = arrow.fx.rx2.SingleK
+   .monadDefer()
+   .later<A>(arg0) as arrow.fx.rx2.SingleK<A>
+
+@JvmName("lazy")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun lazy(): SingleK<Unit> = arrow.fx.rx2.SingleK
+   .monadDefer()
+   .lazy() as arrow.fx.rx2.SingleK<kotlin.Unit>
+
+@JvmName("laterOrRaise")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> laterOrRaise(arg0: Function0<Either<Throwable, A>>): SingleK<A> = arrow.fx.rx2.SingleK
+   .monadDefer()
+   .laterOrRaise<A>(arg0) as arrow.fx.rx2.SingleK<A>
+
+@JvmName("Ref")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Ref(arg0: A): SingleK<Ref<ForSingleK, A>> = arrow.fx.rx2.SingleK
+   .monadDefer()
+   .Ref<A>(arg0) as arrow.fx.rx2.SingleK<arrow.fx.Ref<arrow.fx.rx2.ForSingleK, A>>
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadDefer(): SingleKMonadDefer = monadDefer_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/monadError/SingleKMonadError.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/monadError/SingleKMonadError.kt
@@ -1,0 +1,72 @@
+package arrow.fx.rx2.extensions.singlek.monadError
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKMonadError
+import kotlin.Boolean
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadError_singleton: SingleKMonadError = object :
+    arrow.fx.rx2.extensions.SingleKMonadError {}
+
+@JvmName("ensure")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, A>.ensure(arg1: Function0<Throwable>, arg2: Function1<A, Boolean>):
+    SingleK<A> = arrow.fx.rx2.SingleK.monadError().run {
+  this@ensure.ensure<A>(arg1, arg2) as arrow.fx.rx2.SingleK<A>
+}
+
+@JvmName("redeemWith")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A, B> Kind<ForSingleK, A>.redeemWith(
+  arg1: Function1<Throwable, Kind<ForSingleK, B>>,
+  arg2: Function1<A, Kind<ForSingleK, B>>
+): SingleK<B> = arrow.fx.rx2.SingleK.monadError().run {
+  this@redeemWith.redeemWith<A, B>(arg1, arg2) as arrow.fx.rx2.SingleK<B>
+}
+
+@JvmName("rethrow")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Kind<ForSingleK, Either<Throwable, A>>.rethrow(): SingleK<A> =
+    arrow.fx.rx2.SingleK.monadError().run {
+  this@rethrow.rethrow<A>() as arrow.fx.rx2.SingleK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadError(): SingleKMonadError = monadError_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/monadThrow/SingleKMonadThrow.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/monadThrow/SingleKMonadThrow.kt
@@ -1,0 +1,37 @@
+package arrow.fx.rx2.extensions.singlek.monadThrow
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.SingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKMonadThrow
+import kotlin.Deprecated
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val monadThrow_singleton: SingleKMonadThrow = object :
+    arrow.fx.rx2.extensions.SingleKMonadThrow {}
+
+@JvmName("raiseNonFatal")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+fun <A> Throwable.raiseNonFatal(): SingleK<A> = arrow.fx.rx2.SingleK.monadThrow().run {
+  this@raiseNonFatal.raiseNonFatal<A>() as arrow.fx.rx2.SingleK<A>
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.monadThrow(): SingleKMonadThrow = monadThrow_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/timer/SingleKTimer.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/timer/SingleKTimer.kt
@@ -1,0 +1,20 @@
+package arrow.fx.rx2.extensions.singlek.timer
+
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKTimer
+import kotlin.PublishedApi
+import kotlin.Suppress
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val timer_singleton: SingleKTimer = object : arrow.fx.rx2.extensions.SingleKTimer {}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.timer(): SingleKTimer = timer_singleton

--- a/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/unsafeRun/SingleKUnsafeRun.kt
+++ b/arrow-fx-rx2/src/main/kotlin/arrow/fx/rx2/extensions/singlek/unsafeRun/SingleKUnsafeRun.kt
@@ -1,0 +1,59 @@
+package arrow.fx.rx2.extensions.singlek.unsafeRun
+
+import arrow.Kind
+import arrow.core.Either
+import arrow.fx.rx2.DeprecateRxJava
+import arrow.fx.rx2.ForSingleK
+import arrow.fx.rx2.SingleK.Companion
+import arrow.fx.rx2.extensions.SingleKUnsafeRun
+import arrow.unsafe
+import kotlin.Deprecated
+import kotlin.Function0
+import kotlin.Function1
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.Throwable
+import kotlin.Unit
+import kotlin.jvm.JvmName
+
+/**
+ * cached extension
+ */
+@PublishedApi()
+internal val unsafeRun_singleton: SingleKUnsafeRun = object :
+    arrow.fx.rx2.extensions.SingleKUnsafeRun {}
+
+@JvmName("runBlocking")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <A> unsafe.runBlocking(arg1: Function0<Kind<ForSingleK, A>>): A =
+    arrow.fx.rx2.SingleK.unsafeRun().run {
+  this@runBlocking.runBlocking<A>(arg1) as A
+}
+
+@JvmName("runNonBlocking")
+@Suppress(
+  "UNCHECKED_CAST",
+  "USELESS_CAST",
+  "EXTENSION_SHADOWED_BY_MEMBER",
+  "UNUSED_PARAMETER"
+)
+@Deprecated(DeprecateRxJava)
+suspend fun <A> unsafe.runNonBlocking(
+  arg1: Function0<Kind<ForSingleK, A>>,
+  arg2: Function1<Either<Throwable, A>, Unit>
+): Unit = arrow.fx.rx2.SingleK.unsafeRun().run {
+  this@runNonBlocking.runNonBlocking<A>(arg1, arg2) as kotlin.Unit
+}
+
+@Suppress(
+  "UNCHECKED_CAST",
+  "NOTHING_TO_INLINE"
+)
+@Deprecated(DeprecateRxJava)
+inline fun Companion.unsafeRun(): SingleKUnsafeRun = unsafeRun_singleton


### PR DESCRIPTION
## Status
READY

## Description
This PR removes all `@extension` from the Arrow Fx RxJava2 module, and deprecates all public code.

## Related PRs
* https://github.com/arrow-kt/arrow-fx/pull/384
